### PR TITLE
Simple API for prototyping

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -33,8 +33,13 @@ slog = "2.1"
 tokio-net = { version = "0.2.0-alpha.5", default-features = false }
 tokio-timer = "0.3.0-alpha.5"
 tokio-io = "0.2.0-alpha.5"
+tokio-executor = { version = "0.2.0-alpha.5", optional = true }
 webpki = "0.21"
 webpki-roots = "0.17"
+
+[features]
+default = ["simple"]
+simple = ["tokio-executor"]
 
 [dev-dependencies]
 crc = "1.8.1"

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -105,7 +105,7 @@ pub struct NewConnection {
     /// Streams initiated by the peer, in the order they were opened
     pub streams: IncomingStreams,
     /// Leave room for future extensions
-    _non_exhaustive: (),
+    pub(crate) _non_exhaustive: (),
 }
 
 impl NewConnection {

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -4,7 +4,8 @@
 //! shortcomings of TCP, such as head-of-line blocking, poor security, slow handshakes, and
 //! inefficient congestion control. This crate provides a portable userspace implementation.
 //!
-//! The entry point of this crate is the [`Endpoint`](struct.Endpoint.html).
+//! The main entry point of this crate is the [`Endpoint`](struct.Endpoint.html). The
+//! [`simple`](simple) module can be used for prototyping.
 //!
 //! ```
 //! # use futures::TryFutureExt;
@@ -75,6 +76,9 @@ pub use streams::{
     NewStream, Read, ReadError, ReadExact, ReadExactError, ReadToEnd, ReadToEndError, RecvStream,
     SendStream, WriteError,
 };
+
+#[cfg(feature = "simple")]
+pub mod simple;
 
 #[cfg(test)]
 mod tests;

--- a/quinn/src/simple.rs
+++ b/quinn/src/simple.rs
@@ -1,0 +1,133 @@
+//! Simplified interface
+//!
+//! This module makes it easy to get a prototype up and running quickly. Real-world applications are
+//! encouraged to use the regular interface to optimize for the application protocol in question.
+
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
+use err_derive::Error;
+use futures::{future, FutureExt, Stream, StreamExt};
+
+use crate::{
+    CertificateChain, ConnectError, Connection, ConnectionError, Endpoint, EndpointError,
+    IncomingStreams, PrivateKey,
+};
+
+/// Connect to a server at `remote`, authenticating it as `domain_name`
+///
+/// `domain_name` must be a valid DNS name. If the server cannot authenticate itself under that name
+/// with a valid TLS certificate, the connection will fail.
+///
+/// # Example
+/// ```no_run
+/// # async {
+/// use std::net::ToSocketAddrs;
+/// let domain_name = "example.com";
+/// let addr = domain_name.to_socket_addrs().unwrap().next().unwrap();
+/// let nc = quinn::simple::connect(&addr, domain_name).await.unwrap();
+/// # };
+/// ```
+pub async fn connect(remote: &SocketAddr, domain_name: &str) -> Result<NewConnection, SimpleError> {
+    let bind_addr: SocketAddr = match remote {
+        SocketAddr::V4(_) => SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0).into(),
+        SocketAddr::V6(_) => SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0).into(),
+    };
+    let (endpoint_driver, endpoint, _) = Endpoint::builder().bind(bind_addr)?;
+    tokio_executor::spawn(endpoint_driver.map(|_| ()));
+    let conn = endpoint
+        .connect(&remote, domain_name)
+        .map_err(|e| match e {
+            ConnectError::EndpointStopping | ConnectError::Config(_) => {
+                unreachable!("impossible under the simple connect interface")
+            }
+            ConnectError::InvalidDnsName(_) => SimpleError::InvalidDnsName,
+        })?
+        .await?;
+    Ok(NewConnection::new(conn))
+}
+
+/// Listen for incoming connections on `address`
+///
+/// # Example
+/// ```no_run
+/// # async {
+/// use std::net::{SocketAddr, Ipv6Addr};
+/// let certs = quinn::CertificateChain::from_pem(&std::fs::read("fullchain.pem").unwrap()).unwrap();
+/// let key = quinn::PrivateKey::from_pem(&std::fs::read("key.pem").unwrap()).unwrap();
+/// let mut incoming = quinn::simple::listen(&"[::]:0".parse().unwrap(), certs, key).unwrap();
+/// use futures::StreamExt;
+/// while let Some(connection) = incoming.next().await {
+///   // ...
+/// }
+/// # };
+/// ```
+pub fn listen(
+    address: &SocketAddr,
+    certificate_chain: CertificateChain,
+    private_key: PrivateKey,
+) -> Result<impl Stream<Item = NewConnection>, SimpleError> {
+    let mut server_config = crate::ServerConfigBuilder::default();
+    server_config
+        .certificate(certificate_chain, private_key)
+        .map_err(EndpointError::Tls)?;
+    let mut endpoint = Endpoint::builder();
+    endpoint.listen(server_config.build());
+    let (endpoint_driver, _, conns) = endpoint.bind(address)?;
+    tokio_executor::spawn(endpoint_driver.map(|_| ()));
+    Ok(conns
+        .buffer_unordered(4096)
+        .filter_map(|conn| future::ready(conn.ok().map(NewConnection::new))))
+}
+
+/// Components of a newly established simple connection
+pub struct NewConnection {
+    /// Handle for interacting with the connection
+    pub connection: Connection,
+    /// Streams initiated by the peer, in the order they were opened
+    pub streams: IncomingStreams,
+    /// Leave room for future extensions
+    _non_exhaustive: (),
+}
+
+impl NewConnection {
+    fn new(x: crate::NewConnection) -> Self {
+        let crate::NewConnection {
+            driver,
+            connection,
+            streams,
+            _non_exhaustive: (),
+        } = x;
+        tokio_executor::spawn(driver.map(|_| ()));
+        Self {
+            connection,
+            streams,
+            _non_exhaustive: (),
+        }
+    }
+}
+
+/// Errors that may arise from from functions in this module
+#[derive(Debug, Error)]
+pub enum SimpleError {
+    /// Endpoint setup failed
+    #[error(display = "{}", 0)]
+    EndpointError(EndpointError),
+    /// The DNS name supplied to authenticate the peer is invalid
+    #[error(display = "invalid DNS name")]
+    InvalidDnsName,
+    /// The connection failed
+    #[error(display = "connection failed: {}", 0)]
+    ConnectionError(ConnectionError),
+}
+
+impl From<ConnectionError> for SimpleError {
+    fn from(x: ConnectionError) -> Self {
+        Self::ConnectionError(x)
+    }
+}
+
+impl From<EndpointError> for SimpleError {
+    fn from(x: EndpointError) -> Self {
+        Self::EndpointError(x)
+    }
+}


### PR DESCRIPTION
We've sought to expose an extremely flexible API, which is as a consequence somewhat complicated to get started with. This PR presents a straw proposal for an optional alternative API that's much friendlier and less versatile.

Drawbacks include:
- No specialization for a particular application protocol
- Valid certificates are even more strongly required than with the main API, since there's no way to manually trust one. Therefore prototyping a complete client-server system may actually be *harder* than with the main API, defeating the purpose.

Are there ways we can improve on those? If not, is this worth doing at all?