### PR TITLE
Bug Fix when accepting and retiring connection ID

### DIFF
--- a/quinn-proto/src/cid_queue.rs
+++ b/quinn-proto/src/cid_queue.rs
@@ -8,29 +8,30 @@ use crate::{shared::IssuedCid, ConnectionId, ResetToken};
 #[derive(Debug)]
 pub struct CidQueue {
     /// Ring buffer indexed by `self.cursor`
-    buffer: [Option<(ConnectionId, ResetToken)>; Self::LEN],
+    buffer: [Option<(ConnectionId, Option<ResetToken>)>; Self::LEN],
     /// Index at which circular buffer addressing is based
     cursor: usize,
     /// Sequence number of `self.buffer[cursor]`
     ///
-    /// The CID sequenced immediately prior to this is the active CID, which this data structure is
-    /// not responsible for retiring.
+    /// The sequence of active (in use) CID. This sequence is also the smallest among CIDs in `buffer`.
     offset: u64,
 }
 
 impl CidQueue {
-    pub const LEN: usize = 4;
+    pub const LEN: usize = 5;
 
-    pub fn new(offset: u64) -> Self {
-        Self {
+    pub fn new(cid: ConnectionId) -> Self {
+        let mut this = Self {
             buffer: [None; Self::LEN],
             cursor: 0,
-            offset,
-        }
+            offset: 0,
+        };
+        this.buffer[this.cursor] = Some((cid, None));
+        this
     }
 
     pub fn insert(&mut self, cid: IssuedCid) -> Result<(), InsertError> {
-        if cid.sequence + 1 == self.offset {
+        if cid.sequence == self.offset && self.buffer[self.cursor].is_some() {
             // This is a duplicate of the active CID.
             return Ok(());
         }
@@ -42,7 +43,7 @@ impl CidQueue {
             return Err(InsertError::ExceedsLimit);
         }
         let index = (self.cursor + index as usize) % Self::LEN;
-        self.buffer[index] = Some((cid.id, cid.reset_token));
+        self.buffer[index] = Some((cid.id, Some(cid.reset_token)));
         Ok(())
     }
 
@@ -63,35 +64,43 @@ impl CidQueue {
         orig_offset..sequence
     }
 
-    /// Returns a new CID if any were available and a possibly-empty range preceding it to retire
-    pub fn next(&mut self) -> Option<(IssuedCid, Range<u64>)> {
-        for i in 0..Self::LEN {
+    /// Switch to next active CID if possible, return
+    /// 1) the corresponding ResetToken and 2) a possibly-empty range preceding it to retire
+    pub fn next(&mut self) -> Option<(ResetToken, Range<u64>)> {
+        for i in 1..Self::LEN {
             let index = (self.cursor + i) % Self::LEN;
-            let (id, reset_token) = match self.buffer[index].take() {
+            let reset_token = match self.buffer[index].as_ref() {
                 None => continue,
-                Some(x) => x,
+                Some((_, token)) => *token,
             };
+            self.buffer[self.cursor] = None;
+
             let orig_offset = self.offset;
-            self.offset += i as u64 + 1;
-            self.cursor = (self.cursor + i + 1) % Self::LEN;
+            self.offset += i as u64;
+            self.cursor = (self.cursor + i) % Self::LEN;
             let sequence = orig_offset + i as u64;
-            let cid = IssuedCid {
-                sequence,
-                id,
-                reset_token,
-            };
-            return Some((cid, orig_offset..sequence));
+            return Some((reset_token.unwrap(), orig_offset..sequence));
         }
         None
     }
 
-    /// Reset offset field and guarantee the smallest sequence of active CID is prior to this value
-    pub fn assign_offset(&mut self, v: u64) {
-        self.offset = v;
+    pub fn update_cid(&mut self, cid: ConnectionId) {
+        debug_assert_eq!(self.offset, 0);
+        self.buffer[self.cursor] = Some((cid, None));
     }
 
-    /// Lowest queued sequence number
-    pub fn offset(&self) -> u64 {
+    /// Return active remote CID itself
+    pub fn rem_cid(&self) -> ConnectionId {
+        self.buffer[self.cursor].unwrap().0
+    }
+
+    /// Check whether self.offset points to a valid CID in CidQueue
+    pub fn validate_rem_cid(&mut self) -> bool {
+        self.buffer[self.cursor].as_ref().is_some()
+    }
+
+    /// Return the sequence number of active remote CID
+    pub fn rem_cid_seq(&self) -> u64 {
         self.offset
     }
 }
@@ -116,63 +125,67 @@ mod tests {
         }
     }
 
-    #[test]
-    fn next_dense() {
-        let mut q = CidQueue::new(0);
-        assert!(q.next().is_none());
-        assert!(q.next().is_none());
-
-        for i in 0..CidQueue::LEN as u64 {
-            q.insert(cid(i)).unwrap();
-        }
-        for i in 0..CidQueue::LEN as u64 {
-            let (cid, retire) = q.next().unwrap();
-            assert_eq!(cid.sequence, i);
-            assert_eq!(retire.end - retire.start, 0);
-        }
-        assert!(q.next().is_none());
+    fn initial_cid() -> ConnectionId {
+        ConnectionId::new(&[0xFF; 8])
     }
 
     #[test]
+    fn next_dense() {
+        let mut q = CidQueue::new(initial_cid());
+        assert!(q.next().is_none());
+        assert!(q.next().is_none());
+
+        for i in 1..CidQueue::LEN as u64 {
+            q.insert(cid(i)).unwrap();
+        }
+        for i in 1..CidQueue::LEN as u64 {
+            let (_, retire) = q.next().unwrap();
+            assert_eq!(q.rem_cid_seq(), i);
+            assert_eq!(retire.end - retire.start, 1);
+        }
+        assert!(q.next().is_none());
+    }
+    #[test]
     fn next_sparse() {
-        let mut q = CidQueue::new(0);
-        let seqs = (0..CidQueue::LEN as u64).filter(|x| x % 2 == 0);
+        let mut q = CidQueue::new(initial_cid());
+        let seqs = (1..CidQueue::LEN as u64).filter(|x| x % 2 == 0);
         for i in seqs.clone() {
             q.insert(cid(i)).unwrap();
         }
         for i in seqs {
-            let (cid, retire) = q.next().unwrap();
+            let (_, retire) = q.next().unwrap();
             dbg!(&retire);
-            assert_eq!(cid.sequence, i);
-            assert_eq!(retire, (cid.sequence.saturating_sub(1))..cid.sequence);
+            assert_eq!(q.rem_cid_seq(), i);
+            assert_eq!(retire, (q.rem_cid_seq().saturating_sub(2))..q.rem_cid_seq());
         }
         assert!(q.next().is_none());
     }
 
     #[test]
     fn wrap() {
-        let mut q = CidQueue::new(0);
+        let mut q = CidQueue::new(initial_cid());
 
-        for i in 0..CidQueue::LEN as u64 {
+        for i in 1..CidQueue::LEN as u64 {
             q.insert(cid(i)).unwrap();
         }
-        for _ in 0..3 {
+        for _ in 1..(CidQueue::LEN as u64 - 1) {
             q.next().unwrap();
         }
         for i in CidQueue::LEN as u64..(CidQueue::LEN as u64 + 3) {
             q.insert(cid(i)).unwrap();
         }
-        for i in 3..(CidQueue::LEN as u64 + 3) {
-            assert_eq!(q.next().unwrap().0.sequence, i);
+        for i in (CidQueue::LEN as u64 - 1)..(CidQueue::LEN as u64 + 3) {
+            q.next().unwrap();
+            assert_eq!(q.rem_cid_seq(), i);
         }
         assert!(q.next().is_none());
     }
 
     #[test]
     fn retire() {
-        let mut q = CidQueue::new(0);
+        let mut q = CidQueue::new(initial_cid());
 
-        for i in 0..CidQueue::LEN as u64 {
+        for i in 1..CidQueue::LEN as u64 {
             q.insert(cid(i)).unwrap();
         }
 
@@ -180,17 +193,12 @@ mod tests {
         let r = q.retire_prior_to(4);
         assert_eq!(r.end - r.start, 0);
 
-        for i in 4..CidQueue::LEN as u64 {
-            let (cid, retire) = q.next().unwrap();
-            assert_eq!(cid.sequence, i);
-            assert_eq!(retire.end - retire.start, 0);
-        }
         assert!(q.next().is_none());
     }
 
     #[test]
     fn insert_limit() {
-        let mut q = CidQueue::new(0);
+        let mut q = CidQueue::new(initial_cid());
         assert_eq!(q.insert(cid(CidQueue::LEN as u64 - 1)), Ok(()));
         assert_eq!(
             q.insert(cid(CidQueue::LEN as u64)),
@@ -200,16 +208,14 @@ mod tests {
 
     #[test]
     fn insert_duplicate() {
-        let mut q = CidQueue::new(0);
+        let mut q = CidQueue::new(initial_cid());
         q.insert(cid(0)).unwrap();
         q.insert(cid(0)).unwrap();
     }
 
     #[test]
     fn insert_retired() {
-        let mut q = CidQueue::new(0);
-        q.insert(cid(0)).unwrap();
-        q.next().unwrap();
+        let mut q = CidQueue::new(initial_cid());
         assert_eq!(q.insert(cid(0)), Ok(()), "reinserting active CID succeeds");
         assert!(q.next().is_none(), "active CID isn't requeued");
         q.insert(cid(1)).unwrap();
@@ -223,8 +229,8 @@ mod tests {
 
     #[test]
     fn retire_then_insert_next() {
-        let mut q = CidQueue::new(0);
-        for i in 0..CidQueue::LEN as u64 {
+        let mut q = CidQueue::new(initial_cid());
+        for i in 1..CidQueue::LEN as u64 {
             q.insert(cid(i)).unwrap();
         }
         q.next().unwrap();
@@ -233,5 +239,13 @@ mod tests {
             q.insert(cid(CidQueue::LEN as u64 + 1)),
             Err(InsertError::ExceedsLimit)
         );
+    }
+
+    #[test]
+    fn always_valid() {
+        let mut q = CidQueue::new(initial_cid());
+        assert!(q.next().is_none());
+        assert_eq!(q.rem_cid(), initial_cid());
+        assert_eq!(q.rem_cid_seq(), 0);
     }
 }

--- a/quinn-proto/src/cid_queue.rs
+++ b/quinn-proto/src/cid_queue.rs
@@ -90,8 +90,8 @@ impl CidQueue {
         self.offset = v;
     }
 
-    /// Read the current offset value
-    pub fn read_offset(&self) -> u64 {
+    /// Lowest queued sequence number
+    pub fn offset(&self) -> u64 {
         self.offset
     }
 }

--- a/quinn-proto/src/cid_queue.rs
+++ b/quinn-proto/src/cid_queue.rs
@@ -196,11 +196,20 @@ mod tests {
             q.insert(cid(i)).unwrap();
         }
 
-        assert_eq!(q.retire_prior_to(4), 0..4);
-        let r = q.retire_prior_to(4);
+        assert_eq!(q.retire_prior_to(2), 0..2);
+        let r = q.retire_prior_to(2);
         assert_eq!(r.end - r.start, 0);
 
+        for i in 2..(CidQueue::LEN as u64 - 1) {
+            let _ = q.next().unwrap();
+            assert_eq!(q.active_seq(), i + 1);
+            let retire = q.retire_prior_to(i + 1);
+            assert_eq!(retire.end - retire.start, 0);
+            assert!(!q.is_active_retired());
+        }
+
         assert!(q.next().is_none());
+        assert!(!q.is_active_retired());
     }
 
     #[test]

--- a/quinn-proto/src/cid_queue.rs
+++ b/quinn-proto/src/cid_queue.rs
@@ -13,7 +13,7 @@ pub struct CidQueue {
     cursor: usize,
     /// Sequence number of `self.buffer[cursor]`
     ///
-    /// The sequence of active (in use) CID. This sequence is also the smallest among CIDs in `buffer`.
+    /// The sequence number of the active CID; must be the smallest among CIDs in `buffer`.
     offset: u64,
 }
 
@@ -90,17 +90,17 @@ impl CidQueue {
     }
 
     /// Return active remote CID itself
-    pub fn rem_cid(&self) -> ConnectionId {
+    pub fn active(&self) -> ConnectionId {
         self.buffer[self.cursor].unwrap().0
     }
 
     /// Check whether self.offset points to a valid CID in CidQueue
-    pub fn validate_rem_cid(&mut self) -> bool {
-        self.buffer[self.cursor].as_ref().is_some()
+    pub fn is_active_retired(&mut self) -> bool {
+        self.buffer[self.cursor].is_none()
     }
 
     /// Return the sequence number of active remote CID
-    pub fn rem_cid_seq(&self) -> u64 {
+    pub fn active_seq(&self) -> u64 {
         self.offset
     }
 }

--- a/quinn-proto/src/cid_queue.rs
+++ b/quinn-proto/src/cid_queue.rs
@@ -84,6 +84,16 @@ impl CidQueue {
         }
         None
     }
+
+    /// Reset offset field and guarantee the smallest sequence of active CID is prior to this value
+    pub fn assign_offset(&mut self, v: u64) {
+        self.offset = v;
+    }
+
+    /// Read the current offset value
+    pub fn read_offset(&self) -> u64 {
+        self.offset
+    }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2361,6 +2361,11 @@ where
                         ));
                     }
                     self.cids_active_seq.remove(&sequence);
+                    // Consider a scenario where peer A has active remote cid 0,1,2.
+                    // Peer B first send a NEW_CONNECTION_ID with cid 3 and retire_prior_to set to 0.
+                    // Peer A processes this NEW_CONNECTION_ID frame; update remote cid to 1,2,3
+                    // and meanwhile send a RETIRE_CONNECTION_ID to retire cid 0 to peer B.
+                    // If peer B doesn't check the cid limit here and send a new cid again, peer A will then face CONNECTION_ID_LIMIT_ERROR
                     let allow_more_cid = self
                         .peer_params
                         .active_connection_id_limit

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -77,7 +77,7 @@ where
     /// Exactly one prior to `self.rem_cids.offset` except during processing of certain
     /// NEW_CONNECTION_ID frames.
     rem_cid_seq: u64,
-    /// The sequence number of active (not yet rotated/retired by peer) local connection IDs
+    /// The sequence numbers of local connection IDs not yet retired by the peer
     cids_active_seq: HashSet<u64>,
     /// Sequence number to set in retire_prior_to field in NEW_CONNECTION_ID frame
     retire_cid_seq: u64,

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -28,8 +28,7 @@ use crate::{
     },
     transport_parameters::TransportParameters,
     Dir, Frame, Side, StreamId, Transmit, TransportError, TransportErrorCode, VarInt,
-    LOC_CID_COUNT, MAX_STREAM_COUNT, MIN_INITIAL_SIZE, MIN_MTU, RESET_TOKEN_SIZE,
-    TIMER_GRANULARITY,
+    MAX_STREAM_COUNT, MIN_INITIAL_SIZE, MIN_MTU, RESET_TOKEN_SIZE, TIMER_GRANULARITY,
 };
 
 mod assembler;

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2415,7 +2415,7 @@ where
                         // switch immediately to enable clientside stateless resets.
                         debug_assert_eq!(self.rem_cids.rem_cid_seq(), 0);
                         self.update_rem_cid().unwrap();
-                    } else if update_reset_token && !self.rem_cids.validate_rem_cid() {
+                    } else if !self.rem_cids.validate_rem_cid() {
                         // If our current CID is meant to be retired; or
                         // active remote CID is invalid (due to packet loss or reordering),
                         // we must switch to next valid CID

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2573,7 +2573,7 @@ where
         );
     }
 
-    /// Return None if no CIDs were available
+    /// Does nothing and returns None if no unused CIDs were available
     fn retire_rem_cid(&mut self) -> Option<IssuedCid> {
         let (cid, retired) = self.rem_cids.next()?;
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2362,7 +2362,7 @@ where
                     }
                     self.cids_active_seq.remove(&sequence);
                     // Consider a scenario where peer A has active remote cid 0,1,2.
-                    // Peer B first send a NEW_CONNECTION_ID with cid 3 and retire_prior_to set to 0.
+                    // Peer B first send a NEW_CONNECTION_ID with cid 3 and retire_prior_to set to 1.
                     // Peer A processes this NEW_CONNECTION_ID frame; update remote cid to 1,2,3
                     // and meanwhile send a RETIRE_CONNECTION_ID to retire cid 0 to peer B.
                     // If peer B doesn't check the cid limit here and send a new cid again, peer A will then face CONNECTION_ID_LIMIT_ERROR

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -122,11 +122,13 @@ where
                     warn!("duplicate reset token");
                 }
             }
-            RetireConnectionId(seq) => {
+            RetireConnectionId(seq, allow_more_cid) => {
                 if let Some(cid) = self.connections[ch].loc_cids.remove(&seq) {
                     trace!("peer retired CID {}: {}", seq, cid);
                     self.connection_ids.remove(&cid);
-                    return Some(self.send_new_identifiers(ch, 1));
+                    if allow_more_cid {
+                        return Some(self.send_new_identifiers(ch, 1));
+                    }
                 }
             }
             Drained => {

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -52,7 +52,7 @@ pub(crate) enum EndpointEventInner {
     /// The connection needs connection identifiers
     NeedIdentifiers(u64),
     /// Stop routing connection ID for this sequence number to the connection
-    RetireConnectionId(u64),
+    RetireConnectionId(u64, bool),
 }
 
 /// Protocol-level identifier for a connection.

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -52,6 +52,7 @@ pub(crate) enum EndpointEventInner {
     /// The connection needs connection identifiers
     NeedIdentifiers(u64),
     /// Stop routing connection ID for this sequence number to the connection
+    /// When `bool == true`, a new connection ID will be issued to peer
     RetireConnectionId(u64, bool),
 }
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1196,7 +1196,7 @@ fn cid_retirement() {
     let mut active_cid_num = CidQueue::LEN as u64;
     active_cid_num = active_cid_num.min(LOC_CID_COUNT);
 
-    let _next_retire_prior_to = active_cid_num + 1;
+    let next_retire_prior_to = active_cid_num + 1;
     pair.client_conn_mut(client_ch).ping();
     // Server retires all valid remote CIDs
     pair.server_conn_mut(server_ch)

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1200,7 +1200,7 @@ fn cid_retirement() {
     pair.client_conn_mut(client_ch).ping();
     // Server retires all valid remote CIDs
     pair.server_conn_mut(server_ch)
-        .rotate_local_cid(_next_retire_prior_to);
+        .rotate_local_cid(next_retire_prior_to);
     pair.drive();
     assert!(!pair.client_conn_mut(client_ch).is_closed());
     assert!(!pair.server_conn_mut(server_ch).is_closed());

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1184,7 +1184,7 @@ fn cid_retirement() {
     let (client_ch, server_ch) = pair.connect();
 
     // Server retires current active remote CIDs
-    pair.server_conn_mut(server_ch).rotate_rem_cid(1, 1);
+    pair.server_conn_mut(server_ch).rotate_local_cid(1);
     pair.drive();
     // Any unexpected behavior may trigger TransportError::CONNECTION_ID_LIMIT_ERROR
     assert!(!pair.client_conn_mut(client_ch).is_closed());
@@ -1193,14 +1193,14 @@ fn cid_retirement() {
 
     use crate::cid_queue::CidQueue;
     use crate::LOC_CID_COUNT;
-    let mut active_cid_num = CidQueue::LEN as u64 + 1;
+    let mut active_cid_num = CidQueue::LEN as u64;
     active_cid_num = active_cid_num.min(LOC_CID_COUNT);
 
     let _next_retire_prior_to = active_cid_num + 1;
     pair.client_conn_mut(client_ch).ping();
     // Server retires all valid remote CIDs
     pair.server_conn_mut(server_ch)
-        .rotate_rem_cid(_next_retire_prior_to, 1);
+        .rotate_local_cid(_next_retire_prior_to);
     pair.drive();
     assert!(!pair.client_conn_mut(client_ch).is_closed());
     assert!(!pair.server_conn_mut(server_ch).is_closed());

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1184,7 +1184,7 @@ fn cid_retirement() {
     let (client_ch, server_ch) = pair.connect();
 
     // Server retires current active remote CIDs
-    pair.server_conn_mut(server_ch).mock_retire_cid(1, 1);
+    pair.server_conn_mut(server_ch).rotate_rem_cid(1, 1);
     pair.drive();
     // Any unexpected behavior may trigger TransportError::CONNECTION_ID_LIMIT_ERROR
     assert!(!pair.client_conn_mut(client_ch).is_closed());
@@ -1200,7 +1200,7 @@ fn cid_retirement() {
     pair.client_conn_mut(client_ch).ping();
     // Server retires all valid remote CIDs
     pair.server_conn_mut(server_ch)
-        .mock_retire_cid(_next_retire_prior_to, 1);
+        .rotate_rem_cid(_next_retire_prior_to, 1);
     pair.drive();
     assert!(!pair.client_conn_mut(client_ch).is_closed());
     assert!(!pair.server_conn_mut(server_ch).is_closed());

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1178,6 +1178,38 @@ fn keep_alive() {
 }
 
 #[test]
+fn cid_retirement() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let (client_ch, server_ch) = pair.connect();
+
+    // Server retires current active remote CIDs
+    pair.server_conn_mut(server_ch).mock_retire_cid(1, 1);
+    pair.drive();
+    // Any unexpected behavior may trigger TransportError::CONNECTION_ID_LIMIT_ERROR
+    assert!(!pair.client_conn_mut(client_ch).is_closed());
+    assert!(!pair.server_conn_mut(server_ch).is_closed());
+    assert_matches!(pair.client_conn_mut(client_ch).active_rem_cid_seq(), 1);
+
+    use crate::cid_queue::CidQueue;
+    use crate::LOC_CID_COUNT;
+    let mut active_cid_num = CidQueue::LEN as u64 + 1;
+    active_cid_num = active_cid_num.min(LOC_CID_COUNT);
+
+    let next_retire_prior_to = active_cid_num + 1;
+    // Server retires all valid remote CIDs
+    pair.server_conn_mut(server_ch)
+        .mock_retire_cid(next_retire_prior_to, 1);
+    pair.drive();
+    assert!(!pair.client_conn_mut(client_ch).is_closed());
+    assert!(!pair.server_conn_mut(server_ch).is_closed());
+    assert_matches!(
+        pair.client_conn_mut(client_ch).active_rem_cid_seq(),
+        next_retire_prior_to
+    );
+}
+
+#[test]
 fn finish_stream_flow_control_reordered() {
     let _guard = subscribe();
     let mut pair = Pair::default();

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1197,6 +1197,7 @@ fn cid_retirement() {
     active_cid_num = active_cid_num.min(LOC_CID_COUNT);
 
     let next_retire_prior_to = active_cid_num + 1;
+    pair.client_conn_mut(client_ch).ping();
     // Server retires all valid remote CIDs
     pair.server_conn_mut(server_ch)
         .mock_retire_cid(next_retire_prior_to, 1);

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1196,17 +1196,17 @@ fn cid_retirement() {
     let mut active_cid_num = CidQueue::LEN as u64 + 1;
     active_cid_num = active_cid_num.min(LOC_CID_COUNT);
 
-    let next_retire_prior_to = active_cid_num + 1;
+    let _next_retire_prior_to = active_cid_num + 1;
     pair.client_conn_mut(client_ch).ping();
     // Server retires all valid remote CIDs
     pair.server_conn_mut(server_ch)
-        .mock_retire_cid(next_retire_prior_to, 1);
+        .mock_retire_cid(_next_retire_prior_to, 1);
     pair.drive();
     assert!(!pair.client_conn_mut(client_ch).is_closed());
     assert!(!pair.server_conn_mut(server_ch).is_closed());
     assert_matches!(
         pair.client_conn_mut(client_ch).active_rem_cid_seq(),
-        next_retire_prior_to
+        _next_retire_prior_to
     );
 }
 

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -21,7 +21,7 @@ use crate::{
     config::{EndpointConfig, ServerConfig, TransportConfig},
     crypto,
     shared::ConnectionId,
-    ResetToken, Side, TransportError, VarInt, MAX_CID_SIZE, RESET_TOKEN_SIZE,
+    ResetToken, Side, TransportError, VarInt, LOC_CID_COUNT, MAX_CID_SIZE, RESET_TOKEN_SIZE,
 };
 
 // Apply a given macro to a list of all the transport parameters having integer types, along with
@@ -174,6 +174,13 @@ impl TransportParameters {
             ));
         }
         Ok(())
+    }
+
+    /// Calculate the maximum number of CIDs that a peer is willing to issue
+    /// Consider both a) the active_connection_id_limit from the other end; and
+    /// b) LOC_CID_COUNT used locally
+    pub(crate) fn issue_cids_limit(&self) -> u64 {
+        self.active_connection_id_limit.0.min(LOC_CID_COUNT)
     }
 }
 

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -143,8 +143,7 @@ impl TransportParameters {
             active_connection_id_limit: if cid_gen.cid_len() == 0 {
                 2 // i.e. default, i.e. unsent
             } else {
-                // + 1 to account for the currently used CID, which isn't kept in the queue
-                CidQueue::LEN as u32 + 1
+                CidQueue::LEN as u32
             }
             .into(),
             max_datagram_frame_size: config

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -175,7 +175,8 @@ impl TransportParameters {
         Ok(())
     }
 
-    /// Calculate the maximum number of CIDs that a peer is willing to issue
+    /// Maximum number of CIDs to issue to this peer
+    ///
     /// Consider both a) the active_connection_id_limit from the other end; and
     /// b) LOC_CID_COUNT used locally
     pub(crate) fn issue_cids_limit(&self) -> u64 {

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -21,7 +21,8 @@ use crate::{
     config::{EndpointConfig, ServerConfig, TransportConfig},
     crypto,
     shared::ConnectionId,
-    ResetToken, Side, TransportError, VarInt, MAX_CID_SIZE, MAX_STREAM_COUNT, RESET_TOKEN_SIZE,
+    ResetToken, Side, TransportError, VarInt, LOC_CID_COUNT, MAX_CID_SIZE, MAX_STREAM_COUNT,
+    RESET_TOKEN_SIZE,
 };
 
 // Apply a given macro to a list of all the transport parameters having integer types, along with


### PR DESCRIPTION
As requested in https://github.com/quinn-rs/quinn/pull/860, this PR extracts code change particularly for fixing existing bugs when processing cid retirement.

Currently in quinn-proto, retire_prior_to field in `NEW_CONNECTION_ID` frame is constantly set to 0 which means the logic for cid retirement is not properly tested and thus a few bugs are found.

1. quinn-proto maintains both `rem_cid` (as active remote cid) and `rem_cids` (in CidQueue as cid candidates). In a corner case, we may need to pick one candidate from `rem_cids` to replace `rem_cid`. However, current code cannot properly handle this case as `update_rem_cid` is always called after `insert` function of CidQueue. Please follow the added unit test to understand the details.

2. Based on RFC, "An endpoint SHOULD supply a new connection ID when the peer retires a connection ID". quinn-proto just issues new cid without any condition check. Meanwhile in RFC, there is also following statement "An endpoint MUST NOT provide more connection IDs than the peer's limit". Since "MUST" overrides "SHOULD", [condition check](https://github.com/quinn-rs/quinn/compare/main...liwenjieQu:retire_cid?expand=1#diff-423ed266e9aaf5fcae0fa8b85ca382f495528c18cd7c890cef1cf438221f2ef6R2363-R2374) is needed to avoid creating NEW_CONNECTION_ID frame endlessly.