### PR TITLE
Use vectors instead of boxed slices

### DIFF
--- a/quinn-proto/src/assembler.rs
+++ b/quinn-proto/src/assembler.rs
@@ -105,12 +105,12 @@ impl Assembler {
     }
 
     #[cfg(test)]
-    fn next(&mut self, size: usize) -> Option<Box<[u8]>> {
+    fn next(&mut self, size: usize) -> Option<Vec<u8>> {
         let mut buf = vec![0; size];
         let read = self.read(&mut buf);
         buf.resize(read, 0);
         if !buf.is_empty() {
-            Some(buf.into())
+            Some(buf)
         } else {
             None
         }

--- a/quinn-proto/src/connection.rs
+++ b/quinn-proto/src/connection.rs
@@ -2358,7 +2358,7 @@ where
 
         Some(Transmit {
             destination: self.path.remote,
-            contents: buf.into(),
+            contents: buf,
             ecn: if self.path.sending_ecn {
                 Some(EcnCodepoint::ECT0)
             } else {
@@ -3197,7 +3197,7 @@ pub fn initial_close<K, R>(
     local_id: &ConnectionId,
     packet_number: u8,
     reason: R,
-) -> Box<[u8]>
+) -> Vec<u8>
 where
     K: crypto::Keys,
     R: Into<Close>,
@@ -3220,7 +3220,7 @@ where
         header_crypto,
         Some((u64::from(packet_number), crypto)),
     );
-    buf.into()
+    buf
 }
 
 /// Reasons why a connection might be lost.

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -216,7 +216,7 @@ pub struct Transmit {
     /// Explicit congestion notification bits to set on the packet
     pub ecn: Option<EcnCodepoint>,
     /// Contents of the datagram
-    pub contents: Box<[u8]>,
+    pub contents: Vec<u8>,
 }
 
 //

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -173,7 +173,7 @@ pub struct TestEndpoint {
     timeout: Option<Instant>,
     pub outbound: VecDeque<Transmit>,
     delayed: VecDeque<Transmit>,
-    pub inbound: VecDeque<(Instant, Option<EcnCodepoint>, Box<[u8]>)>,
+    pub inbound: VecDeque<(Instant, Option<EcnCodepoint>, Vec<u8>)>,
     accepted: Option<ConnectionHandle>,
     pub connections: HashMap<ConnectionHandle, Connection>,
     conn_events: HashMap<ConnectionHandle, VecDeque<ConnectionEvent>>,

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -214,7 +214,7 @@ async fn handle_request(
     Ok(())
 }
 
-fn process_get(root: &Path, x: &[u8]) -> Result<Box<[u8]>> {
+fn process_get(root: &Path, x: &[u8]) -> Result<Vec<u8>> {
     if x.len() < 4 || &x[0..4] != b"GET " {
         bail!("missing GET");
     }
@@ -244,5 +244,5 @@ fn process_get(root: &Path, x: &[u8]) -> Result<Box<[u8]>> {
         }
     }
     let data = fs::read(&real_path).context("failed reading file")?;
-    Ok(data.into())
+    Ok(data)
 }


### PR DESCRIPTION
The conversion from Vec<u8> into Box<[u8]> is not always for free.
It will call `Vec::into_boxed_slice`, which will call `shrink_to_fit`.
https://github.com/rust-lang/rust/blob/28f03ac4c08fc7ec62428d0b914e1510ce7ee2cb/library/alloc/src/vec.rs#L689

If the `Vec` isn't fully utilized before, this will cause a reallocation
and a copy of all data. This might currently happen with every
outgoing packet.

This change simply keeps things as `Vec<u8>`, which works just fine since
the IO layer can deal with it.