### PR TITLE
Use vectors instead of boxed slices

### DIFF
--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -135,12 +135,12 @@ impl Assembler {
     }
 
     #[cfg(test)]
-    fn next(&mut self, size: usize) -> Option<Box<[u8]>> {
+    fn next(&mut self, size: usize) -> Option<Vec<u8>> {
         let mut buf = vec![0; size];
         let read = self.read(&mut buf).unwrap();
         buf.resize(read, 0);
         if !buf.is_empty() {
-            Some(buf.into())
+            Some(buf)
         } else {
             None
         }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -336,7 +336,7 @@ where
                 self.finish_packet(builder);
                 return Some(Transmit {
                     destination,
-                    contents: buf.into(),
+                    contents: buf,
                     ecn: None,
                 });
             }
@@ -499,7 +499,7 @@ where
 
         Some(Transmit {
             destination: self.path.remote,
-            contents: buf.into(),
+            contents: buf,
             ecn: if self.path.sending_ecn {
                 Some(EcnCodepoint::ECT0)
             } else {

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -186,7 +186,7 @@ where
                     self.transmits.push_back(Transmit {
                         destination: remote,
                         ecn: None,
-                        contents: buf.into(),
+                        contents: buf,
                     });
                     return None;
                 }
@@ -331,7 +331,7 @@ where
         self.transmits.push_back(Transmit {
             destination: remote,
             ecn: None,
-            contents: buf.into(),
+            contents: buf,
         });
     }
 
@@ -572,7 +572,7 @@ where
                 self.transmits.push_back(Transmit {
                     destination: remote,
                     ecn: None,
-                    contents: buf.into(),
+                    contents: buf,
                 });
                 return None;
             }
@@ -664,7 +664,7 @@ where
         self.transmits.push_back(Transmit {
             destination,
             ecn: None,
-            contents: buf.into(),
+            contents: buf,
         })
     }
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -248,7 +248,7 @@ pub struct Transmit {
     /// Explicit congestion notification bits to set on the packet
     pub ecn: Option<EcnCodepoint>,
     /// Contents of the datagram
-    pub contents: Box<[u8]>,
+    pub contents: Vec<u8>,
 }
 
 //

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -226,7 +226,7 @@ impl TestEndpoint {
             let (_, ecn, packet) = self.inbound.pop_front().unwrap();
             if let Some((ch, event)) =
                 self.endpoint
-                    .handle(now, remote, ecn, Vec::from(packet).as_slice().into())
+                    .handle(now, remote, ecn, packet.as_slice().into())
             {
                 match event {
                     DatagramEvent::NewConnection(conn) => {

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -181,7 +181,7 @@ pub struct TestEndpoint {
     timeout: Option<Instant>,
     pub outbound: VecDeque<Transmit>,
     delayed: VecDeque<Transmit>,
-    pub inbound: VecDeque<(Instant, Option<EcnCodepoint>, Box<[u8]>)>,
+    pub inbound: VecDeque<(Instant, Option<EcnCodepoint>, Vec<u8>)>,
     accepted: Option<ConnectionHandle>,
     pub connections: HashMap<ConnectionHandle, Connection>,
     conn_events: HashMap<ConnectionHandle, VecDeque<ConnectionEvent>>,

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -215,7 +215,6 @@ async fn handle_request(
         error!("failed: {}", e);
         format!("failed to process request: {}\n", e)
             .into_bytes()
-            .into()
     });
     // Write the response
     send.write_all(&resp)

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -213,8 +213,7 @@ async fn handle_request(
     // Execute the request
     let resp = process_get(&root, &req).unwrap_or_else(|e| {
         error!("failed: {}", e);
-        format!("failed to process request: {}\n", e)
-            .into_bytes()
+        format!("failed to process request: {}\n", e).into_bytes()
     });
     // Write the response
     send.write_all(&resp)

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -229,7 +229,7 @@ async fn handle_request(
     Ok(())
 }
 
-fn process_get(root: &Path, x: &[u8]) -> Result<Box<[u8]>> {
+fn process_get(root: &Path, x: &[u8]) -> Result<Vec<u8>> {
     if x.len() < 4 || &x[0..4] != b"GET " {
         bail!("missing GET");
     }
@@ -259,5 +259,5 @@ fn process_get(root: &Path, x: &[u8]) -> Result<Box<[u8]>> {
         }
     }
     let data = fs::read(&real_path).context("failed reading file")?;
-    Ok(data.into())
+    Ok(data)
 }


### PR DESCRIPTION
The conversion from Vec<u8> into Box<[u8]> is not always for free.
It will call `Vec::into_boxed_slice`, which will call `shrink_to_fit`.
https://github.com/rust-lang/rust/blob/28f03ac4c08fc7ec62428d0b914e1510ce7ee2cb/library/alloc/src/vec.rs#L689

If the `Vec` isn't fully utilized before, this will cause a reallocation
and a copy of all data. This might currently happen with every
outgoing packet.

This change simply keeps things as `Vec<u8>`, which works just fine since
the IO layer can deal with it.