### PR TITLE
Transmit multiple packets at once from connection to endpoint task

### DIFF
--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -358,6 +358,9 @@ where
                         }
                     }
                     Transmit(t) => self.outgoing.push_back(t),
+                    EndpointEvent::TransmitMultiple(t) => {
+                        self.outgoing.extend(t);
+                    }
                 },
                 Poll::Ready(None) => unreachable!("EndpointInner owns one sender"),
                 Poll::Pending => {

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -151,6 +151,7 @@ enum ConnectionEvent {
 enum EndpointEvent {
     Proto(proto::EndpointEvent),
     Transmit(proto::Transmit),
+    TransmitMultiple(Vec<proto::Transmit>),
 }
 
 /// Maximum number of send/recv calls to make before moving on to other processing


### PR DESCRIPTION
Currently all ougoing packets are sent 1 by 1 from the connection
task to the endpoint task using an async queue. This has a couple of
downsides:
1. It requires additional synchronization for each queue operation.
2. It requires an additional heap allocation due to the nature of
  an unbounded futures channel.
3. It might lead to situations where less than the maximum number
  of possible packets could be transmtited in the endpoint task.
  It gets woken up after the first packet(s) arrive, might send those,
  but miss packets which are shortly queued after this.

I opted to add another event variant to cover for single/multiple
packets, to make sure the single packet version doesn't have an
extra allocation. A more elegant version might however be to
import SmallVec, and use a certain inline list size. I however didn't
want to add additional dependencies.
Yet another option is to just always use `Vec`.  But I thought if
this about efficiency - why not look into really efficient.

Performance gain in the bulk transmission test seems to be in the
1% range. Not that much, but better than nothing.