### PR TITLE
Add connection level statistics

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -43,6 +43,9 @@ mod send_buffer;
 mod spaces;
 use spaces::{PacketSpace, Retransmits, SentPacket};
 
+mod stats;
+use stats::ConnectionStats;
+
 mod streams;
 pub use streams::Streams;
 pub use streams::{FinishError, ReadError, StreamEvent, UnknownStream, WriteError};
@@ -161,6 +164,8 @@ where
     rem_cids: CidQueue,
     /// State of the unreliable datagram extension
     datagrams: DatagramState,
+    /// Connection level statistics
+    stats: ConnectionStats,
 }
 
 impl<S> Connection<S>
@@ -261,6 +266,7 @@ where
             config,
             rem_cids: CidQueue::new(1),
             rng,
+            stats: ConnectionStats::default(),
         };
         if side.is_client() {
             // Kick off the connection
@@ -496,6 +502,9 @@ where
 
         trace!("sending {} byte datagram", buf.len());
         self.total_sent = self.total_sent.wrapping_add(buf.len() as u64);
+
+        self.stats.packet_tx.packets += 1;
+        self.stats.packet_tx.bytes += buf.len() as u64;
 
         Some(Transmit {
             destination: self.path.remote,
@@ -2589,12 +2598,16 @@ where
         if !is_0rtt && mem::replace(&mut space.pending.handshake_done, false) {
             buf.write(frame::Type::HANDSHAKE_DONE);
             sent.retransmits.handshake_done = true;
+            // This is just a u8 counter and the frame is typically just sent once
+            self.stats.frame_tx.handshake_done =
+                self.stats.frame_tx.handshake_done.saturating_add(1);
         }
 
         // PING
         if mem::replace(&mut space.ping_pending, false) {
             trace!("PING");
             buf.write(frame::Type::PING);
+            self.stats.frame_tx.ping += 1;
         }
 
         // ACK
@@ -2609,6 +2622,7 @@ where
             };
             frame::Ack::encode(0, &space.pending_acks, ecn, buf);
             sent.acks = space.pending_acks.clone();
+            self.stats.frame_tx.acks += 1;
         }
 
         // PATH_CHALLENGE
@@ -2620,6 +2634,7 @@ where
                 trace!("PATH_CHALLENGE {:08x}", token);
                 buf.write(frame::Type::PATH_CHALLENGE);
                 buf.write(token);
+                self.stats.frame_tx.path_challenge += 1;
             }
         }
 
@@ -2629,6 +2644,7 @@ where
                 trace!("PATH_RESPONSE {:08x}", response.token);
                 buf.write(frame::Type::PATH_RESPONSE);
                 buf.write(response.token);
+                self.stats.frame_tx.path_response += 1;
             }
         }
 
@@ -2653,6 +2669,7 @@ where
                 truncated.data.len()
             );
             truncated.encode(buf);
+            self.stats.frame_tx.crypto += 1;
             sent.retransmits.crypto.push_back(truncated);
             if !frame.data.is_empty() {
                 frame.offset += len as u64;
@@ -2665,6 +2682,7 @@ where
                 buf,
                 &mut space.pending,
                 &mut sent.retransmits,
+                &mut self.stats.frame_tx,
                 max_size,
             );
         }
@@ -2688,6 +2706,7 @@ where
             }
             .encode(buf);
             sent.retransmits.new_cids.push(issued);
+            self.stats.frame_tx.new_connection_id += 1;
         }
 
         // RETIRE_CONNECTION_ID
@@ -2700,6 +2719,7 @@ where
             buf.write(frame::Type::RETIRE_CONNECTION_ID);
             buf.write_var(seq);
             sent.retransmits.retire_cids.push(seq);
+            self.stats.frame_tx.retire_connection_id += 1;
         }
 
         // DATAGRAM
@@ -2716,11 +2736,13 @@ where
             }
             self.datagrams.outgoing_total -= datagram.data.len();
             datagram.encode(true, buf);
+            self.stats.frame_tx.datagram += 1;
         }
 
         // STREAM
         if space_id == SpaceId::Data {
             sent.stream_frames = self.streams.write_stream_frames(buf, max_size);
+            self.stats.frame_tx.stream += sent.stream_frames.len() as u64;
         }
 
         sent

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -1,0 +1,71 @@
+/// Statistics about packets transmitted on a connection
+#[derive(Default)]
+#[non_exhaustive]
+pub struct PacketTransmissionStats {
+    /// The amount of packets transmitted on a connection
+    pub packets: u64,
+    /// The total amount of bytes transmitted on a connection
+    pub bytes: u64,
+}
+
+impl std::fmt::Debug for PacketTransmissionStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PacketTransmissionStats")
+            .field("packets", &self.packets)
+            .field("bytes", &self.bytes)
+            .finish()
+    }
+}
+
+/// Statistics about frames transmitted or received on a connection
+#[derive(Default)]
+#[non_exhaustive]
+pub struct FrameStats {
+    pub acks: u64,
+    pub crypto: u64,
+    pub datagram: u64,
+    pub handshake_done: u8,
+    pub max_data: u64,
+    pub max_stream_data: u64,
+    pub max_streams_bidi: u64,
+    pub max_streams_uni: u64,
+    pub new_connection_id: u64,
+    pub path_challenge: u64,
+    pub path_response: u64,
+    pub ping: u64,
+    pub reset_stream: u64,
+    pub retire_connection_id: u64,
+    pub stop_sending: u64,
+    pub stream: u64,
+}
+
+impl std::fmt::Debug for FrameStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FrameStats")
+            .field("ACK", &self.acks)
+            .field("CRYPTO", &self.crypto)
+            .field("DATAGRAM", &self.datagram)
+            .field("HANDSHAKE_DONE", &self.handshake_done)
+            .field("MAX_DATA", &self.max_data)
+            .field("MAX_STREAM_DATA", &self.max_stream_data)
+            .field("MAX_STREAMS_BIDI", &self.max_streams_bidi)
+            .field("MAX_STREAMS_UNI", &self.max_streams_uni)
+            .field("NEW_CONNECTION_ID", &self.new_connection_id)
+            .field("PATH_CHALLENGE", &self.path_challenge)
+            .field("PATH_RESPONSE", &self.path_response)
+            .field("PING", &self.ping)
+            .field("RESET_STREAM", &self.reset_stream)
+            .field("RETIRE_CONNECTION_ID", &self.retire_connection_id)
+            .field("STOP_SENDING", &self.stop_sending)
+            .field("STREAM", &self.stream)
+            .finish()
+    }
+}
+
+/// Connection statistics
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct ConnectionStats {
+    pub packet_tx: PacketTransmissionStats,
+    pub frame_tx: FrameStats,
+}


### PR DESCRIPTION
This change adds some structs which track connection-level statistics.
These are rather helpful to determine how the implementation performs,
and which impact certain changes have.

The implementation is not complete. It's just a first step on getting
some more visibility into the transmitting side of the library. More
statistics - e.g. around congestion control, retransmission, timing, etc
could be added.

The stats are currently private, and I just debug printed them so far
where found useful. They could however be public if the API is fine.
Another possibility is to have the stats behind a feature flag if people
are concerned about extra memory usage.