### PR TITLE
Packet reception stats

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -500,8 +500,8 @@ where
         trace!("sending {} byte datagram", buf.len());
         self.total_sent = self.total_sent.wrapping_add(buf.len() as u64);
 
-        self.stats.packet_tx.packets += 1;
-        self.stats.packet_tx.bytes += buf.len() as u64;
+        self.stats.udp_tx.datagrams += 1;
+        self.stats.udp_tx.bytes += buf.len() as u64;
 
         Some(Transmit {
             destination: self.path.remote,
@@ -703,10 +703,13 @@ where
                     return;
                 }
 
+                self.stats.udp_rx.datagrams += 1;
+                self.stats.udp_rx.bytes += first_decode.len() as u64;
                 self.total_recvd = self.total_recvd.wrapping_add(first_decode.len() as u64);
 
                 self.handle_decode(now, remote, ecn, first_decode);
                 if let Some(data) = remaining {
+                    self.stats.udp_rx.bytes += data.len() as u64;
                     self.handle_coalesced(now, remote, ecn, data);
                 }
             }

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -1,24 +1,15 @@
-/// Statistics about packets transmitted on a connection
-#[derive(Default)]
+/// Statistics about UDP datagrams transmitted or received on a connection
+#[derive(Default, Debug, Copy, Clone)]
 #[non_exhaustive]
-pub struct PacketTransmissionStats {
-    /// The amount of packets transmitted on a connection
-    pub packets: u64,
-    /// The total amount of bytes transmitted on a connection
+pub struct UdpStats {
+    /// The amount of UDP datagrams observed
+    pub datagrams: u64,
+    /// The total amount of bytes which have been transferred inside UDP datagrams
     pub bytes: u64,
 }
 
-impl std::fmt::Debug for PacketTransmissionStats {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PacketTransmissionStats")
-            .field("packets", &self.packets)
-            .field("bytes", &self.bytes)
-            .finish()
-    }
-}
-
 /// Statistics about frames transmitted or received on a connection
-#[derive(Default)]
+#[derive(Default, Copy, Clone)]
 #[non_exhaustive]
 pub struct FrameStats {
     pub acks: u64,
@@ -63,9 +54,13 @@ impl std::fmt::Debug for FrameStats {
 }
 
 /// Connection statistics
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Copy, Clone)]
 #[non_exhaustive]
 pub struct ConnectionStats {
-    pub packet_tx: PacketTransmissionStats,
+    /// Statistics about UDP datagrams transmitted on a connection
+    pub udp_tx: UdpStats,
+    /// Statistics about UDP datagrams received on a connection
+    pub udp_rx: UdpStats,
+    /// Statistics about frames transmitted on a connection
     pub frame_tx: FrameStats,
 }


### PR DESCRIPTION
This adds the same set of stats for received datagrams
that have been merged previously for transmitted datagrams.