### PR TITLE
Send only significant MAX_DATA frames (2)

### DIFF
--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -826,6 +826,28 @@ impl Datagram {
     }
 }
 
+/// Indicates whether a frame needs to be transmitted
+///
+/// This type wraps around bool and uses the `#[must_use]` attribute in order
+/// to prevent accidental loss of the frame transmission requirement.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[must_use = "A frame might need to be enqueued"]
+pub struct ShouldTransmit {
+    should_transmit: bool,
+}
+
+impl ShouldTransmit {
+    /// Creates a new `ShouldTransmit` instance
+    pub fn new(should_transmit: bool) -> Self {
+        Self { should_transmit }
+    }
+
+    /// Returns whether a frame should be transmitted
+    pub fn should_transmit(self) -> bool {
+        self.should_transmit
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
This is an update to #893 which uses a newtype to indicate whether an outgoing frame needs to be enqueued.
The update is in the second commit.

#893 could be merged before this - or this can be extended and replace the orginal CR.