### PR TITLE
Add README note about address families

### DIFF
--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -104,6 +104,7 @@ async fn run(options: Opt) -> Result<()> {
         .map_or_else(|| url.host_str(), |x| Some(&x))
         .ok_or_else(|| anyhow!("no hostname specified"))?;
 
+    eprintln!("connecting to {} at {}", host, remote);
     let new_conn = endpoint
         .connect(&remote, &host)?
         .await

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -126,7 +126,7 @@ async fn run(options: Opt) -> Result<()> {
     }
 
     let (endpoint, mut incoming) = endpoint.bind(&options.listen)?;
-    info!("listening on {}", endpoint.local_addr()?);
+    eprintln!("listening on {}", endpoint.local_addr()?);
     drop(endpoint);
 
     while let Some(conn) = incoming.next().await {


### PR DESCRIPTION
Just one proposal to prevent issues like #77 (which I think we've seen a few times). Bikeshedding on the most lucent and concise way to explain this welcome. (Also, do we need something like this in other places, maybe the example's docstrings?)