### PR TITLE
Create example README

### DIFF
--- a/quinn/examples/README.md
+++ b/quinn/examples/README.md
@@ -3,9 +3,6 @@
 The `https` example shows how to request a file on the `server` from the `client` over HTTPS. 
 This is HTTP/0.9, which is a toy protocol that's much simpler than real HTTP, especially HTTP/3.
 
-(Note: when providing the example server with a specific address to listen on,
-make sure you match the correct IPv4 vs IPv6 address in the client command.)
-
 1. HTTPS Server (`http_server.rs`)
 
 The server listens for any client requesting a file. 

--- a/quinn/examples/README.md
+++ b/quinn/examples/README.md
@@ -1,0 +1,83 @@
+                                                                            ## HTTPS File Serving Example
+                                                                            
+                                                                            The `https` example shows how to request a file on the `server` from the `client` over HTTPS. 
+                                                                            This is HTTP/0.9, which is a toy protocol that's much simpler than real HTTP, especially HTTP/3.
+                                                                            
+                                                                            (Note: when providing the example server with a specific address to listen on,
+                                                                            make sure you match the correct IPv4 vs IPv6 address in the client command.)
+                                                                            
+                                                                            1. HTTPS Server (`http_server.rs`)
+                                                                            
+                                                                            The server listens for any client requesting a file. 
+                                                                            If the file path is valid and allowed, it returns the contents. 
+                                                                            
+                                                                            Open up a terminal and execute:
+                                                                            
+                                                                            ```text
+                                                                            $ cargo run --example https_server ./
+                                                                            ```
+                                                                            
+                                                                            2. HTTP Client (`http_client.rs`)
+                                                                            
+                                                                            The client requests a file and prints it to the console. 
+                                                                            If the file is on the server, it will receive the response. 
+                                                                            
+                                                                            In a new terminal execute:
+                                                                            
+                                                                            ```test
+                                                                            $ cargo run --example https_client https://localhost:4433/README.MD
+                                                                            ```
+                                                                            
+                                                                            **Result:**
+                                                                            
+                                                                            The output will be the contents of this README.
+                                                                            
+                                                                            ## Minimal Example
+                                                                            The `connection.rs` example intends to use the smallest amount of code to make a simple QUIC connection.
+                                                                            The server issues it's own certificate and passes it to the client to trust.
+                                                                            
+                                                                            ```text
+                                                                            $ cargo run --example connection
+                                                                            ```
+                                                                            
+                                                                            This example will make a QUIC connection on localhost, and you should see output like:
+                                                                            
+                                                                            ```text
+                                                                            [server] incoming connection: id=3680c7d3b3ebd250 addr=127.0.0.1:50469
+                                                                            [client] connected: id=61a2df1548935aeb, addr=127.0.0.1:5000
+                                                                            ```
+                                                                            
+                                                                            ## Insecure Connection Example
+                                                                            
+                                                                            The `insecure_connection.rs` example demonstrates how to make a QUIC connection that ignores the server certificate.
+                                                                            
+                                                                            ```text
+                                                                            $ cargo run --example insecure_connection --features="rustls/dangerous_configuration"
+                                                                            ```
+                                                                            
+                                                                            ## Single Socket Example
+                                                                            
+                                                                            You can have multiple QUIC connections over a single UDP socket. This is especially
+                                                                            useful, if you are building a peer-to-peer system where you potentially need to communicate with
+                                                                            thousands of peers or if you have a
+                                                                            [hole punched](https://en.wikipedia.org/wiki/UDP_hole_punching) UDP socket.
+                                                                            Additionally, QUIC servers and clients can both operate on the same UDP socket.
+                                                                            This example demonstrates how to make multiple outgoing connections on a single UDP socket.
+                                                                            
+                                                                            ```text 
+                                                                            $ cargo run --example single_socket
+                                                                            ```
+                                                                            
+                                                                            The expected output should be something like:
+                                                                            
+                                                                            ```text
+                                                                            [server] incoming connection: id=bdd481e853111f09 addr=127.0.0.1:43149
+                                                                            [server] incoming connection: id=bfdeae5f7a67d89f addr=127.0.0.1:43149
+                                                                            [server] incoming connection: id=36ae757fc0d81d6a addr=127.0.0.1:43149
+                                                                            [client] connected: id=751758ed2c93350e, addr=127.0.0.1:5001
+                                                                            [client] connected: id=3722568139d78726, addr=127.0.0.1:5000
+                                                                            [client] connected: id=621265b108a59fad, addr=127.0.0.1:5002
+                                                                            ```
+                                                                            
+                                                                            Notice how the server sees multiple incoming connections with different IDs coming from the same
+                                                                            endpoint.

--- a/quinn/examples/README.md
+++ b/quinn/examples/README.md
@@ -1,83 +1,83 @@
-                                                                            ## HTTPS File Serving Example
-                                                                            
-                                                                            The `https` example shows how to request a file on the `server` from the `client` over HTTPS. 
-                                                                            This is HTTP/0.9, which is a toy protocol that's much simpler than real HTTP, especially HTTP/3.
-                                                                            
-                                                                            (Note: when providing the example server with a specific address to listen on,
-                                                                            make sure you match the correct IPv4 vs IPv6 address in the client command.)
-                                                                            
-                                                                            1. HTTPS Server (`http_server.rs`)
-                                                                            
-                                                                            The server listens for any client requesting a file. 
-                                                                            If the file path is valid and allowed, it returns the contents. 
-                                                                            
-                                                                            Open up a terminal and execute:
-                                                                            
-                                                                            ```text
-                                                                            $ cargo run --example https_server ./
-                                                                            ```
-                                                                            
-                                                                            2. HTTP Client (`http_client.rs`)
-                                                                            
-                                                                            The client requests a file and prints it to the console. 
-                                                                            If the file is on the server, it will receive the response. 
-                                                                            
-                                                                            In a new terminal execute:
-                                                                            
-                                                                            ```test
-                                                                            $ cargo run --example https_client https://localhost:4433/README.MD
-                                                                            ```
-                                                                            
-                                                                            **Result:**
-                                                                            
-                                                                            The output will be the contents of this README.
-                                                                            
-                                                                            ## Minimal Example
-                                                                            The `connection.rs` example intends to use the smallest amount of code to make a simple QUIC connection.
-                                                                            The server issues it's own certificate and passes it to the client to trust.
-                                                                            
-                                                                            ```text
-                                                                            $ cargo run --example connection
-                                                                            ```
-                                                                            
-                                                                            This example will make a QUIC connection on localhost, and you should see output like:
-                                                                            
-                                                                            ```text
-                                                                            [server] incoming connection: id=3680c7d3b3ebd250 addr=127.0.0.1:50469
-                                                                            [client] connected: id=61a2df1548935aeb, addr=127.0.0.1:5000
-                                                                            ```
-                                                                            
-                                                                            ## Insecure Connection Example
-                                                                            
-                                                                            The `insecure_connection.rs` example demonstrates how to make a QUIC connection that ignores the server certificate.
-                                                                            
-                                                                            ```text
-                                                                            $ cargo run --example insecure_connection --features="rustls/dangerous_configuration"
-                                                                            ```
-                                                                            
-                                                                            ## Single Socket Example
-                                                                            
-                                                                            You can have multiple QUIC connections over a single UDP socket. This is especially
-                                                                            useful, if you are building a peer-to-peer system where you potentially need to communicate with
-                                                                            thousands of peers or if you have a
-                                                                            [hole punched](https://en.wikipedia.org/wiki/UDP_hole_punching) UDP socket.
-                                                                            Additionally, QUIC servers and clients can both operate on the same UDP socket.
-                                                                            This example demonstrates how to make multiple outgoing connections on a single UDP socket.
-                                                                            
-                                                                            ```text 
-                                                                            $ cargo run --example single_socket
-                                                                            ```
-                                                                            
-                                                                            The expected output should be something like:
-                                                                            
-                                                                            ```text
-                                                                            [server] incoming connection: id=bdd481e853111f09 addr=127.0.0.1:43149
-                                                                            [server] incoming connection: id=bfdeae5f7a67d89f addr=127.0.0.1:43149
-                                                                            [server] incoming connection: id=36ae757fc0d81d6a addr=127.0.0.1:43149
-                                                                            [client] connected: id=751758ed2c93350e, addr=127.0.0.1:5001
-                                                                            [client] connected: id=3722568139d78726, addr=127.0.0.1:5000
-                                                                            [client] connected: id=621265b108a59fad, addr=127.0.0.1:5002
-                                                                            ```
-                                                                            
-                                                                            Notice how the server sees multiple incoming connections with different IDs coming from the same
-                                                                            endpoint.
+## HTTPS File Serving Example
+
+The `https` example shows how to request a file on the `server` from the `client` over HTTPS. 
+This is HTTP/0.9, which is a toy protocol that's much simpler than real HTTP, especially HTTP/3.
+
+(Note: when providing the example server with a specific address to listen on,
+make sure you match the correct IPv4 vs IPv6 address in the client command.)
+
+1. HTTPS Server (`http_server.rs`)
+
+The server listens for any client requesting a file. 
+If the file path is valid and allowed, it returns the contents. 
+
+Open up a terminal and execute:
+
+```text
+$ cargo run --example https_server ./
+```
+
+2. HTTP Client (`http_client.rs`)
+
+The client requests a file and prints it to the console. 
+If the file is on the server, it will receive the response. 
+
+In a new terminal execute:
+
+```test
+$ cargo run --example https_client https://localhost:4433/README.MD
+```
+
+**Result:**
+
+The output will be the contents of this README.
+
+## Minimal Example
+The `connection.rs` example intends to use the smallest amount of code to make a simple QUIC connection.
+The server issues it's own certificate and passes it to the client to trust.
+
+```text
+$ cargo run --example connection
+```
+
+This example will make a QUIC connection on localhost, and you should see output like:
+
+```text
+[server] incoming connection: id=3680c7d3b3ebd250 addr=127.0.0.1:50469
+[client] connected: id=61a2df1548935aeb, addr=127.0.0.1:5000
+```
+
+## Insecure Connection Example
+
+The `insecure_connection.rs` example demonstrates how to make a QUIC connection that ignores the server certificate.
+
+```text
+$ cargo run --example insecure_connection --features="rustls/dangerous_configuration"
+```
+
+## Single Socket Example
+
+You can have multiple QUIC connections over a single UDP socket. This is especially
+useful, if you are building a peer-to-peer system where you potentially need to communicate with
+thousands of peers or if you have a
+[hole punched](https://en.wikipedia.org/wiki/UDP_hole_punching) UDP socket.
+Additionally, QUIC servers and clients can both operate on the same UDP socket.
+This example demonstrates how to make multiple outgoing connections on a single UDP socket.
+
+```text 
+$ cargo run --example single_socket
+```
+
+The expected output should be something like:
+
+```text
+[server] incoming connection: id=bdd481e853111f09 addr=127.0.0.1:43149
+[server] incoming connection: id=bfdeae5f7a67d89f addr=127.0.0.1:43149
+[server] incoming connection: id=36ae757fc0d81d6a addr=127.0.0.1:43149
+[client] connected: id=751758ed2c93350e, addr=127.0.0.1:5001
+[client] connected: id=3722568139d78726, addr=127.0.0.1:5000
+[client] connected: id=621265b108a59fad, addr=127.0.0.1:5002
+```
+
+Notice how the server sees multiple incoming connections with different IDs coming from the same
+endpoint.

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -1,6 +1,6 @@
-//! Checkout the `README.md` for guidance.
+//! This example demonstrates a HTTP client that requests files from a server.
 //!
-//! README: https://github.com/quinn-rs/quinn/tree/main/quinn/examples/README.md
+//! Checkout the `README.md` for guidance.
 
 use std::{
     fs,

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -1,3 +1,7 @@
+//! Checkout the `README.md` for guidance.
+//!
+//! README: https://github.com/quinn-rs/quinn/tree/main/quinn/examples/README.md
+
 use std::{
     fs,
     io::{self, Write},

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -1,4 +1,4 @@
-//! This example demonstrates a HTTP client that requests files from a server.
+//! This example demonstrates an HTTP client that requests files from a server.
 //!
 //! Checkout the `README.md` for guidance.
 

--- a/quinn/examples/connection.rs
+++ b/quinn/examples/connection.rs
@@ -1,6 +1,6 @@
-//! Checkout the `README.md` for guidance.
+//! This example intends to use the smallest amount of code to make a simple QUIC connection.
 //!
-//! README: https://github.com/quinn-rs/quinn/tree/main/quinn/examples/README.md
+//! Checkout the `README.md` for guidance.
 
 // Provides the async `next()` method on `incoming` below
 use futures::StreamExt;

--- a/quinn/examples/connection.rs
+++ b/quinn/examples/connection.rs
@@ -1,17 +1,6 @@
-//! This example intends to use the smallest amount of code to make a simple QUIC connection.
+//! Checkout the `README.md` for guidance.
 //!
-//! The server issues it's own certificate and passes it to the client to trust.
-//!
-//! Run:
-//! ```text
-//! $ cargo run --example connection
-//! ```
-//!
-//! This example will make a QUIC connection on localhost, and you should see output like:
-//! ```text
-//! [server] incoming connection: id=3680c7d3b3ebd250 addr=127.0.0.1:50469
-//! [client] connected: id=61a2df1548935aeb, addr=127.0.0.1:5000
-//! ```
+//! README: https://github.com/quinn-rs/quinn/tree/main/quinn/examples/README.md
 
 // Provides the async `next()` method on `incoming` below
 use futures::StreamExt;

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -1,4 +1,4 @@
-//! This example intends to demonstrates how to make a QUIC connection that ignores the server certificate.
+//! This example demonstrates how to make a QUIC connection that ignores the server certificate.
 //!
 //! Checkout the `README.md` for guidance.
 

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -1,6 +1,6 @@
-//! Checkout the `README.md` for guidance.
+//! This example intends to demonstrates how to make a QUIC connection that ignores the server certificate.
 //!
-//! README: https://github.com/quinn-rs/quinn/tree/main/quinn/examples/README.md
+//! Checkout the `README.md` for guidance.
 
 use futures::StreamExt;
 use std::{error::Error, net::SocketAddr, sync::Arc};

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -1,9 +1,6 @@
-//! Demonstrates how to make a QUIC connection that ignores the server certificate.
+//! Checkout the `README.md` for guidance.
 //!
-//! Run:
-//! ```text
-//! $ cargo run --example insecure_connection --features="rustls/dangerous_configuration"
-//! ```
+//! README: https://github.com/quinn-rs/quinn/tree/main/quinn/examples/README.md
 
 use futures::StreamExt;
 use std::{error::Error, net::SocketAddr, sync::Arc};

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -1,4 +1,4 @@
-//! This example demonstrates a HTTP server that serve's files from a directory.
+//! This example demonstrates an HTTP server that serves files from a directory.
 //!
 //! Checkout the `README.md` for guidance.
 

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -1,18 +1,6 @@
-//! Example to serve files from a directory.
+//! Checkout the `README.md` for guidance.
 //!
-//! Run:
-//! ```text
-//! $ RUST_LOG=debug cargo run --example server ./
-//! ```
-//!
-//! and in another terminal you can run the client example:
-//!
-//! Run:
-//! ```test
-//! $ cargo run --example client https://localhost:4433/Cargo.toml
-//! ```
-//!
-//! The output will be the source code of the Cargo.toml file.
+//! README: https://github.com/quinn-rs/quinn/tree/main/quinn/examples/README.md
 
 use std::{
     ascii, fs, io,

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -1,6 +1,6 @@
-//! Checkout the `README.md` for guidance.
+//! This example demonstrates a HTTP server that serve's files from a directory.
 //!
-//! README: https://github.com/quinn-rs/quinn/tree/main/quinn/examples/README.md
+//! Checkout the `README.md` for guidance.
 
 use std::{
     ascii, fs, io,

--- a/quinn/examples/single_socket.rs
+++ b/quinn/examples/single_socket.rs
@@ -1,28 +1,6 @@
-//! You can have multiple QUIC connections over a single UDP socket. This is especially
-//! useful, if you are building a peer-to-peer system where you potentially need to communicate with
-//! thousands of peers or if you have a
-//! [hole punched](https://en.wikipedia.org/wiki/UDP_hole_punching) UDP socket.
-//! In addition, QUIC servers and clients can both operate on the same UDP socket.
+//! Checkout the `README.md` for guidance.
 //!
-//! This example demonstrate how to make multiple outgoing connections on a single UDP socket.
-//!
-//! Run:
-//! ```text
-//! $ cargo run --example single_socket
-//! ```
-//!
-//! The expected output should be something like:
-//! ```text
-//! [server] incoming connection: id=bdd481e853111f09 addr=127.0.0.1:43149
-//! [server] incoming connection: id=bfdeae5f7a67d89f addr=127.0.0.1:43149
-//! [server] incoming connection: id=36ae757fc0d81d6a addr=127.0.0.1:43149
-//! [client] connected: id=751758ed2c93350e, addr=127.0.0.1:5001
-//! [client] connected: id=3722568139d78726, addr=127.0.0.1:5000
-//! [client] connected: id=621265b108a59fad, addr=127.0.0.1:5002
-//! ```
-//!
-//! Notice how server sees multiple incoming connections with different IDs coming from the same
-//! endpoint.
+//! README: https://github.com/quinn-rs/quinn/tree/main/quinn/examples/README.md
 
 use futures::StreamExt;
 use std::{error::Error, net::SocketAddr};

--- a/quinn/examples/single_socket.rs
+++ b/quinn/examples/single_socket.rs
@@ -1,6 +1,6 @@
-//! Checkout the `README.md` for guidance.
+//! This example demonstrates how to make multiple outgoing connections on a single UDP socket.
 //!
-//! README: https://github.com/quinn-rs/quinn/tree/main/quinn/examples/README.md
+//! Checkout the `README.md` for guidance.
 
 use futures::StreamExt;
 use std::{error::Error, net::SocketAddr};


### PR DESCRIPTION
Create a new example README, this should provide the user with a single entry point for the examples. As a new user of this library, I found it somewhat hard to get a quick idea of what each example its purpose was and how to navigate them quickly.

## Changes

- Create an example readme with detailed instructions. 
- Change module comments from example files to a redirection to this README.