### PR TITLE
(2) Quinn Introduction Chapter, Certificate Configuration Page

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,4 +1,6 @@
 # Summary
 
 - [Quinn introduction](quinn.md)
+    - [Overview](quinn/introduction.md)
+    - [Certificate Configuration](quinn/certificate.md)
 - [The QUIC protocol](quic.md)

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,6 +1,5 @@
 # Summary
 
 - [Quinn introduction](quinn.md)
-    - [Overview](quinn/introduction.md)
     - [Certificate Configuration](quinn/certificate.md)
 - [The QUIC protocol](quic.md)

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -2,8 +2,7 @@
 
 In this chapter, we discuss the configuration of the certificates that is **required** for a working Quinn connection. 
 
-QUIC uses TLS 1.3 for authentication of connections, the server will have to provide the client with a certificate confirming its identity, 
-and the client must be configured to trust the certificates he receives from our server. 
+As QUIC uses TLS 1.3 for authentication of connections, the server needs  to provide the client with a certificate confirming its identity, and the client must be configured to trust the certificates it receives from the server. 
 
 ## Insecure Connection
 

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -3,7 +3,7 @@
 In this chapter, we discuss the configuration of the certificates that is **required** for a working Quinn connection. 
 
 QUIC uses TLS 1.3 for authentication of connections, the server will have to provide the client with a certificate confirming its identity, 
-and the customer must be configured to trust the certificates he receives from our server. 
+and the client must be configured to trust the certificates he receives from our server. 
 
 ## Insecure Connection
 
@@ -17,7 +17,7 @@ quinn = "*"
 rustls = { version = "*", features = ["dangerous_configuration", "quic"] }
 ``` 
 
-Then, you can skip the certificate validation on the client by implementing [ServerCertVerifier][ServerCertVerifier] and let it assert true for any server. 
+Then, you can skip the certificate validation on the client by implementing [ServerCertVerifier][ServerCertVerifier] and let it assert verification for any server. 
 
 ```rust
 // Implementation of `ServerCertVerifier` that verifies everything as trustworthy.
@@ -32,7 +32,7 @@ impl rustls::ServerCertVerifier for SkipCertificationVerification {
 }
 ```
 
-After that, we can configure our [ClientConfig][ClientConfig] to use this new [ServerCertVerifier][ServerCertVerifier]. 
+After that, we can configure our [ClientConfig][ClientConfig] to use this new [ServerCertVerifier][ServerCertVerifier] implementation. 
 
 ```rust
 pub fn insecure() -> ClientConfig {
@@ -55,15 +55,15 @@ Finally, if you plug this [ClientConfig][ClientConfig] into the [EndpointBuilder
 
 ## Using Certificates
 
-In this section we look at certifying an endpoint with a real certificate. 
-This can be done with either a real certificate or a self-identified certificate.
+In this section we look at certifying an endpoint with a certificate. 
+This can be done with either a non-self-signed or a self-signed certificate.
 
-### Self Signed
+### Self Signed Certificates
 
-A [self-signed][5] certificate entails that the user signing it will be its own CA. 
-These certificates are easy to create and cost no money. 
-However, they do not offer all the security features that certificates from trusted CA's do have. 
-Some ways to create a self-signed certificate is by using [rcgen][4] or openssl. 
+Relying on [self-signed][5] certificates means that clients allow servers to sign their own certificates. 
+This is simpler because no third party has to be involved in signing the server's certificate.
+However, they do not offer all the security features that certificates from trusted CAs do have. 
+Self-signed certificates, among other options, can be created using the [rcgen][4] crate or the openssl binary.
 In this example [rcgen][4] is used.   
 
 Let's look at an example:
@@ -87,7 +87,7 @@ pub fn generate_self_signed_cert(cert_path: &str, key_path: &str) -> anyhow::Res
 
 *Note that [generate_simple_self_signed][generate_simple_self_signed] returns a [Certificate][2] that can be serialized to both `.der` and `.pem` formats.*
 
-### Official Certificates
+### Non-self-signed Certificates
 
 [Let's Encrypt][6] is a well-known Certificate Authority ([CA][1]) (certificate issuer) and distributes certificates for free.
 For this section lets-encrypt is used however any CA could be used interchangeably. 
@@ -100,7 +100,7 @@ Normally a certificate is generated to secure a web server, however, because we 
 the configuration process will be slightly different than normal.
 If you do want to use an existing web server to generate certificates, please follow the instructions on certbot's website.
 
-Select on the certbot website that you do not have a web server, we assume you dont, and follow the given installation instructions.
+Select on the certbot website that you do not have a web server (we assume you don't) and follow the given installation instructions.
 Certbot must answer a cryptographic challenge of the Let's Encrypt API to prove that you control the domain. 
 It uses ports 80 (HTTP) or 443 (HTTPS) to achieve this. Open the appropriate port in your firewall and router.
 
@@ -123,7 +123,7 @@ pub fn read_cert_from_file() -> anyhow::Result<(quinn::Certificate, quinn::Priva
 
 ### Configuring Certificates
 
-Now you generated, or maybe you already had, the certificate, they need to be configured into the client and server. 
+Now that you have a valid certificate, the client and server need to be configured to use it.
 After configuring plug the configuration into the `Endpoint`.
 
 **Configure Server**
@@ -133,7 +133,7 @@ let mut builder = ServerConfigBuilder::default();
 builder.certificate(CertificateChain::from_certs(vec![certificate]), key)?;
 ```
 
-This is the only thing you need to do for your sever to be secured. 
+This is the only thing you need to do for your server to be secured. 
 
 **Configure Client**
 
@@ -146,7 +146,7 @@ This is the only thing you need to do for your client trust a server certificate
 
 <br><hr>
 
-[Nextup](set-up-connection.md), lets have a look at how to setup a connection. 
+[Next](set-up-connection.md), let's have a look at how to setup a connection. 
 
 [1]: https://en.wikipedia.org/wiki/Certificate_authority
 [2]: https://en.wikipedia.org/wiki/Public_key_certificate

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -7,7 +7,7 @@ As QUIC uses TLS 1.3 for authentication of connections, the server needs  to pro
 ## Insecure Connection
 
 For our example use case, the easiest way to allow the client to trust our server is to disable certificate verification (don't do this in production!). 
-When the `dangerous_configuration` feature flag of [rustls][3] is enabled, a client can be configured to trust any server.
+When the [rustls][3] `dangerous_configuration` feature flag is enabled, a client can be configured to trust any server.
 
 Start with adding a [rustls][3] dependency with the `dangerous_configuration` feature flag to your `Cargo.toml` file.
 

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -60,7 +60,7 @@ This can be done with either a real certificate or a self-identified certificate
 
 ### Self Signed
 
-A [self-signed][5] certificate entails that you sign a certificate with your own CA. 
+A [self-signed][5] certificate entails that the user signing it will be its own CA. 
 These certificates are easy to create and cost no money. 
 However, they do not offer all the security features that certificates from trusted CA's do have. 
 Some ways to create a self-signed certificate is by using [rcgen][4] or openssl. 

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -1,3 +1,7 @@
+In the following chapters we will go through the protocol using examples. 
+The chapters are in order, first we look at configuring a certificate which is **required**, 
+then at setting up a connection and finally at sending data about this connection. 
+
 # Certificates
 
 In this chapter, we discuss the configuration of the certificates that is **required** for a working Quinn connection. 

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -87,8 +87,7 @@ pub fn generate_self_signed_cert(cert_path: &str, key_path: &str) -> anyhow::Res
 
 ### Non-self-signed Certificates
 
-[Let's Encrypt][6] is a well-known Certificate Authority ([CA][1]) (certificate issuer) and distributes certificates for free.
-For this section lets-encrypt is used however any CA could be used interchangeably. 
+For this example, we use [Let's Encrypt][6], a well-known Certificate Authority ([CA][1]) (certificate issuer) which  distributes certificates for free.
 
 **Generate Certificate**
 

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -60,9 +60,8 @@ The certificate can be signed with its own key, or with a certificate authority'
 ### Self Signed Certificates
 
 Relying on [self-signed][5] certificates means that clients allow servers to sign their own certificates. 
-This is simpler because no third party has to be involved in signing the server's certificate.
-However, they do not offer all the security features that certificates from trusted CAs do have. 
-Self-signed certificates, among other options, can be created using the [rcgen][4] crate or the openssl binary.
+This is simpler because no third party is involved in signing the server's certificate.
+However, self-signed certificates do not protect users from person-in-the-middle attacks, because an interceptor can trivially replace the certificate with one that it has signed. Self-signed certificates, among other options, can be created using the [rcgen][4] crate or the openssl binary.
 This example uses [rcgen][4] to generate a certificate.
 
 Let's look at an example:

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -62,7 +62,7 @@ This can be done with either a real certificate or a self-identified certificate
 
 A [self-signed][5] certificate entails that you sign a certificate with your own CA. 
 These certificates are easy to create and cost no money. 
-However, they do not offer all the security features that certificates from a trusted CA do have. 
+However, they do not offer all the security features that certificates from trusted CA's do have. 
 Some ways to create a self-signed certificate is by using [rcgen][4] or openssl. 
 In this example [rcgen][4] is used.   
 
@@ -94,20 +94,17 @@ For this section lets-encrypt is used however any CA could be used interchangeab
 
 **Generate Certificate**
 
-Let's encode [Certbot][7] to generate certificates. 
+Let's encrypt uses [Certbot][7] to generate certificates. 
 The certbot websites give clear instructions on how to use the tool.  
-Normally a certificate is generated to secure a web server and certbot will use it to secure the server. 
-However, since we generate a certificate for a protocol, the configuration process will be slightly different than normal.
+Normally a certificate is generated to secure a web server, however, because we generate a certificate for a protocol,
+the configuration process will be slightly different than normal.
 If you do want to use an existing web server to generate certificates, please follow the instructions on certbot's website.
 
-For this example it is expected that no web server is installed.
- Select on the certbot website that you do not have a web server and follow the given installation instructions. 
-
-Note that servers must be accessible on a public DNS name in order to get a Let's Encrypt certificate.
-Certbot must answer a cryptographic challenge of the Let's Encrypt API to prove that we control our domain. 
+Select on the certbot website that you do not have a web server, we assume you dont, and follow the given installation instructions.
+Certbot must answer a cryptographic challenge of the Let's Encrypt API to prove that you control the domain. 
 It uses ports 80 (HTTP) or 443 (HTTPS) to achieve this. Open the appropriate port in your firewall and router.
 
-If certbot is installed, run `certbot certonly --standalone`, this command will start a web server in the background.
+If certbot is installed, run `certbot certonly --standalone`, this command will start a web server in the background and start the challenge.
 Certbot asks for the required data and writes the certificate to `cert.pem` and the private key to `privkey.pem`.  
 These files can then be referenced in code.  
  

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -1,8 +1,8 @@
 # Certificates
 
-In this chapter, we discuss the configuration of the certificates that is **required** for a working Quinn connection. 
+In this chapter, we discuss the configuration of the certificates that are **required** for a working Quinn connection. 
 
-As QUIC uses TLS 1.3 for authentication of connections, the server needs  to provide the client with a certificate confirming its identity, and the client must be configured to trust the certificates it receives from the server. 
+As QUIC uses TLS 1.3 for authentication of connections, the server needs to provide the client with a certificate confirming its identity, and the client must be configured to trust the certificates it receives from the server. 
 
 ## Insecure Connection
 
@@ -37,12 +37,12 @@ After that, modify the [ClientConfig][ClientConfig] to use this [ServerCertVerif
 pub fn insecure() -> ClientConfig {
     let mut cfg = quinn::ClientConfigBuilder::default().build();
 
-    // Get a mutable reference to the 'crypto' config in the 'client config'..
+    // Get a mutable reference to the 'crypto' config in the 'client config'.
     let tls_cfg: &mut rustls::ClientConfig =
         std::sync::Arc::get_mut(&mut cfg.crypto).unwrap();
 
     // Change the certification verifier.
-    // This is only available when compiled with 'dangerous_configuration' feature.
+    // This is only available when compiled with the 'dangerous_configuration' feature.
     tls_cfg
         .dangerous()
         .set_certificate_verifier(Arc::new(SkipCertificationVerification));
@@ -54,12 +54,12 @@ Finally, if you plug this [ClientConfig][ClientConfig] into the [EndpointBuilder
 
 ## Using Certificates
 
-In this section we look at certifying an endpoint with a certificate. 
-The certificate can be signed with its own key, or with a certificate authority's key.
+In this section, we look at certifying an endpoint with a certificate. 
+The certificate can be signed with its key, or with a certificate authority's key.
 
 ### Self Signed Certificates
 
-Relying on [self-signed][5] certificates means that clients allow servers to sign their own certificates. 
+Relying on [self-signed][5] certificates means that clients allow servers to sign their certificates. 
 This is simpler because no third party is involved in signing the server's certificate.
 However, self-signed certificates do not protect users from person-in-the-middle attacks, because an interceptor can trivially replace the certificate with one that it has signed. Self-signed certificates, among other options, can be created using the [rcgen][4] crate or the openssl binary.
 This example uses [rcgen][4] to generate a certificate.
@@ -87,7 +87,7 @@ pub fn generate_self_signed_cert(cert_path: &str, key_path: &str) -> anyhow::Res
 
 ### Non-self-signed Certificates
 
-For this example, we use [Let's Encrypt][6], a well-known Certificate Authority ([CA][1]) (certificate issuer) which  distributes certificates for free.
+For this example, we use [Let's Encrypt][6], a well-known Certificate Authority ([CA][1]) (certificate issuer) which distributes certificates for free.
 
 **Generate Certificate**
 
@@ -136,11 +136,11 @@ let mut builder = ClientConfigBuilder::default();
 builder.add_certificate_authority(certificate)?;    
 ```
 
-This is the only thing you need to do for your client trust a server certificate. 
+This is the only thing you need to do for your client to trust a server certificate. 
 
 <br><hr>
 
-[Next](set-up-connection.md), let's have a look at how to setup a connection. 
+[Next](set-up-connection.md), let's have a look at how to set up a connection. 
 
 [1]: https://en.wikipedia.org/wiki/Certificate_authority
 [2]: https://en.wikipedia.org/wiki/Public_key_certificate

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -63,7 +63,7 @@ Relying on [self-signed][5] certificates means that clients allow servers to sig
 This is simpler because no third party has to be involved in signing the server's certificate.
 However, they do not offer all the security features that certificates from trusted CAs do have. 
 Self-signed certificates, among other options, can be created using the [rcgen][4] crate or the openssl binary.
-In this example [rcgen][4] is used.   
+This example uses [rcgen][4] to generate a certificate.
 
 Let's look at an example:
 

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -16,7 +16,7 @@ quinn = "*"
 rustls = { version = "*", features = ["dangerous_configuration", "quic"] }
 ``` 
 
-Then, you can skip the certificate validation on the client by implementing [ServerCertVerifier][ServerCertVerifier] and let it assert verification for any server. 
+Then, allow the client to skip the certificate validation by implementing [ServerCertVerifier][ServerCertVerifier] and letting it assert verification for any server. 
 
 ```rust
 // Implementation of `ServerCertVerifier` that verifies everything as trustworthy.

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -1,0 +1,188 @@
+# Certificates
+
+In this chapter, we discuss the configuration of the certificates that is **required** for a working Quinn connection. 
+
+A [Certificate Authority (CA)][1] is an entity that issues digital [certificates][2]. 
+These digital certificates certify ownership of a public key associated with, for example, a host, server, client, or document.
+Digital certificates ensure that users can be confident that the content actually comes from a reliable, secure source.
+
+**By default**, Quinn clients validate the cryptographic identity of the servers they connect to. 
+This prevents an attacker from intercepting messages.
+While it is great that quinn offers security by default it requires additional configuration.
+This additional configuration will be the subject of this chapter. 
+
+## Insecure Connection
+
+A certificate is not practical for cases such as: peer-to-peer, trust-on-first-use,
+deliberately insecure applications, or when the servers are not identified by the domain name. 
+You can change certificate validation logic when the `dangerous_configuration` feature flag of [rustls][3] is enabled.
+Then the only thing that needs to be done is to configure the client to trust any server.
+
+Start with adding a [rustls][3] dependency with the `dangerous_configuration` feature flag to your `Cargo.toml` file.
+
+```toml
+quinn = "*"
+rustls = { version = "*", features = ["dangerous_configuration", "quic"] }
+``` 
+
+Then, you can skip the certificate validation on the client by implementing [ServerCertVerifier][ServerCertVerifier] and let it assert true for any server. 
+
+```rust
+// Implementation of `ServerCertVerifier` that verifies everything as trustworthy.
+struct SkipCertificationVerification;
+
+impl rustls::ServerCertVerifier for SkipCertificationVerification {
+    fn verify_server_cert(
+        &self,
+        _roots: &rustls::RootCertStore,
+        _presented_certs: &[rustls::Certificate],
+        _dns_name: webpki::DNSNameRef,
+        _ocsp_response: &[u8],
+    ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
+        Ok(ServerCertVerified::assertion())
+    }
+}
+```
+
+After that, we can configure our [ClientConfig][ClientConfig] to use this new [ServerCertVerifier][ServerCertVerifier]. 
+
+```rust
+pub fn insecure() -> ClientConfig {
+    let mut cfg = quinn::ClientConfigBuilder::default().build();
+
+    // Get a mutable reference to the 'crypto' config in the 'client config'..
+    let tls_cfg: &mut rustls::ClientConfig =
+        std::sync::Arc::get_mut(&mut cfg.crypto).unwrap();
+
+    // Change the certification verifier.
+    // This is only available when compiled with 'dangerous_configuration' feature.
+    tls_cfg
+        .dangerous()
+        .set_certificate_verifier(Arc::new(SkipCertificationVerification));
+    cfg
+}
+```
+ 
+Finally, if you plug this [ClientConfig][ClientConfig] into the [EndpointBuilder::default_client_config()][default_client_config] your client endpoint should verify all connections as trustworthy.
+
+## Using Certificates
+
+In this section we look at certifying an endpoint with a real certificate. 
+This can be done with either a real certificate or a self-identified certificate.
+
+Let's define two useful functions that can dissect byte certificates and return quinn types.
+
+```rust
+pub fn parse_der(cert: Vec<u8>, private_key: Vec<u8>) -> anyhow::Result<(quinn::Certificate, quinn::PrivateKey)> {
+    let cert = quinn::Certificate::from_der(&cert)?;
+    let key = quinn::PrivateKey::from_der(&private_key)?;
+    Ok((cert, key))
+}
+
+pub fn parse_pem(cert: Vec<u8>, private_key: Vec<u8>) -> anyhow::Result<(quinn::Certificate, quinn::PrivateKey)> {
+    // Parse to certificate chain whereafter taking the first certifcater in this chain.
+    let cert = quinn::CertificateChain::from_pem(&cert)?.iter().next().unwrap().clone();
+    let key = quinn::PrivateKey::from_pem(&private_key)?;
+
+    Ok((quinn::Certificate::from(cert), key))
+}
+```
+
+There are two common certificate formats namely: `.pem` and `.der`.
+The `.der` certificates are byte-coded, while `.pem` is text-coded.
+You can translate one to the other by using tooling such as openssl or even within code self. 
+The code translation is shown above. 
+
+### Self Signed
+
+A [self-signed][5] certificate entails that you sign a certificate with your own CA. 
+These certificates are easy to create and cost no money. 
+However, they do not offer all the security features that certificates from a CA do have. 
+Some ways to create a self-signed certificate is by using [rcgen][4] or openssl. 
+In this example [rcgen][4] is used.   
+
+Let's look at an example:
+
+```rust
+pub fn generate_self_signed_cert(cert_path: &str, key_path: &str) -> anyhow::Result<(quinn::Certificate, quinn::PrivateKey)> {
+    // Generate dummy certificate.
+    let certificate = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+    let serialized_key = certificate.serialize_private_key_der();
+    let serialized_certificate = certificate.serialize_der().unwrap();
+
+    // Write to files.
+    fs::write(&cert_path, &serialized_certificate).context("failed to write certificate")?;
+    fs::write(&key_path, &serialized_key).context("failed to write private key")?;
+
+    parse_der(serialized_certificate, serialized_key)
+}
+```
+
+*Note that [generate_simple_self_signed][generate_simple_self_signed] returns a [Certificate][2] that can be serialized to both `.der` and `.pem` formats.*
+
+### Official Certificates
+
+[Let's Encrypt][6] is a CA and distributes certificates for free. 
+Its a very well-known CA used by many applications around the world.
+We can cover a detailed lets-encrypt tutorial but there is plenty of good documentation out there.  
+
+**Generate Certificate**
+
+Let's Encrypt works with [Certbot][7], certbort generates the certificate for you.
+Often a certificate is generated to secure a web server. 
+Because we generate a certificate for a protocol, the configuration process will be slightly different than normal. 
+We assume that you do not have a web server. 
+Select on the certbot website that you do not have a web server and follow the given installation instructions.
+
+If certbot is installed, execute `certbot certonly --standalone`, this command will fire up a web server in the background.
+Certbot asks for your data, after entering it two `.pem` files are generated, namely `cert.pem` and `privkey.pem`. 
+Next we can reference those files in the code.  
+ 
+```rust
+// Read from certificate and key from directory. 
+let (cert, key) = fs::read(&"./cert.pem").and_then(|x| Ok((x, fs::read(&"./privkey.pem")?)))?;
+// Parse bytes to type.
+parse_pem(cert, key)
+```
+
+### Configuring Certificates
+
+Now you generated, or maybe you already had, the certificate, they need to be configured into the client and server. 
+After configuring plug the configuration into the `Endpoint`.
+
+
+**Configure Server**
+
+```rust
+let mut builder = ServerConfigBuilder::default();
+builder.certificate(CertificateChain::from_certs(vec![certificate]), key)?;
+```
+
+This is the only thing you need to do for your sever to be secured. 
+
+**Configure Client**
+
+```rust
+let mut builder = ClientConfigBuilder::default();
+builder.add_certificate_authority(certificate)?;    
+```
+
+This is the only thing you need to do for your client trust a server certificate. 
+
+<br><hr>
+
+[Nextup](set-up-connection.md), lets look at how to setup a connection. 
+
+[1]: https://en.wikipedia.org/wiki/Certificate_authority
+[2]: https://en.wikipedia.org/wiki/Public_key_certificate
+[3]: https://github.com/ctz/rustls
+[4]: https://github.com/est31/rcgen
+[5]: https://en.wikipedia.org/wiki/Self-signed_certificate#:~:text=In%20cryptography%20and%20computer%20security,a%20CA%20aim%20to%20provide.
+[6]: https://letsencrypt.org/getting-started/
+[7]: https://certbot.eff.org/instructions
+
+[ClientConfig]: https://docs.rs/quinn/latest/quinn/generic/struct.ClientConfig.html
+[ServerCertVerifier]: https://docs.rs/rustls/latest/rustls/trait.ServerCertVerifier.html
+[default_client_config]: https://docs.rs/quinn/latest/quinn/generic/struct.EndpointBuilder.html#method.default_client_config
+[generate_simple_self_signed]: https://docs.rs/rcgen/latest/rcgen/fn.generate_simple_self_signed.html
+[Certificate]: https://docs.rs/rcgen/latest/rcgen/struct.Certificate.html

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -91,18 +91,15 @@ For this example, we use [Let's Encrypt][6], a well-known Certificate Authority 
 
 **Generate Certificate**
 
-Let's encrypt uses [Certbot][7] to generate certificates. 
-The certbot websites give clear instructions on how to use the tool.  
-Normally a certificate is generated to secure a web server, however, because we generate a certificate for a protocol,
-the configuration process will be slightly different than normal.
-If you do want to use an existing web server to generate certificates, please follow the instructions on certbot's website.
+[certbot][7] can be used with Let's Encrypt to generate certificates; its website comes with clear instructions.
+Because we're generating a certificate for an internal test server, the process used will be slightly different compared to what you would do when generating certificates for an existing (public) website.
 
-Select on the certbot website that you do not have a web server (we assume you don't) and follow the given installation instructions.
-Certbot must answer a cryptographic challenge of the Let's Encrypt API to prove that you control the domain. 
-It uses ports 80 (HTTP) or 443 (HTTPS) to achieve this. Open the appropriate port in your firewall and router.
+On the certbot website, select that you do not have a public web server and follow the given installation instructions.
+certbot must answer a cryptographic challenge of the Let's Encrypt API to prove that you control the domain. 
+It needs to listen on port 80 (HTTP) or 443 (HTTPS) to achieve this. Open the appropriate port in your firewall and router.
 
 If certbot is installed, run `certbot certonly --standalone`, this command will start a web server in the background and start the challenge.
-Certbot asks for the required data and writes the certificate to `cert.pem` and the private key to `privkey.pem`.  
+certbot asks for the required data and writes the certificate to `cert.pem` and the private key to `privkey.pem`.  
 These files can then be referenced in code.  
  
 ```rust

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -55,7 +55,7 @@ Finally, if you plug this [ClientConfig][ClientConfig] into the [EndpointBuilder
 ## Using Certificates
 
 In this section we look at certifying an endpoint with a certificate. 
-This can be done with either a non-self-signed or a self-signed certificate.
+The certificate can be signed with its own key, or with a certificate authority's key.
 
 ### Self Signed Certificates
 

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -31,7 +31,7 @@ impl rustls::ServerCertVerifier for SkipCertificationVerification {
 }
 ```
 
-After that, we can configure our [ClientConfig][ClientConfig] to use this new [ServerCertVerifier][ServerCertVerifier] implementation. 
+After that, modify the [ClientConfig][ClientConfig] to use this [ServerCertVerifier][ServerCertVerifier] implementation. 
 
 ```rust
 pub fn insecure() -> ClientConfig {

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -9,7 +9,7 @@ As QUIC uses TLS 1.3 for authentication of connections, the server needs  to pro
 For our example use case, the easiest way to allow the client to trust our server is to disable certificate verification (don't do this in production!). 
 When the [rustls][3] `dangerous_configuration` feature flag is enabled, a client can be configured to trust any server.
 
-Start with adding a [rustls][3] dependency with the `dangerous_configuration` feature flag to your `Cargo.toml` file.
+Start by adding a [rustls][3] dependency with the `dangerous_configuration` feature flag to your `Cargo.toml` file.
 
 ```toml
 quinn = "*"


### PR DESCRIPTION
This PR is part of a series of PR's regarding the book creation as described in #865. Each page of this chapter will have its own PR for reducing PR size.

- Network Introduction (#917)
- QUINN Introduction (#868)
    **- Certificate Configuration (#920)**
    - Connection Setup (#921)
    - Data Transfer (#922)

## Live Version

A live version of this page can be found [here](https://timonpost.github.io/quinn/). This book shows all the work that I have up-to-now. The pages that are visible but don't have a PR yet should are welcome to have general feedback.

## Chapter Motivation

This chapter will go through the protocol by examples. The chapters are in the required order, first, we look at configuring a certificate which is **required**, then at setting up a connection, and finally at sending data about this connection. In the future, more pages can be added.

After reading this chapter the reader should be able to **send data** over a secured with a real or self-signed **certificate**, or insecure, **connection**.

The target audience is people who are new to the library and want to get started quickly by some examples and a short explanation. It is not meant to describe the entire API. 

## Page Motivation

The page introduces the reader to certificate generation and configuration. After reading the user will understand the process of getting: self-signed certificates, signed certificates with lets encrypt, and insecure connections, to work.

- Letsencrypt is used because it is free and very common and requested by @Ralith .
- rcgen as requested by @Ralith 

## Remarks

- Some links to other chapters don't work yet, but will be working as soon other PR's are merged. 

