### PR TITLE
(2) Quinn Introduction Chapter, Connection Setup Page

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,4 +1,7 @@
 # Summary
 
-- [Quinn introduction](quinn.md)
+- [QUINN Introduction](quinn.md)
+    - [Overview](quinn/introduction.md)
+    - [Certificate Configuration](quinn/certificate.md)
+    - [Connection Setup](quinn/set-up-connection.md)
 - [The QUIC protocol](quic.md)

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,7 +1,6 @@
 # Summary
 
 - [QUINN Introduction](quinn.md)
-    - [Overview](quinn/introduction.md)
     - [Certificate Configuration](quinn/certificate.md)
     - [Connection Setup](quinn/set-up-connection.md)
 - [The QUIC protocol](quic.md)

--- a/docs/book/src/quinn/set-up-connection.md
+++ b/docs/book/src/quinn/set-up-connection.md
@@ -24,7 +24,6 @@ fn server_addr() -> SocketAddr {
 ```   
 
 On both the client and the server, the [EndpointBuilder][EndpointBuilder] should be used to configure an endpoint. 
-The [bind(address)][bind] method initializes a UDP socket on the specified address.
 It is also possible to provide Quinn with an initialized socket via [with_socket()][with_socket]. 
 
 **Server**

--- a/docs/book/src/quinn/set-up-connection.md
+++ b/docs/book/src/quinn/set-up-connection.md
@@ -23,8 +23,7 @@ fn server_addr() -> SocketAddr {
 }
 ```   
 
-On both the client and the server, the [EndpointBuilder][EndpointBuilder] should be used to configure an endpoint. 
-It is also possible to provide Quinn with an initialized socket via [with_socket()][with_socket]. 
+The [EndpointBuilder][EndpointBuilder] should be used to configure an endpoint. It is also possible to provide Quinn with an initialized socket via [with_socket()][with_socket]. 
 
 **Server**
 

--- a/docs/book/src/quinn/set-up-connection.md
+++ b/docs/book/src/quinn/set-up-connection.md
@@ -77,7 +77,7 @@ async fn client() -> anyhow::Result<()> {
 ```
 <br><hr>
 
-[Nextup](set-up-connection.md), lets have a look at sending data over this connection.  
+[Next up](set-up-connection.md), let's have a look at sending data over this connection.  
 
 
 [Endpoint]: https://docs.rs/quinn/latest/quinn/generic/struct.Endpoint.html

--- a/docs/book/src/quinn/set-up-connection.md
+++ b/docs/book/src/quinn/set-up-connection.md
@@ -56,7 +56,7 @@ async fn server() -> anyhow::Result<()> {
 **Client**
 
 The client needs to connect to the server using the [connect(server_name)][connect] method.  
-The argument 'server name' is the DNS name (matching the certificate configured in the server).
+The `SERVER_NAME` argument is the DNS name, matching the certificate configured in the server.
 
 ```rust
 async fn client() -> anyhow::Result<()> {

--- a/docs/book/src/quinn/set-up-connection.md
+++ b/docs/book/src/quinn/set-up-connection.md
@@ -66,9 +66,7 @@ async fn client() -> anyhow::Result<()> {
     let (endpoint, _) = endpoint_builder.bind(&client_addr())?;
 
     // Connect to the server passing in the server name which is supposed to be in the server certificate.
-    let connection: NewConnection = endpoint
-        .connect(&server_addr(), SERVER_NAME)?
-        .await?;
+    let connection = endpoint.connect(&server_addr(), SERVER_NAME)?.await?;
 
     // Start transferring, receiving data, see data transfer page.
 

--- a/docs/book/src/quinn/set-up-connection.md
+++ b/docs/book/src/quinn/set-up-connection.md
@@ -2,7 +2,7 @@
 
 In the [previous chapter](certificate.md) we looked at how to configure a certificate.
 This aspect is omitted in this chapter to prevent duplication. 
-But **remember** that tis is required to get your [Endpoint][Endpoint] up and running. 
+But **remember** that this is required to get your [Endpoint][Endpoint] up and running. 
 This chapter explains how to set up a connection and prepare it for data transfer. 
 
 It all starts with the [Endpoint][Endpoint] struct, this is the entry of the library. 

--- a/docs/book/src/quinn/set-up-connection.md
+++ b/docs/book/src/quinn/set-up-connection.md
@@ -1,0 +1,89 @@
+# Connection Setup
+
+In the [previous chapter](certificate.md) we looked at how to configure a certificate.
+This aspect is omitted in this chapter to prevent duplication. 
+But **remember** that is is required to get your [Endpoint][Endpoint] up and running. 
+This chapter explains how to set up a connection and prepare it for data transfer. 
+
+It all starts with the [Endpoint][Endpoint] struct, this is the entry of the library. 
+
+## Example
+
+Let's start by defining some constants. 
+
+```rust
+static SERVER_NAME: &str = "localhost";
+
+fn client_addr() -> SocketAddr {
+    "127.0.0.1:5000".parse::<SocketAddr>().unwrap()
+}
+
+fn server_addr() -> SocketAddr {
+    "127.0.0.1:5001".parse::<SocketAddr>().unwrap()
+}
+```   
+
+For both the server and the client we use the [EndpointBuilder][EndpointBuilder]. 
+The [EndpointBuilder][EndpointBuilder] has a method [bind(address)][bind] with which you link an address to the endpoint. 
+This method initializes a UDP-socket that is used by quinn.
+If you need more control over the socket creation, it is also possible to initialize a quinn endpoint with an existing UDP socket with [with_socket][with_socket]. 
+
+**Server**
+
+Just like a TCP Listener, you have to listen to incoming connections.
+Before you can listen to connections you need to configure the [EndpointBuilder][EndpointBuilder] as a server. 
+Note that the configuration itself does not perform any listening logic, instead use the `Incomming` type returned by [bind()][bind].  
+
+```rust
+async fn server() -> anyhow::Result<()> {
+    let mut endpoint_builder = Endpoint::builder();
+    // Configure this endpoint as a server by passing in `ServerConfig`.
+    endpoint_builder.listen(ServerConfig::default());
+
+    // Bind this endpoint to a UDP socket on the given server address. 
+    let (endpoint, mut incoming) = endpoint_builder.bind(&server_addr())?;
+
+    // Start iterating over incoming connections.
+    while let Some(conn) = incoming.next().await {
+        let mut connection: NewConnection = conn.await?;
+
+        // Save connection somewhere, start transferring, receiving data, see DataTransfer tutorial.
+    }
+
+    Ok(())
+}
+```
+
+**Client**
+
+Just like a TCP client, you need to connect to a listening endpoint (the server).
+In quinn you can do this with the method [connect()][connect].
+The [connect()][connect] method has an argument 'server name' which has to be the name that is in the configured certificate. 
+
+```rust
+async fn client() -> anyhow::Result<()> {
+    let mut endpoint_builder = Endpoint::builder();
+
+    // Bind this endpoint to a UDP socket on the given client address.
+    let (endpoint, _) = endpoint_builder.bind(&client_addr())?;
+
+    // Connect to the server passing in the server name which is supposed to be in the server certificate.
+    let connection: NewConnection = endpoint
+        .connect(&server_addr(), SERVER_NAME)?
+        .await?;
+
+    // Start transferring, receiving data, see data transfer page.
+
+    Ok(())
+}
+```
+<br><hr>
+
+[Nextup](set-up-connection.md), lets have a look at sending data over this connection.  
+
+
+[Endpoint]: https://docs.rs/quinn/latest/quinn/generic/struct.Endpoint.html
+[EndpointBuilder]: https://docs.rs/quinn/latest/quinn/generic/struct.EndpointBuilder.html
+[bind]: https://docs.rs/quinn/latest/quinn/generic/struct.EndpointBuilder.html#method.bind
+[connect]: https://docs.rs/quinn/latest/quinn/generic/struct.Endpoint.html#method.connect
+[with_socket]: https://docs.rs/quinn/latest/quinn/generic/struct.EndpointBuilder.html#method.with_socket

--- a/docs/book/src/quinn/set-up-connection.md
+++ b/docs/book/src/quinn/set-up-connection.md
@@ -2,7 +2,7 @@
 
 In the [previous chapter](certificate.md) we looked at how to configure a certificate.
 This aspect is omitted in this chapter to prevent duplication. 
-But **remember** that is is required to get your [Endpoint][Endpoint] up and running. 
+But **remember** that tis is required to get your [Endpoint][Endpoint] up and running. 
 This chapter explains how to set up a connection and prepare it for data transfer. 
 
 It all starts with the [Endpoint][Endpoint] struct, this is the entry of the library. 
@@ -23,16 +23,15 @@ fn server_addr() -> SocketAddr {
 }
 ```   
 
-For both the server and the client we use the [EndpointBuilder][EndpointBuilder]. 
-The [EndpointBuilder][EndpointBuilder] has a method [bind(address)][bind] with which you link an address to the endpoint. 
-This method initializes a UDP-socket that is used by quinn.
-If you need more control over the socket creation, it is also possible to initialize a quinn endpoint with an existing UDP socket with [with_socket][with_socket]. 
+On both the client and the server, the [EndpointBuilder][EndpointBuilder] should be used to configure an endpoint. 
+The [bind(address)][bind] method initializes a UDP socket on the specified address.
+It is also possible to provide Quinn with an initialized socket via [with_socket()][with_socket]. 
 
 **Server**
 
-Just like a TCP Listener, you have to listen to incoming connections.
-Before you can listen to connections you need to configure the [EndpointBuilder][EndpointBuilder] as a server. 
-Note that the configuration itself does not perform any listening logic, instead use the `Incomming` type returned by [bind()][bind].  
+First, the server endpoint should be bound to a socket. 
+The [bind()][bind] method, which can be used for this, returns a tuple with the `Endpoint` and `Incomming` types. 
+The `Endpoint` type can be used to start outgoing connections, and the `Incoming` type can be used to listen for incoming connections.
 
 ```rust
 async fn server() -> anyhow::Result<()> {
@@ -56,9 +55,8 @@ async fn server() -> anyhow::Result<()> {
 
 **Client**
 
-Just like a TCP client, you need to connect to a listening endpoint (the server).
-In quinn you can do this with the method [connect()][connect].
-The [connect()][connect] method has an argument 'server name' which has to be the name that is in the configured certificate. 
+The client needs to connect to the server using the [connect(server_name)][connect] method.  
+The argument 'server name' is the DNS name (matching the certificate configured in the server).
 
 ```rust
 async fn client() -> anyhow::Result<()> {

--- a/docs/book/src/quinn/set-up-connection.md
+++ b/docs/book/src/quinn/set-up-connection.md
@@ -5,7 +5,7 @@ This aspect is omitted in this chapter to prevent duplication.
 But **remember** that this is required to get your [Endpoint][Endpoint] up and running. 
 This chapter explains how to set up a connection and prepare it for data transfer. 
 
-It all starts with the [Endpoint][Endpoint] struct, this is the entry of the library. 
+It all starts with the [Endpoint][Endpoint] struct, this is the entry point of the library. 
 
 ## Example
 
@@ -30,7 +30,7 @@ It is also possible to provide Quinn with an initialized socket via [with_socket
 **Server**
 
 First, the server endpoint should be bound to a socket. 
-The [bind()][bind] method, which can be used for this, returns a tuple with the `Endpoint` and `Incomming` types. 
+The [bind()][bind] method, which can be used for this, returns a tuple containing the `Endpoint` and `Incoming` types. 
 The `Endpoint` type can be used to start outgoing connections, and the `Incoming` type can be used to listen for incoming connections.
 
 ```rust


### PR DESCRIPTION
This PR is part of a series of PR's regarding the book creation as described in #865. Each page of this chapter will have its own PR for reducing PR size.

- Network Introduction (#917)
- QUINN Introduction (#868)
    - Certificate Configuration (#920)
    **- Connection Setup (#921)**
    - Data Transfer (#922)

## Live Version

A live version of this page can be found [here](https://timonpost.github.io/quinn/). This book shows all the work that I have up-to-now. The pages that are visible but don't have a PR yet should are welcome to have general feedback.

## Chapter Motivation

This chapter will go through the protocol by examples. The chapters are in the required order, first, we look at configuring a certificate which is **required**, then at setting up a connection, and finally at sending data about this connection. In the future, more pages can be added.

After reading this chapter the reader should be able to **send data** over a secured with a real or self-signed **certificate**, or insecure, **connection**.

The target audience is people who are new to the library and want to get started quickly by some examples and a short explanation. It is not meant to describe the entire API. 

## Page Motivation

The page introduces the reader to set up an endpoint and to acquire access to the `Connection` and `NewConnection` types. The process of certificates (#920) and data transfer (#922) is omitted on this page to prevent duplication.  

## Remarks

- Some links to other chapters don't work yet, but will be working as soon other PR's are merged. 
