### PR TITLE
Expose cid genearator customization API in endpoint builder

### DIFF
--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -105,7 +105,9 @@ where
     }
 
     /// Use a customized cid generator factory in the endpoint
-    pub fn connection_id_generator<F: Fn() -> Box<dyn ConnectionIdGenerator> + Send + Sync + 'static>(
+    pub fn connection_id_generator<
+        F: Fn() -> Box<dyn ConnectionIdGenerator> + Send + Sync + 'static,
+    >(
         &mut self,
         factory: F,
     ) -> &mut Self {

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -105,7 +105,7 @@ where
     }
 
     /// Use a customized cid generator factory in the endpoint
-    pub fn use_customized_cid<F: Fn() -> Box<dyn ConnectionIdGenerator> + Send + Sync + 'static>(
+    pub fn connection_id_generator<F: Fn() -> Box<dyn ConnectionIdGenerator> + Send + Sync + 'static>(
         &mut self,
         factory: F,
     ) -> &mut Self {

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -1,6 +1,9 @@
 use std::{io, net::SocketAddr, sync::Arc};
 
-use proto::{generic::{ClientConfig, EndpointConfig, ServerConfig}, ConnectionIdGenerator};
+use proto::{
+    generic::{ClientConfig, EndpointConfig, ServerConfig},
+    ConnectionIdGenerator,
+};
 use thiserror::Error;
 use tracing::error;
 

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -1,6 +1,6 @@
 use std::{io, net::SocketAddr, sync::Arc};
 
-use proto::generic::{ClientConfig, EndpointConfig, ServerConfig};
+use proto::{generic::{ClientConfig, EndpointConfig, ServerConfig}, ConnectionIdGenerator};
 use thiserror::Error;
 use tracing::error;
 
@@ -98,6 +98,15 @@ where
     /// [`Endpoint::connect_with()`]: crate::generic::Endpoint::connect_with
     pub fn default_client_config(&mut self, config: ClientConfig<S>) -> &mut Self {
         self.default_client_config = config;
+        self
+    }
+
+    /// Use a customized cid generator factory in the endpoint
+    pub fn use_customized_cid<F: Fn() -> Box<dyn ConnectionIdGenerator> + Send + Sync + 'static>(
+        &mut self,
+        factory: F,
+    ) -> &mut Self {
+        self.config.cid_generator(factory);
         self
     }
 }


### PR DESCRIPTION
A CID generator interface was implemented in transport layer https://github.com/quinn-rs/quinn/pull/851 but there is still no way to actually enable this feature when HTTP/3 endpoint is built. This PR provides an API in `EndpointBuilder` to allow customization on CID generator.