### PR TITLE
Sanity-check remote addresses before trying to connect

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -347,6 +347,9 @@ where
         if self.is_full() {
             return Err(ConnectError::TooManyConnections);
         }
+        if remote.port() == 0 {
+            return Err(ConnectError::InvalidRemoteAddress(remote));
+        }
         let (remote_id, _) = RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid();
         trace!(initial_dcid = %remote_id);
         let (ch, conn) = self.add_connection(
@@ -822,6 +825,11 @@ pub enum ConnectError {
     /// The transport configuration was invalid
     #[error("transport configuration error: {0}")]
     Config(#[source] ConfigError),
+    /// The remote [`SocketAddr`] supplied was malformed
+    ///
+    /// Examples include attempting to connect to port 0, or using an inappropriate address family.
+    #[error("invalid remote address: {0}")]
+    InvalidRemoteAddress(SocketAddr),
 }
 
 #[derive(Default, Debug)]

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -80,6 +80,9 @@ where
         if endpoint.driver_lost {
             return Err(ConnectError::EndpointStopping);
         }
+        if addr.is_ipv6() && !endpoint.ipv6 {
+            return Err(ConnectError::InvalidRemoteAddress(*addr));
+        }
         let addr = if endpoint.ipv6 {
             SocketAddr::V6(ensure_ipv6(*addr))
         } else {


### PR DESCRIPTION
Catches some common user errors that would otherwise manifest as difficult-to-diagnose I/O errors.