### PR TITLE
Allow to lookup the initial local IP address

### DIFF
--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -28,6 +28,7 @@ fn version_negotiate_server() {
         now,
         client_addr,
         None,
+        None,
         // Long-header packet with reserved version number
         hex!("80 0a1a2a3a 04 00000000 04 00000000 00")[..].into(),
     );
@@ -63,6 +64,7 @@ fn version_negotiate_client() {
     let opt_event = client.handle(
         now,
         server_addr,
+        None,
         None,
         // Version negotiation packet for reserved version
         hex!(

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -226,7 +226,7 @@ impl TestEndpoint {
             let (_, ecn, packet) = self.inbound.pop_front().unwrap();
             if let Some((ch, event)) =
                 self.endpoint
-                    .handle(now, remote, ecn, packet.as_slice().into())
+                    .handle(now, remote, None, ecn, packet.as_slice().into())
             {
                 match event {
                     DatagramEvent::NewConnection(conn) => {

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -3,7 +3,7 @@ use std::{
     fmt,
     future::Future,
     mem,
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll, Waker},
@@ -126,6 +126,27 @@ where
                     .clone()
                     .expect("spurious handshake data ready notification")
             })
+    }
+
+    /// The local IP address which was used when the peer established
+    /// the connection
+    ///
+    /// This can be different from the address the endpoint is bound to, in case
+    /// the endpoint is bound to a wildcard address like `0.0.0.0` or `::`.
+    ///
+    /// This will return `None` for clients.
+    ///
+    /// Retrieving the local IP address is currently supported on the following
+    /// platforms:
+    /// - Linux
+    ///
+    /// On all non-supported platforms the local IP address will not be available,
+    /// and the method will return `None`.
+    pub fn local_ip(&self) -> Option<IpAddr> {
+        let conn = self.conn.as_ref().unwrap();
+        let inner = conn.lock().unwrap();
+
+        inner.inner.local_ip()
     }
 }
 
@@ -395,6 +416,24 @@ where
     /// switching to a cellular internet connection.
     pub fn remote_address(&self) -> SocketAddr {
         self.0.lock().unwrap().inner.remote_address()
+    }
+
+    /// The local IP address which was used when the peer established
+    /// the connection
+    ///
+    /// This can be different from the address the endpoint is bound to, in case
+    /// the endpoint is bound to a wildcard address like `0.0.0.0` or `::`.
+    ///
+    /// This will return `None` for clients.
+    ///
+    /// Retrieving the local IP address is currently supported on the following
+    /// platforms:
+    /// - Linux
+    ///
+    /// On all non-supported platforms the local IP address will not be available,
+    /// and the method will return `None`.
+    pub fn local_ip(&self) -> Option<IpAddr> {
+        self.0.lock().unwrap().inner.local_ip()
     }
 
     /// Current best estimate of this connection's latency (round-trip-time)

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -279,7 +279,10 @@ where
                     recvd += msgs;
                     for (meta, buf) in metas.iter().zip(iovs.iter()).take(msgs) {
                         let data = buf[0..meta.len].into();
-                        match self.inner.handle(now, meta.addr, meta.ecn, data) {
+                        match self
+                            .inner
+                            .handle(now, meta.addr, meta.dst_ip, meta.ecn, data)
+                        {
                             Some((handle, DatagramEvent::NewConnection(conn))) => {
                                 let conn = self.connections.insert(handle, conn);
                                 self.incoming.push_back(conn);

--- a/quinn/src/platform/fallback.rs
+++ b/quinn/src/platform/fallback.rs
@@ -38,6 +38,7 @@ impl super::UdpExt for UdpSocket {
             len,
             addr,
             ecn: None,
+            dst_ip: None,
         };
         Ok(1)
     }

--- a/quinn/src/udp.rs
+++ b/quinn/src/udp.rs
@@ -1,7 +1,7 @@
 use std::{
     io,
     io::IoSliceMut,
-    net::{Ipv6Addr, SocketAddr},
+    net::{IpAddr, Ipv6Addr, SocketAddr},
     task::{Context, Poll},
 };
 
@@ -74,6 +74,8 @@ pub struct RecvMeta {
     pub addr: SocketAddr,
     pub len: usize,
     pub ecn: Option<EcnCodepoint>,
+    /// The destination IP address which was encoded in this datagram
+    pub dst_ip: Option<IpAddr>,
 }
 
 impl Default for RecvMeta {
@@ -83,6 +85,7 @@ impl Default for RecvMeta {
             addr: SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 0),
             len: 0,
             ecn: None,
+            dst_ip: None,
         }
     }
 }


### PR DESCRIPTION
When a listener is bound to multiple network interfaces (e.g. `::0`),
it is not obvious which IP the peer used to send a packet. We however
might need this information to send packets back to the peer with the
same source address.

This problem is described in #508.

This change makes the destination IP address which was used to send
the initial packet available in the `Conneting` and `Connection` types.

The information is far available only on Linux due to missing test on
other platforms.