### PR TITLE
Extend bulk benchmark

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -9,9 +9,11 @@ publish = false
 [dependencies]
 anyhow = "1.0.22"
 futures = "0.3.8"
+hdrhistogram = "7.2"
 quinn = { path = "../quinn" }
 rcgen = "0.8"
 rustls = { git = "https://github.com/ctz/rustls", rev = "fee894f7e030" }
+structopt = "0.3"
 tokio = { version = "0.2.13", features = ["rt-core"] }
 tracing = "0.1.10"
 tracing-subscriber = { version = "0.2.5", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}


### PR DESCRIPTION
This change improves the bulk benchmark:
- The total amount of requests the benchmark performs can be configured
- The amount of concurrent requests on a given connection can be
  configured
- The amount of data to transfer per stream can be configured

E.g.

```
bulk --streams 300 --max_streams 100 --stream_size 10
```

will create 300 streams - with a maximum of 100 active streams at a time,
and send 10MB of data on each stream.

The "short" cli flags are taken form h2load where applicable.

The benchmark now also shows metrics which indicate the performance
of individual streams, which allows to judge fairness. Example output:

```
Overall stats:

Sent 3145728000 bytes on 300 streams in 12.11s (247.81 MiB/s)

Stream metrics:

      │  Throughput   │ Duration
──────┼───────────────┼──────────
 AVG  │  149.17 MiB/s │  396.00ms
 P0   │    0.83 MiB/s │   39.00ms
 P10  │   51.19 MiB/s │   40.00ms
 P50  │  129.75 MiB/s │   77.00ms
 P90  │  247.00 MiB/s │  195.00ms
 P100 │  254.75 MiB/s │    12.11s
```