### PR TITLE
Improve fairness on stream transmissions

### DIFF
--- a/quinn-proto/src/connection/streams.rs
+++ b/quinn-proto/src/connection/streams.rs
@@ -44,7 +44,7 @@ pub struct Streams {
     /// permitted to open but which have not yet been opened.
     send_streams: usize,
     /// Streams with outgoing data queued
-    pending: Vec<StreamId>,
+    pending: VecDeque<StreamId>,
 
     events: VecDeque<StreamEvent>,
     /// Streams blocked on connection-level flow control or stream window space
@@ -92,7 +92,7 @@ impl Streams {
             opened: [false, false],
             next_reported_remote: [0, 0],
             send_streams: 0,
-            pending: Vec::new(),
+            pending: VecDeque::new(),
             events: VecDeque::new(),
             connection_blocked: Vec::new(),
             max_data: 0,
@@ -256,7 +256,7 @@ impl Streams {
         self.unacked_data += len as u64;
         trace!(stream = %id, "wrote {} bytes", len);
         if !was_pending {
-            self.pending.push(id);
+            self.pending.push_back(id);
         }
         Ok(len)
     }
@@ -380,7 +380,7 @@ impl Streams {
         let was_pending = stream.is_pending();
         stream.finish()?;
         if !was_pending {
-            self.pending.push(id);
+            self.pending.push_back(id);
         }
         Ok(())
     }
@@ -584,7 +584,12 @@ impl Streams {
                 Some(x) => x,
                 None => break,
             };
-            let id = match self.pending.pop() {
+            // Poppping data from the front of the queue, storing as much data
+            // as possible in a single frame, and enqueing sending further
+            // remaining data at the end of the queue helps with fairness.
+            // Other streams will have a chance to write data before we touch
+            // this stream again.
+            let id = match self.pending.pop_front() {
                 Some(x) => x,
                 None => break,
             };
@@ -607,7 +612,7 @@ impl Streams {
                 stream.fin_pending = false;
             }
             if stream.is_pending() {
-                self.pending.push(id);
+                self.pending.push_back(id);
             }
 
             let meta = frame::StreamMeta { id, offsets, fin };
@@ -667,7 +672,7 @@ impl Streams {
             Some(x) => x,
         };
         if !stream.is_pending() {
-            self.pending.push(frame.id);
+            self.pending.push_back(frame.id);
         }
         stream.fin_pending |= frame.fin;
         stream.pending.retransmit(frame.offsets);
@@ -684,7 +689,7 @@ impl Streams {
                     continue;
                 }
                 if !stream.is_pending() {
-                    self.pending.push(id);
+                    self.pending.push_back(id);
                 }
                 stream.pending.retransmit_all_for_0rtt();
             }


### PR DESCRIPTION
The current version of send multiplexing tries to send as much data from
a single stream as possible before switching over to the next stream.
The only situation where data from another stream than the original one
is sent is if there are no peer flow control credits available anymore,
or if the application didn't feed new data.
If none of this situations occur, other streams will be starved.

This is typically not what people expect, and can lead to high latencies
on streams which are queued behind earlier streams.

This change makes the send behavior "fairer" by enqueuing stream which
just have sent data **after** all other pending streams instead of in
front of them. This is simply achieved by switching to a `VecDeque` and
using the the right insert/remove orders.

Stats (obtained via #946), when running

```
./bulk --streams 300 --max_streams 10 --stream_size 10
```

```
Stream metrics:

AVG : Throughput:  172.38 MiB/s, Duration:  395.00ms
P0  : Throughput:    0.83 MiB/s, Duration:   39.00ms
P10 : Throughput:   49.19 MiB/s, Duration:   40.00ms
P50 : Throughput:  232.50 MiB/s, Duration:   42.00ms
P90 : Throughput:  245.87 MiB/s, Duration:  203.00ms
P100: Throughput:  251.25 MiB/s, Duration:    12.08s
```

```
Stream metrics:

AVG : Throughput:   24.20 MiB/s, Duration:  413.00ms
P0  : Throughput:   21.42 MiB/s, Duration:  279.00ms
P10 : Throughput:   23.25 MiB/s, Duration:  403.00ms
P50 : Throughput:   24.34 MiB/s, Duration:  410.00ms
P90 : Throughput:   24.81 MiB/s, Duration:  430.00ms
P100: Throughput:   35.78 MiB/s, Duration:  466.00ms
```

With this change throughput on streams is a lot more consistent than
before.