### PR TITLE
Make connection stats public

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -43,7 +43,7 @@ mod spaces;
 use spaces::{PacketSpace, Retransmits, SentPacket};
 
 mod stats;
-use stats::ConnectionStats;
+pub use stats::ConnectionStats;
 
 mod streams;
 pub use streams::Streams;
@@ -910,6 +910,11 @@ where
             return Err(WriteError::Blocked);
         }
         self.streams.write(stream, data)
+    }
+
+    /// Returns connection statistics
+    pub fn stats(&self) -> ConnectionStats {
+        self.stats
     }
 
     /// Stop accepting data on the given receive stream

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -34,7 +34,7 @@ mod varint;
 pub use varint::{VarInt, VarIntBoundsExceeded};
 
 mod connection;
-pub use crate::connection::{ConnectionError, Event, SendDatagramError};
+pub use crate::connection::{ConnectionError, ConnectionStats, Event, SendDatagramError};
 pub use crate::connection::{FinishError, ReadError, StreamEvent, UnknownStream, WriteError};
 
 mod config;

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -15,7 +15,7 @@ use futures::{
     channel::{mpsc, oneshot},
     FutureExt, StreamExt,
 };
-use proto::{ConnectionError, ConnectionHandle, Dir, StreamEvent, StreamId};
+use proto::{ConnectionError, ConnectionHandle, ConnectionStats, Dir, StreamEvent, StreamId};
 use thiserror::Error;
 use tokio::time::{delay_until, Delay, Instant as TokioInstant};
 use tracing::info_span;
@@ -439,6 +439,11 @@ where
     /// Current best estimate of this connection's latency (round-trip-time)
     pub fn rtt(&self) -> Duration {
         self.0.lock().unwrap().inner.rtt()
+    }
+
+    /// Returns connection statistics
+    pub fn stats(&self) -> ConnectionStats {
+        self.0.lock().unwrap().inner.stats()
     }
 
     /// Parameters negotiated during the handshake


### PR DESCRIPTION
So far those haven't been consumable by applications.
This makes the struct public, and adds an accessor
for `quinn_proto::Connection` and `quinn::Connection`.