### PR TITLE
GSO platform support

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -379,6 +379,7 @@ where
                     destination,
                     contents: buf,
                     ecn: None,
+                    segment_size: None,
                 });
             }
         }
@@ -559,6 +560,7 @@ where
             } else {
                 None
             },
+            segment_size: None,
         })
     }
 

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -189,6 +189,7 @@ where
                         destination: remote,
                         ecn: None,
                         contents: buf,
+                        segment_size: None,
                     });
                     return None;
                 }
@@ -334,6 +335,7 @@ where
             destination: remote,
             ecn: None,
             contents: buf,
+            segment_size: None,
         });
     }
 
@@ -587,6 +589,7 @@ where
                     destination: remote,
                     ecn: None,
                     contents: buf,
+                    segment_size: None,
                 });
                 return None;
             }
@@ -679,6 +682,7 @@ where
             destination,
             ecn: None,
             contents: buf,
+            segment_size: None,
         })
     }
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -274,6 +274,9 @@ pub struct Transmit {
     pub ecn: Option<EcnCodepoint>,
     /// Contents of the datagram
     pub contents: Vec<u8>,
+    /// The segment size if this transmission contains multiple datagrams.
+    /// This is `None` if the transmit only contains a single datagram
+    pub segment_size: Option<usize>,
 }
 
 //

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -38,6 +38,9 @@ tracing = "0.1.10"
 tokio = { version = "0.2.6", features = ["rt-core", "io-driver", "time"] }
 webpki = { version = "0.21", optional = true }
 
+[target.'cfg(unix)'.dependencies]
+lazy_static = "1"
+
 [dev-dependencies]
 anyhow = "1.0.22"
 crc = "1.8.1"

--- a/quinn/src/platform/fallback.rs
+++ b/quinn/src/platform/fallback.rs
@@ -44,4 +44,9 @@ impl super::UdpExt for UdpSocket {
     }
 }
 
+/// Returns the platforms UDP socket capabilities
+pub fn caps() -> super::UdpCapabilities {
+    super::UdpCapabilities { gso: false }
+}
+
 pub const BATCH_SIZE: usize = 1;

--- a/quinn/src/platform/mod.rs
+++ b/quinn/src/platform/mod.rs
@@ -15,6 +15,12 @@ mod imp;
 #[path = "fallback.rs"]
 mod imp;
 
+#[allow(dead_code)] // TODO: Remove when used
+/// Returns the platforms UDP socket capabilities
+pub fn caps() -> UdpCapabilities {
+    imp::caps()
+}
+
 /// Number of UDP packets to send/receive at a time
 pub const BATCH_SIZE: usize = imp::BATCH_SIZE;
 
@@ -22,4 +28,11 @@ pub trait UdpExt {
     fn init_ext(&self) -> io::Result<()>;
     fn send_ext(&self, transmits: &[Transmit]) -> io::Result<usize>;
     fn recv_ext(&self, bufs: &mut [IoSliceMut<'_>], meta: &mut [RecvMeta]) -> io::Result<usize>;
+}
+
+/// The capabilities a UDP socket suppports on a certain platform
+#[derive(Debug, Clone, Copy)]
+pub struct UdpCapabilities {
+    /// Whether the platform supports Generic Send Offload (GSO)
+    pub gso: bool,
 }


### PR DESCRIPTION
This splits out the platform/socket parts for UDP GSO support
from #953 to reduce the amount of code to review.

This change mainly implements setting the segment size
socket option, and adds a runtime detection mechanism for
GSO support.