### PR TITLE
Allow to use the incoming IP address for sending outgoing packets

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -365,6 +365,7 @@ where
                     contents: buf,
                     ecn: None,
                     segment_size: None,
+                    src_ip: self.local_ip,
                 });
             }
         }
@@ -554,6 +555,7 @@ where
                 None
             },
             segment_size: None,
+            src_ip: self.local_ip,
         })
     }
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -18,7 +18,13 @@
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::too_many_arguments)]
 
-use std::{convert::TryInto, fmt, net::SocketAddr, ops, time::Duration};
+use std::{
+    convert::TryInto,
+    fmt,
+    net::{IpAddr, SocketAddr},
+    ops,
+    time::Duration,
+};
 
 mod cid_queue;
 #[doc(hidden)]
@@ -277,6 +283,8 @@ pub struct Transmit {
     /// The segment size if this transmission contains multiple datagrams.
     /// This is `None` if the transmit only contains a single datagram
     pub segment_size: Option<usize>,
+    /// Optional source IP address for the datagram
+    pub src_ip: Option<IpAddr>,
 }
 
 //


### PR DESCRIPTION
This is a follow-up for #943. When a socket is bound to a wildcard
IP address, sending the outgoing IP might use a different source IP
address than the one the packet was received on, since the OS might
not be able to identify the necessary route. This would lead packets
not allowing to reach the client.

This change adds a setting which will set an explicit source address
in all outgoing packets. The source address which will be used is
the local IP address which was used to receive the initial incoming
packet.