### PR TITLE
Add recovery stats as part of ConnectionStats

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -935,7 +935,11 @@ where
 
     /// Returns connection statistics
     pub fn stats(&self) -> ConnectionStats {
-        self.stats
+        let mut stats = self.stats;
+        stats.path.rtt = self.path.rtt.get();
+        stats.path.cwnd = self.path.congestion.window();
+
+        stats
     }
 
     /// Stop accepting data on the given receive stream

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -1,4 +1,7 @@
+//! Connection statistics
+
 use crate::{frame::Frame, Dir};
+use std::time::Duration;
 
 /// Statistics about UDP datagrams transmitted or received on a connection
 #[derive(Default, Debug, Copy, Clone)]
@@ -108,6 +111,16 @@ impl std::fmt::Debug for FrameStats {
     }
 }
 
+/// Statistics related to a transmission path
+#[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
+pub struct PathStats {
+    /// Current best estimate of this connection's latency (round-trip-time)
+    pub rtt: Duration,
+    /// Current congestion window of the connection
+    pub cwnd: u64,
+}
+
 /// Connection statistics
 #[derive(Debug, Default, Copy, Clone)]
 #[non_exhaustive]
@@ -120,4 +133,6 @@ pub struct ConnectionStats {
     pub frame_tx: FrameStats,
     /// Statistics about frames received on a connection
     pub frame_rx: FrameStats,
+    /// Statistics related to the current transmission path
+    pub path: PathStats,
 }


### PR DESCRIPTION
This is an alternative version of #972, where we add the new stats
to ConnectionStats instead of exposing additional accessors.

The naming of `recovery` could probably be improved. `path` might
be an option. But where would we add something like packet loss?
That seems more like an overall stat.