### PR TITLE
Non contiguous Send buffer

### DIFF
--- a/quinn-proto/src/range_set.rs
+++ b/quinn-proto/src/range_set.rs
@@ -56,7 +56,7 @@ impl RangeSet {
     }
 
     pub fn insert(&mut self, mut x: Range<u64>) -> bool {
-        if x.end == 0 {
+        if x.end == 0 || x.start == x.end {
             return false;
         }
         if let Some((start, end)) = self.pred(x.start) {
@@ -458,5 +458,16 @@ mod tests {
         assert_eq!(set.replace(0..2).collect::<Vec<_>>(), &[]);
         assert_eq!(set.len(), 1);
         assert_eq!(set.peek_min().unwrap(), 0..4);
+    }
+
+    #[test]
+    fn skip_empty_ranges() {
+        let mut set = RangeSet::new();
+        assert!(!set.insert(2..2));
+        assert_eq!(set.len(), 0);
+        assert!(!set.insert(4..4));
+        assert_eq!(set.len(), 0);
+        assert!(!set.insert(0..0));
+        assert_eq!(set.len(), 0);
     }
 }


### PR DESCRIPTION
During testing with a multithreaded runtime I discovered that threads
block a fair amount of time on Mutexes, even though everything in the
state machine should be non-blocking.

By inserting some more timing checks I discovered that the `poll_write`
call took more than 10ms and locked the Mutex for this duration. This
happened due to the `BytesMut::extend_from_slice` taking this time.

The reason here is that extending the buffer require a reallocation of
the buffer and a copy of the complete data. This can be a big size
(up the maximum internal buffer size) - even if only a tiny chunk of
data is added.

This change improves on this by using a non-contiguous send buffer.
New data is appended as a new `Bytes` segment, which only requires
an allocation for this particular size. The 10ms blocking problem is
gone with this.

Another benefit of this change is that it can easily enable zero-copy
writes by accepting `Bytes` as a parameter in the user-facing API.
This is however not performed here yet.

```
Jan 18 11:14:00.064  WARN quinn_proto::connection::send_buffer: self.unacked.extend_from_slice(data[..1048576]) took 10.3452ms. Now unacked size: 94924462
Jan 18 11:14:00.064  WARN quinn_proto::connection::streams: Long Send::write. Total: 10.3943ms, Budget check: 0ns, data_len: 1048576, written: 1048576
Jan 18 11:14:00.064  WARN quinn_proto::connection::streams: Long Streams::write. Total: 10.4203ms, Limit check: 100ns, Unsent check: 200ns, Write: 10.4202ms. data_len: 1048576, written: 1048576
Jan 18 11:14:00.064  WARN quinn::streams: Long poll_write time: close_check 100ns, write_time 10.4456ms, end_time 10.4456ms
```