### PR TITLE
Wake up the connection driver only if flow control needs to be issued

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -50,7 +50,7 @@ pub use stats::ConnectionStats;
 
 mod streams;
 pub use streams::Streams;
-pub use streams::{FinishError, ReadError, StreamEvent, UnknownStream, WriteError};
+pub use streams::{DidRead, FinishError, ReadError, StreamEvent, UnknownStream, WriteError};
 
 mod timer;
 use timer::{Timer, TimerTable};

--- a/quinn-proto/src/connection/streams.rs
+++ b/quinn-proto/src/connection/streams.rs
@@ -18,9 +18,9 @@ use crate::{
 };
 
 mod recv;
-pub use recv::ReadError;
 pub(super) use recv::ReadResult;
-use recv::{BytesRead, DidRead, ReadChunks, Recv, StreamReadResult};
+use recv::{BytesRead, ReadChunks, Recv, StreamReadResult};
+pub use recv::{DidRead, ReadError};
 
 mod send;
 pub use send::{FinishError, WriteError};

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -248,6 +248,27 @@ pub struct DidRead<T> {
     pub(crate) max_data: ShouldTransmit,
 }
 
+impl<T> DidRead<T> {
+    /// Returns `true` iff the producing `Streams::read` call causes a transmit.
+    pub fn causes_transmit(&self) -> bool {
+        self.max_stream_data.should_transmit() || self.max_data.should_transmit()
+    }
+
+    /// Maps an `DidRead<T>` to `DidRead<U>` by applying a function to the contained result.
+    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> DidRead<U> {
+        DidRead {
+            result: f(self.result),
+            max_stream_data: self.max_stream_data,
+            max_data: self.max_data,
+        }
+    }
+
+    /// Returns the contained result, consuming the `self` value.
+    pub fn into_inner(self) -> T {
+        self.result
+    }
+}
+
 pub(super) type StreamReadResult<T> = Result<Option<T>, ReadError>;
 
 pub(crate) trait BytesRead {

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -242,10 +242,10 @@ pub(crate) type ReadResult<T> = Result<Option<DidRead<T>>, ReadError>;
 /// Result of a `Streams::read` call in case the stream had not ended yet
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 #[must_use = "A frame might need to be enqueued"]
-pub(crate) struct DidRead<T> {
-    pub result: T,
-    pub max_stream_data: ShouldTransmit,
-    pub max_data: ShouldTransmit,
+pub struct DidRead<T> {
+    pub(crate) result: T,
+    pub(crate) max_stream_data: ShouldTransmit,
+    pub(crate) max_data: ShouldTransmit,
 }
 
 pub(super) type StreamReadResult<T> = Result<Option<T>, ReadError>;

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -40,7 +40,7 @@ mod varint;
 pub use varint::{VarInt, VarIntBoundsExceeded};
 
 mod connection;
-pub use crate::connection::{ConnectionError, ConnectionStats, Event, SendDatagramError};
+pub use crate::connection::{ConnectionError, ConnectionStats, DidRead, Event, SendDatagramError};
 pub use crate::connection::{FinishError, ReadError, StreamEvent, UnknownStream, WriteError};
 
 mod config;


### PR DESCRIPTION
This tries to fix issue #984. It makes the `DidRead` type of quinn-proto public and changes `quinn_proto::Connection::read_unordered`, `quinn_proto::Connection::read`, and `quinn_proto::Connection::read_chunks` to return `Result<Option<DidRead<U>>, ReadError>` instead of `Result<Option<U>, ReadError>`.
With that we can check in `quinn::RecvStream::poll_read_generic` if we need to wake up the connection driver.