### PR TITLE
Wake up the connection driver only if flow control needs to be issued (based on #991)

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1080,6 +1080,11 @@ where
         self.zero_rtt_enabled
     }
 
+    /// Whether there are any pending retransmits
+    pub fn has_pending_retransmits(&self) -> bool {
+        !self.spaces[SpaceId::Data].pending.is_empty()
+    }
+
     /// Look up whether we're the client or server of this Connection
     pub fn side(&self) -> Side {
         self.side

--- a/quinn/src/streams.rs
+++ b/quinn/src/streams.rs
@@ -509,8 +509,9 @@ where
         }
         match read_fn(&mut conn, self.stream) {
             Ok(Some(u)) => {
-                // Flow control credit may have been issued
-                conn.wake();
+                if conn.inner.has_pending_retransmits() {
+                    conn.wake()
+                }
                 Poll::Ready(Ok(Some(u)))
             }
             Ok(None) => {


### PR DESCRIPTION
Add a has_pending_retransmits method to
quinn_proto::connection::Connection and use it inside of
quinn::RecvStream::poll_read_generic to decide if we should wake up the
connection driver.