### PR TITLE
Increase datagram utilization

### DIFF
--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -262,6 +262,18 @@ impl StreamId {
     }
 }
 
+impl Into<VarInt> for StreamId {
+    fn into(self) -> VarInt {
+        unsafe { VarInt::from_u64_unchecked(self.0) }
+    }
+}
+
+impl From<VarInt> for StreamId {
+    fn from(v: VarInt) -> Self {
+        Self(v.0)
+    }
+}
+
 impl coding::Codec for StreamId {
     fn decode<B: bytes::Buf>(buf: &mut B) -> coding::Result<StreamId> {
         VarInt::decode(buf).map(|x| StreamId(x.into_inner()))


### PR DESCRIPTION
This change will increase the amount of data that will be written in
STREAM frames. The previous approach was pessimistic and assumed
- 8 bytes are used for Stream ID
- 8 bytes are used for the offset
- 8 bytes are used for the length

This change calculates the available size better on the amount of actual
bytes required to encode the stream ID and length. It also allows to
omit the length field if enough information is available to fully utilize the
datagram.

This allows to store up to 22 byte more payload data per MTU.