### PR TITLE
Make fairness on stream transmissions configurable

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -52,7 +52,9 @@ pub use stats::ConnectionStats;
 
 mod streams;
 pub use streams::Streams;
-pub use streams::{FinishError, ReadError, ShouldTransmit, StreamEvent, UnknownStream, WriteError};
+pub use streams::{
+    FinishError, Priority, ReadError, ShouldTransmit, StreamEvent, UnknownStream, WriteError,
+};
 
 mod timer;
 use timer::{Timer, TimerTable};
@@ -1660,7 +1662,7 @@ where
     pub fn set_priority(
         &mut self,
         stream_id: StreamId,
-        priority: i32,
+        priority: Priority,
     ) -> Result<(), UnknownStream> {
         assert!(
             stream_id.dir() == Dir::Bi || stream_id.initiator() == self.side,
@@ -1675,7 +1677,7 @@ where
     ///
     /// # Panics
     /// - when applied to a receive stream
-    pub fn priority(&mut self, stream_id: StreamId) -> Result<i32, UnknownStream> {
+    pub fn priority(&mut self, stream_id: StreamId) -> Result<Priority, UnknownStream> {
         assert!(
             stream_id.dir() == Dir::Bi || stream_id.initiator() == self.side,
             "only streams supporting outgoing data have a priority"

--- a/quinn-proto/src/connection/streams/send.rs
+++ b/quinn-proto/src/connection/streams/send.rs
@@ -9,7 +9,7 @@ pub(super) struct Send {
     pub(super) max_data: u64,
     pub(super) state: SendState,
     pub(super) pending: SendBuffer,
-    pub(super) priority: i32,
+    pub(super) priority: Priority,
     /// Whether a frame containing a FIN bit must be transmitted, even if we don't have any new data
     pub(super) fin_pending: bool,
     /// Whether this stream is in the `connection_blocked` list of `Streams`
@@ -24,7 +24,7 @@ impl Send {
             max_data: max_data.into(),
             state: SendState::Ready,
             pending: SendBuffer::new(),
-            priority: 0,
+            priority: Priority::default(),
             fin_pending: false,
             connection_blocked: false,
             stop_reason: None,
@@ -177,4 +177,26 @@ pub enum FinishError {
     /// The stream has not been opened or was already finished or reset
     #[error("unknown stream")]
     UnknownStream,
+}
+
+/// Priority of a send stream
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub struct Priority {
+    /// Pending data of streams with a higher level will be transmitted before data of streams
+    /// with a lower level. Defaults to `0`.
+    pub level: i32,
+    /// If set to `true`, all streams with the same priority will transmit their pending data
+    /// in a round-robin fashion. Otherwise all pending data of a stream will be transmitted
+    /// before transmitting the next stream. Defaults to `true`.
+    pub fair: bool,
+}
+
+impl Default for Priority {
+    fn default() -> Self {
+        Self {
+            level: 0,
+            fair: true,
+        }
+    }
 }

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -40,7 +40,9 @@ mod varint;
 pub use varint::{VarInt, VarIntBoundsExceeded};
 
 mod connection;
-pub use crate::connection::{Chunk, ConnectionError, ConnectionStats, Event, SendDatagramError};
+pub use crate::connection::{
+    Chunk, ConnectionError, ConnectionStats, Event, Priority, SendDatagramError,
+};
 pub use crate::connection::{FinishError, ReadError, StreamEvent, UnknownStream, WriteError};
 
 mod config;

--- a/quinn/src/streams.rs
+++ b/quinn/src/streams.rs
@@ -11,7 +11,7 @@ use futures::{
     io::{AsyncRead, AsyncWrite},
     ready, FutureExt,
 };
-use proto::{Chunk, ConnectionError, FinishError, StreamId};
+use proto::{Chunk, ConnectionError, FinishError, Priority, StreamId};
 use thiserror::Error;
 use tokio::io::ReadBuf;
 
@@ -152,19 +152,18 @@ where
 
     /// Set the priority of the send stream
     ///
-    /// Every send stream has an initial priority of 0. Locally buffered data from streams with
-    /// higher priority will be transmitted before data from streams with lower priority. Changing
-    /// the priority of a stream with pending data may only take effect after that data has been
-    /// transmitted. Using many different priority levels per connection may have a negative
-    /// impact on performance.
-    pub fn set_priority(&self, priority: i32) -> Result<(), UnknownStream> {
+    /// Locally buffered data from streams with higher priority will be transmitted before data
+    /// from streams with lower priority. Changing the priority of a stream with pending data may
+    /// only take effect after that data has been transmitted. Using many different priorities per
+    /// connection may have a negative impact on performance.
+    pub fn set_priority(&self, priority: Priority) -> Result<(), UnknownStream> {
         let mut conn = self.conn.lock().unwrap();
         conn.inner.set_priority(self.stream, priority)?;
         Ok(())
     }
 
     /// Get the priority of the send stream
-    pub fn priority(&self) -> Result<i32, UnknownStream> {
+    pub fn priority(&self) -> Result<Priority, UnknownStream> {
         let mut conn = self.conn.lock().unwrap();
         Ok(conn.inner.priority(self.stream)?)
     }


### PR DESCRIPTION
This allows making a send stream unfair, so it will block other streams of the same priority.

This enables users of quinn to implement a prioritization scheme like [this](https://datatracker.ietf.org/doc/draft-ietf-httpbis-priority/) for their application protocol.


