### PR TITLE
Lock tracking

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -18,6 +18,8 @@ all-features = true
 default = ["native-certs", "certificate-transparency", "tls-rustls"]
 # Use Google's list of CT logs to enable certificate transparency checks
 certificate-transparency = ["proto/certificate-transparency"]
+# Records how long locks are held, and warns if they are held >= 1ms
+lock_tracking = []
 # Trust the contents of the OS certificate store by default
 native-certs = ["proto/native-certs"]
 tls-rustls = ["rustls", "webpki", "proto/tls-rustls"]

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -54,6 +54,7 @@ mod broadcast;
 mod builders;
 mod connection;
 mod endpoint;
+mod mutex;
 mod platform;
 mod streams;
 

--- a/quinn/src/mutex.rs
+++ b/quinn/src/mutex.rs
@@ -1,0 +1,163 @@
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
+
+#[cfg(feature = "lock_tracking")]
+mod tracking {
+    use super::*;
+    use std::{
+        collections::VecDeque,
+        time::{Duration, Instant},
+    };
+    use tracing::warn;
+
+    #[derive(Debug)]
+    struct Inner<T> {
+        last_lock_owner: VecDeque<(&'static str, Duration)>,
+        value: T,
+    }
+
+    /// A Mutex which optionally allows to track the time a lock was held and
+    /// emit warnings in case of excessive lock times
+    pub struct Mutex<T> {
+        inner: std::sync::Mutex<Inner<T>>,
+    }
+
+    impl<T: Debug> std::fmt::Debug for Mutex<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            std::fmt::Debug::fmt(&self.inner, f)
+        }
+    }
+
+    impl<T> Mutex<T> {
+        pub fn new(value: T) -> Self {
+            Self {
+                inner: std::sync::Mutex::new(Inner {
+                    last_lock_owner: VecDeque::new(),
+                    value,
+                }),
+            }
+        }
+
+        /// Acquires the lock for a certain purpose
+        ///
+        /// The purpose will be recorded in the list of last lock owners
+        pub fn lock(&self, purpose: &'static str) -> MutexGuard<T> {
+            let now = Instant::now();
+            let guard = self.inner.lock().unwrap();
+
+            let lock_time = Instant::now();
+            let elapsed = lock_time.duration_since(now);
+
+            if elapsed > Duration::from_millis(1) {
+                warn!(
+                    "Locking the connection for {} took {:?}. Last owners: {:?}",
+                    purpose, elapsed, guard.last_lock_owner
+                );
+            }
+
+            MutexGuard {
+                guard,
+                start_time: lock_time,
+                purpose,
+            }
+        }
+    }
+
+    pub struct MutexGuard<'a, T> {
+        guard: std::sync::MutexGuard<'a, Inner<T>>,
+        start_time: Instant,
+        purpose: &'static str,
+    }
+
+    impl<'a, T> Drop for MutexGuard<'a, T> {
+        fn drop(&mut self) {
+            if self.guard.last_lock_owner.len() == MAX_LOCK_OWNERS {
+                self.guard.last_lock_owner.pop_back();
+            }
+
+            let duration = self.start_time.elapsed();
+
+            if duration > Duration::from_millis(1) {
+                warn!(
+                    "Utilizing the connection for {} took {:?}",
+                    self.purpose, duration
+                );
+            }
+
+            self.guard
+                .last_lock_owner
+                .push_front((self.purpose, duration));
+        }
+    }
+
+    impl<'a, T> Deref for MutexGuard<'a, T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.guard.value
+        }
+    }
+
+    impl<'a, T> DerefMut for MutexGuard<'a, T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.guard.value
+        }
+    }
+
+    const MAX_LOCK_OWNERS: usize = 20;
+}
+
+#[cfg(feature = "lock_tracking")]
+pub use tracking::{Mutex, MutexGuard};
+
+#[cfg(not(feature = "lock_tracking"))]
+mod non_tracking {
+    use super::*;
+
+    /// A Mutex which optionally allows to track the time a lock was held and
+    /// emit warnings in case of excessive lock times
+    #[derive(Debug)]
+    pub struct Mutex<T> {
+        inner: std::sync::Mutex<T>,
+    }
+
+    impl<T> Mutex<T> {
+        pub fn new(value: T) -> Self {
+            Self {
+                inner: std::sync::Mutex::new(value),
+            }
+        }
+
+        /// Acquires the lock for a certain purpose
+        ///
+        /// The purpose will be recorded in the list of last lock owners
+        pub fn lock(&self, _purpose: &'static str) -> MutexGuard<T> {
+            MutexGuard {
+                guard: self.inner.lock().unwrap(),
+            }
+        }
+    }
+
+    pub struct MutexGuard<'a, T> {
+        guard: std::sync::MutexGuard<'a, T>,
+    }
+
+    impl<'a, T> Deref for MutexGuard<'a, T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            self.guard.deref()
+        }
+    }
+
+    impl<'a, T> DerefMut for MutexGuard<'a, T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            self.guard.deref_mut()
+        }
+    }
+}
+
+#[cfg(not(feature = "lock_tracking"))]
+pub use non_tracking::{Mutex, MutexGuard};


### PR DESCRIPTION
This change adds an optional feature which allows to track how much
time was spent inside locks on connections, as well as which other
tasks held the lock (in case there is lock contention).

This makes it easier to determine which code path are currently not
as non-blocking as they should be.

Examples of output:
```
Feb 04 22:05:42.293  WARN quinn::mutex: Utilizing the connection for poll took 165.2318ms
```

```
Feb 04 22:05:42.128  WARN quinn::mutex: Locking the connection for poll took 1.1284ms. Last owners: [("SendStream::poll_write", 7.6µs), ("SendStream::poll_write", 46.4µs), ("SendStream::poll_write", 792.8µs), ("drop", 100ns), ("clone", 100ns), ("OpenUni::next", 1.3µs), ("clone", 295.2µs), ("poll", 14.1546ms), ("drop", 100ns), ("drop", 100ns), ("drop", 439.2µs), ("poll", 9.7657ms), ("clone", 0ns), ("clone", 0ns), ("clone", 100ns), ("connecting", 308.3µs), ("poll", 30.402ms), ("poll", 4.1406ms), ("clone", 100ns)]
```