### PR TITLE
Allow to use the vectored ordered read API in benchmark

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.22"
+bytes = "1"
 futures = "0.3.8"
 hdrhistogram = "7.2"
 quinn = { path = "../quinn" }


### PR DESCRIPTION
This extends the benchmark to make the consumer either utilize the
ordered or unordered read API.
The ordered read API is now set to the default, since it might be
applicable to more applications.