### PR TITLE
Add stats for congestion events

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1298,6 +1298,7 @@ where
             }
             Ok(false) => {}
             Ok(true) => {
+                self.stats.path.congestion_events += 1;
                 self.path
                     .congestion
                     .on_congestion_event(now, largest_sent_time, false);
@@ -1460,6 +1461,7 @@ where
                 < largest_lost_sent - congestion_period;
 
             if lost_ack_eliciting {
+                self.stats.path.congestion_events += 1;
                 self.path.congestion.on_congestion_event(
                     now,
                     largest_lost_sent,

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -119,6 +119,8 @@ pub struct PathStats {
     pub rtt: Duration,
     /// Current congestion window of the connection
     pub cwnd: u64,
+    /// Congestion events on the connection
+    pub congestion_events: u64,
 }
 
 /// Connection statistics


### PR DESCRIPTION
This adds a new metric for the amount of either loss or ECN
related congestion events.