### PR TITLE
Use inline storage for the common case of 1 STREAM frame per packet

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -34,6 +34,7 @@ rustls = { version = "0.19", features = ["quic"], optional = true }
 rustls-native-certs = { version = "0.5", optional = true }
 slab = "0.4"
 thiserror = "1.0.21"
+tinyvec = { version = "1.1", features = ["alloc"] }
 tracing = "0.1.10"
 webpki = { version = "0.21", optional = true }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use bytes::{Bytes, BytesMut};
+use frame::StreamMetaVec;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use thiserror::Error;
 use tracing::{debug, error, trace, trace_span, warn};
@@ -3465,7 +3466,7 @@ struct ZeroRttCrypto<S: crypto::Session> {
 struct SentFrames {
     retransmits: Retransmits,
     acks: RangeSet,
-    stream_frames: Vec<frame::StreamMeta>,
+    stream_frames: StreamMetaVec,
     padding: bool,
 }
 

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -186,7 +186,7 @@ pub(crate) struct SentPacket {
     /// Metadata for stream frames in a packet
     ///
     /// The actual application data is stored with the stream state.
-    pub(crate) stream_frames: Vec<frame::StreamMeta>,
+    pub(crate) stream_frames: frame::StreamMetaVec,
 }
 
 /// Retransmittable data queue

--- a/quinn-proto/src/connection/streams.rs
+++ b/quinn-proto/src/connection/streams.rs
@@ -14,7 +14,7 @@ use super::spaces::Retransmits;
 use crate::{
     coding::BufMutExt,
     connection::stats::FrameStats,
-    frame::{self, FrameStruct},
+    frame::{self, FrameStruct, StreamMetaVec},
     transport_parameters::TransportParameters,
     Dir, Side, StreamId, TransportError, VarInt, MAX_STREAM_COUNT,
 };
@@ -602,12 +602,8 @@ impl Streams {
         }
     }
 
-    pub fn write_stream_frames(
-        &mut self,
-        buf: &mut Vec<u8>,
-        max_buf_size: usize,
-    ) -> Vec<frame::StreamMeta> {
-        let mut stream_frames = Vec::new();
+    pub fn write_stream_frames(&mut self, buf: &mut Vec<u8>, max_buf_size: usize) -> StreamMetaVec {
+        let mut stream_frames = StreamMetaVec::new();
         while buf.len() + frame::Stream::SIZE_BOUND < max_buf_size {
             if max_buf_size
                 .checked_sub(buf.len() + frame::Stream::SIZE_BOUND)


### PR DESCRIPTION
When packets are transmitted, the most common case them is to contain at
most a single STREAM frame. For this common case the current system does
still 2 allocations: One for the `SentPacket` structure which tracks the whole
packet, and one for the stream metadata. This double allocation places
some additional pressure on the allocator. This change changes
`SentPacket::stream_frames`  to make use of vector with small element
optimization, in order to be able to handle the common case of sending
1 stream frame without any further allocation.

Benchmark results
===

Overall the differences don't seem huge. However they become bigger when other
optimizations (like bigger MTUs and size reduction for `SentPacket` are also
enabled).

Without GSO
--

**Before:**

> Sent 4294967296 bytes on 1 streams in 15.37s (266.49 MiB/s)

**After:**

> Sent 4294967296 bytes on 1 streams in 15.33s (267.17 MiB/s)

With GSO
--

**Before:**

> Sent 4294967296 bytes on 1 streams in 11.79s (347.48 MiB/s)

**After:**

> Sent 4294967296 bytes on 1 streams in 11.70s (350.11 MiB/s)