### PR TITLE
Prefer AES cipher suites

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -30,6 +30,9 @@ bytes = "1"
 ct-logs = { version = "0.8", optional = true }
 rand = "0.8"
 ring = { version = "0.16.7", optional = true }
+# If rustls gets updated to a new version which contains
+# https://github.com/ctz/rustls/commit/7117a805e0104705da50259357d8effa7d599e37
+# the custom cipher list in `quinn-proto/src/crypto/rustls.rs` can be removed.
 rustls = { version = "0.19", features = ["quic"], optional = true }
 rustls-native-certs = { version = "0.5", optional = true }
 slab = "0.4"


### PR DESCRIPTION
Testing showed that there is a huge performance boost using AES ciphers
due to hardware acceleration. Therefore those should be preferred.

As an example, a benchmark run using CHACHA20 reached a throughput
of 350MB/s, whereas the same configuration using AES128 reached 520MB/s.

While CHACHA20 might have higher performance on devices without
hardware acceleration for AES, this set of devices might now be tiny.