### PR TITLE
Disable hdrhistogram features

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.22"
 bytes = "1"
 futures = "0.3.8"
-hdrhistogram = "7.2"
+hdrhistogram = { version = "7.2", default-features = false }
 quinn = { path = "../quinn" }
 rcgen = "0.8"
 rustls = "0.19"


### PR DESCRIPTION
This causes nom to be pulled in, which currently causes the CI error and build
conflict between `funty` and `bitvec`: https://github.com/myrrlyn/funty/issues/3

We don't need the feature in this scenario anyway.