### PR TITLE
Simplify congestion interface by introducing a new top-level Session trait

### DIFF
--- a/quinn-proto/src/congestion.rs
+++ b/quinn-proto/src/congestion.rs
@@ -6,7 +6,7 @@ mod new_reno;
 pub use new_reno::{NewReno, NewRenoConfig};
 
 /// Common interface for different congestion controllers
-pub trait Controller: Send {
+pub trait Controller: Send + Clone {
     /// Packet deliveries were confirmed
     ///
     /// `app_limited` indicates whether the connection was blocked on outgoing
@@ -23,15 +23,9 @@ pub trait Controller: Send {
     /// Number of ack-eliciting bytes that may be in flight
     fn window(&self) -> u64;
 
-    /// Duplicate the controller's state
-    fn clone_box(&self) -> Box<dyn Controller>;
-
     /// Initial congestion window
     fn initial_window(&self) -> u64;
-}
-
-/// Constructs controllers on demand
-pub trait ControllerFactory {
-    /// Construct a fresh `Controller`
-    fn build(&self, now: Instant) -> Box<dyn Controller>;
+    
+    /// Construct a state using the current time `now`
+    fn new(now: Instant) -> Self;
 }

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -19,7 +19,7 @@ use crate::{
     cid_queue::CidQueue,
     coding::{BufExt, BufMutExt, UnexpectedEnd},
     config::{EndpointConfig, ServerConfig, TransportConfig},
-    crypto,
+    endpoint,
     shared::ConnectionId,
     ResetToken, Side, TransportError, VarInt, LOC_CID_COUNT, MAX_CID_SIZE, MAX_STREAM_COUNT,
     RESET_TOKEN_SIZE,
@@ -123,7 +123,7 @@ impl TransportParameters {
         server_config: Option<&ServerConfig<S>>,
     ) -> Self
     where
-        S: crypto::Session,
+        S: endpoint::Session,
     {
         TransportParameters {
             initial_src_cid: Some(initial_src_cid),


### PR DESCRIPTION
**NOTE: This PR is incomplete** - it changes `quinn-proto` but I did not yet update the other crates because I wanted to clear the overall approach with you. If you approve, I will update the other crates accordingly.

This PR gets rid of the `ControllerFactory` interface and the ugly `Box<dyn Controller>`.

To make this work, we introduce a new top-level `endpoint::Session` trait that subclasses `crypto::Session` and defines the Controller type as an associated type. This same technique can be used to drop any other cases of `Box<dyn X>` e.g. `Box<dyn ConnectionIdGenerator>`, which I will do in a follow-up PR if this is accepted.

Dropping `Box<dyn X>` makes the state types easier (i.e. possible) to serialise, and makes progress on #927.

In terms of general engineering using advanced type theory mechanisms, I find that associated types are much easier to work with, when writing moderately-complex code in the long run, than existential (dyn) types. Since we have one of those already on `endpoint`, we can reuse it to remove all cases of `Box<dyn>`.