### PR TITLE
Support non local ip binding

### DIFF
--- a/quinn/src/platform/unix.rs
+++ b/quinn/src/platform/unix.rs
@@ -173,6 +173,20 @@ fn init(io: &mio::net::UdpSocket) -> io::Result<()> {
             if rc == -1 {
                 return Err(io::Error::last_os_error());
             }
+
+            let on: libc::c_int = 1;
+            let rc = unsafe {
+                libc::setsockopt(
+                    io.as_raw_fd(),
+                    libc::SOL_IP,
+                    libc::IP_FREEBIND,
+                    &on as *const _ as _,
+                    mem::size_of_val(&on) as _,
+                )
+            };
+            if rc == -1 {
+                return Err(io::Error::last_os_error());
+            }
         }
     }
     if addr.is_ipv6() {


### PR DESCRIPTION
Use socket options IP_FREEBIND to allow quinn binding to
interfaces with IP addresses that are nonlocal.

A use case is binding an ipv6 subnet that will be served by quinn. 