### PR TITLE
Assorted fixes

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -865,13 +865,13 @@ where
         let ack_eliciting = builder.ack_eliciting;
         let exact_number = builder.exact_number;
         let space_id = builder.space;
-        let (size, _) = self.finish_packet(builder, buffer);
+        let (size, padded) = self.finish_packet(builder, buffer);
         let sent = match sent {
             Some(sent) => sent,
             None => return,
         };
 
-        let size = match sent.padding || ack_eliciting {
+        let size = match padded || ack_eliciting {
             true => size as u16,
             false => 0,
         };
@@ -3613,7 +3613,6 @@ struct SentFrames {
     retransmits: ThinRetransmits,
     acks: RangeSet,
     stream_frames: StreamMetaVec,
-    padding: bool,
     requires_padding: bool,
 }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3365,10 +3365,10 @@ pub enum ConnectionError {
     #[error("{0}")]
     TransportError(#[from] TransportError),
     /// The peer's QUIC stack aborted the connection automatically
-    #[error("aborted by peer: {}", 0)]
+    #[error("aborted by peer: {0}")]
     ConnectionClosed(frame::ConnectionClose),
     /// The peer closed the connection
-    #[error("closed by peer: {}", 0)]
+    #[error("closed by peer: {0}")]
     ApplicationClosed(frame::ApplicationClose),
     /// The peer is unable to continue processing this connection, usually due to having restarted
     #[error("reset by peer")]

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -304,7 +304,7 @@ pub enum ReadError {
     /// The peer abandoned transmitting data on this stream.
     ///
     /// Carries an application-defined error code.
-    #[error("reset by peer: code {}", 0)]
+    #[error("reset by peer: code {0}")]
     Reset(VarInt),
     /// The stream has not been opened or was already stopped, finished, or reset
     #[error("unknown stream")]

--- a/quinn-proto/src/connection/streams/send.rs
+++ b/quinn-proto/src/connection/streams/send.rs
@@ -142,7 +142,7 @@ pub enum WriteError {
     /// Carries an application-defined error code.
     ///
     /// [`StreamEvent::Finished`]: crate::StreamEvent::Finished
-    #[error("stopped by peer: code {}", 0)]
+    #[error("stopped by peer: code {0}")]
     Stopped(VarInt),
     /// The stream has not been opened or has already been finished or reset
     #[error("unknown stream")]
@@ -170,7 +170,7 @@ pub enum FinishError {
     /// Carries an application-defined error code.
     ///
     /// [`StreamEvent::Finished`]: crate::StreamEvent::Finished
-    #[error("stopped by peer: code {}", 0)]
+    #[error("stopped by peer: code {0}")]
     Stopped(VarInt),
     /// The stream has not been opened or was already finished or reset
     #[error("unknown stream")]

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -266,7 +266,7 @@ where
                 );
                 return None;
             }
-            if datagram_len < MIN_INITIAL_SIZE {
+            if datagram_len < MIN_INITIAL_SIZE as usize {
                 debug!("ignoring short initial for connection {}", dst_cid);
                 return None;
             }

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -307,7 +307,7 @@ pub struct Transmit {
 const LOC_CID_COUNT: u64 = 8;
 const RESET_TOKEN_SIZE: usize = 16;
 const MAX_CID_SIZE: usize = 20;
-const MIN_INITIAL_SIZE: usize = 1200;
+const MIN_INITIAL_SIZE: u16 = 1200;
 const MIN_MTU: u16 = 1232;
 const TIMER_GRANULARITY: Duration = Duration::from_millis(1);
 /// Maximum number of streams that can be uniquely identified by a stream ID


### PR DESCRIPTION
Issues encountered in the course of #1028. I also discovered an interesting corner case where receive streams that never experience a blocked read can be leaked if the peer finishes them before we stop them, but I still need to investigate whether #1003 fixes that already.