### PR TITLE
Perf client and server improvements

### DIFF
--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.22"
 futures = "0.3.8"
+hdrhistogram = { version = "7.2", default-features = false }
 quinn = { path = "../quinn" }
 rcgen = "0.8"
 rustls = { version = "0.19", features = ["dangerous_configuration"] }

--- a/perf/src/client.rs
+++ b/perf/src/client.rs
@@ -103,9 +103,15 @@ async fn run(opt: Opt) -> Result<()> {
         }
     });
 
+    let drive_fut = async {
+        tokio::try_join!(
+            drive_uni(connection.clone(), opt.uni_requests, opt.upload_size, opt.download_size),
+            drive_bi(connection.clone(), opt.bi_requests, opt.upload_size, opt.download_size)
+        )
+    };
+
     tokio::select! {
-        x = drive_uni(connection.clone(), opt.uni_requests, opt.upload_size, opt.download_size) => x?,
-        x = drive_bi(connection.clone(), opt.bi_requests, opt.upload_size, opt.download_size) => x?,
+        _ = drive_fut => {}
         _ = tokio::signal::ctrl_c() => {
             info!("shutting down");
             connection.close(0u32.into(), b"interrupted");

--- a/perf/src/client.rs
+++ b/perf/src/client.rs
@@ -1,6 +1,7 @@
 use std::{
     net::{IpAddr, Ipv6Addr, SocketAddr},
     sync::Arc,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result};
@@ -35,6 +36,9 @@ struct Opt {
     /// Whether to skip certificate validation
     #[structopt(long)]
     insecure: bool,
+    /// The time to run in seconds
+    #[structopt(long, default_value = "60")]
+    duration: u64,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -118,6 +122,10 @@ async fn run(opt: Opt) -> Result<()> {
         _ = tokio::signal::ctrl_c() => {
             info!("shutting down");
             connection.close(0u32.into(), b"interrupted");
+        }
+        _ = tokio::time::sleep(Duration::from_secs(opt.duration)) => {
+            info!("shutting down");
+            connection.close(0u32.into(), b"done");
         }
     }
 

--- a/perf/src/client.rs
+++ b/perf/src/client.rs
@@ -243,10 +243,10 @@ async fn request(
 ) -> Result<()> {
     stats.upload_start = Some(Instant::now());
     send.write_all(&download.to_be_bytes()).await?;
-    let buf = [42; 4 * 1024];
+    const DATA: [u8; 1024 * 1024] = [42; 1024 * 1024];
     while upload > 0 {
         let n = send
-            .write(&buf[..upload.min(buf.len() as u64) as usize])
+            .write(&DATA[..upload.min(DATA.len() as u64) as usize])
             .await
             .context("sending response")?;
         upload -= n as u64;

--- a/perf/src/server.rs
+++ b/perf/src/server.rs
@@ -160,10 +160,10 @@ async fn drain_stream(mut stream: quinn::RecvStream) -> Result<()> {
 }
 
 async fn respond(mut bytes: u64, mut stream: quinn::SendStream) -> Result<()> {
-    let buf = [42; 4 * 1024];
+    const DATA: [u8; 1024 * 1024] = [42; 1024 * 1024];
     while bytes > 0 {
         let n = stream
-            .write(&buf[..bytes.min(buf.len() as u64) as usize])
+            .write(&DATA[..bytes.min(DATA.len() as u64) as usize])
             .await
             .context("sending response")?;
         bytes -= n as u64;

--- a/perf/src/server.rs
+++ b/perf/src/server.rs
@@ -85,10 +85,7 @@ async fn handle(handshake: quinn::Connecting) -> Result<()> {
         ..
     } = handshake.await.context("handshake failed")?;
     debug!("{} connected", connection.remote_address());
-    tokio::select! {
-        x = drive_uni(connection, uni_streams) => x?,
-        x = drive_bi(bi_streams) => x?,
-    }
+    tokio::try_join!(drive_uni(connection, uni_streams), drive_bi(bi_streams))?;
     Ok(())
 }
 


### PR DESCRIPTION
This change aggregates a couple of improvements for the perf client and server.
Some changes make the client and server more efficient.

Two other commits add stats to the client.

Output is now created in 2s intervals and looks like:

```
Overall stats:
RPS: 0 (2 requests in 14.01s)
Success rate: 100.00%

Stream metrics:

      │ Duration  │ FBL       | Upload Throughput | Download Throughput
──────┼───────────┼───────────┼───────────────────┼────────────────────
 AVG  │     4.96s │    0.00ns │      404.00 MiB/s │        402.62 MiB/s
 P0   │     4.94s │    0.00ns │      400.50 MiB/s │        397.00 MiB/s
 P10  │     4.95s │    0.00ns │      400.75 MiB/s │        397.25 MiB/s
 P50  │     4.95s │    0.00ns │      400.75 MiB/s │        397.25 MiB/s
 P90  │     4.97s │    1.00ms │      407.50 MiB/s │        408.25 MiB/s
 P100 │     4.97s │    1.00ms │      407.50 MiB/s │        408.25 MiB/s
```