### PR TITLE
Reduce stream wakeups

### DIFF
--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -182,8 +182,7 @@ impl<'a> SendStream<'a> {
             return Err(WriteError::Blocked);
         }
 
-        let limit = (self.state.max_data - self.state.data_sent)
-            .min(self.state.send_window - self.state.unacked_data);
+        let limit = self.state.write_limit();
         let stream = self
             .state
             .send

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -651,7 +651,7 @@ impl StreamsState {
 
                 // If it's no longer sensible to write to a stream (even to detect an error) then don't
                 // report it.
-                if stream.is_writable() {
+                if stream.is_writable() && stream.max_data > stream.offset() {
                     return Some(StreamEvent::Writable { id });
                 }
             }


### PR DESCRIPTION
This contains 2 changes which will report a Stream only as writeable if both the connection as well as stream windows are not empty.