### PR TITLE
Perf: Use owned buffers

### DIFF
--- a/perf/src/client.rs
+++ b/perf/src/client.rs
@@ -255,13 +255,14 @@ async fn request(
 ) -> Result<()> {
     stats.upload_start = Some(Instant::now());
     send.write_all(&download.to_be_bytes()).await?;
+
     const DATA: [u8; 1024 * 1024] = [42; 1024 * 1024];
     while upload > 0 {
-        let n = send
-            .write(&DATA[..upload.min(DATA.len() as u64) as usize])
+        let chunk_len = upload.min(DATA.len() as u64);
+        send.write_chunk(Bytes::from_static(&DATA[..chunk_len as usize]))
             .await
             .context("sending response")?;
-        upload -= n as u64;
+        upload -= chunk_len;
     }
     send.finish().await?;
 


### PR DESCRIPTION
Use zero-copy APIs when sending data in perf application.

Performance difference:
1. First line is before
2. Second line is after (but with only the download write change)

```
      │ Duration  │ FBL       | Upload Throughput | Download Throughput
──────┼───────────┼───────────┼───────────────────┼────────────────────
 AVG  │    5.00ms │    1.00ms │      332.82 MiB/s │        334.20 MiB/s
 AVG  │    5.00ms │    0.00ns │      332.64 MiB/s │        335.96 MiB/s
```

=> Makes less than 1%. Still neat to have