### PR TITLE
[0.6.x] Don't assume representation of SocketAddr

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -34,6 +34,7 @@ libc = "0.2.67"
 mio = "0.6"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.6.1" }
 rustls = { version = "0.17", features = ["quic"], optional = true }
+socket2 = "0.3"
 tracing = "0.1.10"
 tokio = { version = "0.2.6", features = ["rt-core", "io-driver", "time"] }
 webpki = { version = "0.21", optional = true }


### PR DESCRIPTION
0.6.x backport of #987 . Only the second commit is needed, see https://github.com/quinn-rs/quinn/issues/968#issuecomment-789294218