### PR TITLE
Pad initial-space datagrams from servers, too

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -636,7 +636,9 @@ where
             )?);
             coalesce = coalesce && !builder.short_header;
 
-            pad_datagram |= space_id == SpaceId::Initial && self.side.is_client();
+            // https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-14.1
+            pad_datagram |=
+                space_id == SpaceId::Initial && (self.side.is_client() || ack_eliciting);
 
             if close {
                 trace!("sending CONNECTION_CLOSE");


### PR DESCRIPTION
Quoth the spec: a server MUST expand the payload of all UDP datagrams
carrying ack-eliciting Initial packets to at least the smallest
allowed maximum datagram size of 1200 bytes.

Found in @Matthias247's recent interop testing