### PR TITLE
perf test improvements

### DIFF
--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -13,6 +13,7 @@ hdrhistogram = { version = "7.2", default-features = false }
 quinn = { path = "../quinn" }
 rcgen = "0.8"
 rustls = { version = "0.19", features = ["dangerous_configuration"] }
+socket2 = "0.3"
 webpki = "0.21"
 structopt = "0.3"
 tokio = { version = "1.0.1", features = ["rt", "macros", "signal", "net", "sync"] }

--- a/perf/src/server.rs
+++ b/perf/src/server.rs
@@ -27,7 +27,7 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     if let Err(e) = run(opt).await {
-        error!("{}", e);
+        error!("{:#}", e);
     }
 }
 

--- a/perf/src/server.rs
+++ b/perf/src/server.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use bytes::Bytes;
 use futures::StreamExt;
 use structopt::StructOpt;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info};
 
 #[derive(StructOpt)]
 #[structopt(name = "server")]
@@ -150,7 +150,7 @@ async fn read_req(mut stream: quinn::RecvStream) -> Result<u64> {
         .await
         .context("reading request")?;
     let n = u64::from_be_bytes(buf);
-    trace!("got req for {} bytes on {}", n, stream.id());
+    debug!("got req for {} bytes on {}", n, stream.id());
     drain_stream(stream).await?;
     Ok(n)
 }
@@ -168,7 +168,7 @@ async fn drain_stream(mut stream: quinn::RecvStream) -> Result<()> {
         Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
     ];
     while stream.read_chunks(&mut bufs[..]).await?.is_some() {}
-    trace!("finished reading {}", stream.id());
+    debug!("finished reading {}", stream.id());
     Ok(())
 }
 
@@ -183,6 +183,6 @@ async fn respond(mut bytes: u64, mut stream: quinn::SendStream) -> Result<()> {
             .context("sending response")?;
         bytes -= chunk_len;
     }
-    trace!("finished responding on {}", stream.id());
+    debug!("finished responding on {}", stream.id());
     Ok(())
 }

--- a/perf/src/socket.rs
+++ b/perf/src/socket.rs
@@ -1,0 +1,49 @@
+use std::net::SocketAddr;
+
+use anyhow::{Context, Result};
+use socket2::{Domain, Protocol, Socket, Type};
+use tracing::warn;
+
+pub fn bind_socket(
+    addr: SocketAddr,
+    send_buffer_size: usize,
+    recv_buffer_size: usize,
+) -> Result<std::net::UdpSocket> {
+    let socket = Socket::new(
+        if addr.is_ipv4() {
+            Domain::ipv4()
+        } else {
+            Domain::ipv6()
+        },
+        Type::dgram(),
+        Some(Protocol::udp()),
+    )
+    .context("create socket")?;
+    socket
+        .bind(&socket2::SockAddr::from(addr))
+        .context("binding endpoint")?;
+    socket
+        .set_send_buffer_size(send_buffer_size)
+        .context("send buffer size")?;
+    socket
+        .set_recv_buffer_size(recv_buffer_size)
+        .context("recv buffer size")?;
+
+    let buf_size = socket.send_buffer_size().context("send buffer size")?;
+    if buf_size < send_buffer_size {
+        warn!(
+            "Unable to set desired send buffer size. Desired: {}, Actual: {}",
+            send_buffer_size, buf_size
+        );
+    }
+
+    let buf_size = socket.recv_buffer_size().context("recv buffer size")?;
+    if buf_size < recv_buffer_size {
+        warn!(
+            "Unable to set desired recv buffer size. Desired: {}, Actual: {}",
+            recv_buffer_size, buf_size
+        );
+    }
+
+    Ok(socket.into())
+}


### PR DESCRIPTION
- Allows to overwrite socket buffer sizes
- Change server logging to use `debug` instead of `trace` logs