### PR TITLE
Automatically activate GSO based on platform capabilities

### DIFF
--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -300,7 +300,7 @@ impl TestEndpoint {
                 endpoint_events.push((*ch, event));
             }
 
-            while let Some(x) = conn.poll_transmit(now) {
+            while let Some(x) = conn.poll_transmit(now, MAX_DATAGRAMS) {
                 self.outbound.extend(split_transmit(x));
             }
             self.timeout = conn.poll_timeout();
@@ -416,6 +416,9 @@ pub fn min_opt<T: Ord>(x: Option<T>, y: Option<T>) -> Option<T> {
         _ => None,
     }
 }
+
+/// The maximum of datagrams TestEndpoint will produce via `poll_transmit`
+const MAX_DATAGRAMS: usize = 10;
 
 fn split_transmit(transmit: Transmit) -> Vec<Transmit> {
     let segment_size = match transmit.segment_size {

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -23,6 +23,7 @@ use tracing::info_span;
 use crate::{
     broadcast::{self, Broadcast},
     mutex::Mutex,
+    platform::caps,
     recv_stream::RecvStream,
     send_stream::{SendStream, WriteError},
     ConnectionEvent, EndpointEvent, VarInt,
@@ -800,7 +801,10 @@ where
 {
     fn drive_transmit(&mut self) {
         let now = Instant::now();
-        while let Some(t) = self.inner.poll_transmit(now) {
+
+        let max_datagrams = caps().max_gso_segments;
+
+        while let Some(t) = self.inner.poll_transmit(now, max_datagrams) {
             // If the endpoint driver is gone, noop.
             let _ = self
                 .endpoint_events

--- a/quinn/src/platform/fallback.rs
+++ b/quinn/src/platform/fallback.rs
@@ -77,7 +77,9 @@ impl UdpSocket {
 
 /// Returns the platforms UDP socket capabilities
 pub fn caps() -> super::UdpCapabilities {
-    super::UdpCapabilities { gso: false }
+    super::UdpCapabilities {
+        max_gso_segments: 1,
+    }
 }
 
 pub const BATCH_SIZE: usize = 1;

--- a/quinn/src/platform/mod.rs
+++ b/quinn/src/platform/mod.rs
@@ -19,7 +19,6 @@ mod imp;
 
 pub use imp::UdpSocket;
 
-#[allow(dead_code)] // TODO: Remove when used
 /// Returns the platforms UDP socket capabilities
 pub fn caps() -> UdpCapabilities {
     imp::caps()

--- a/quinn/src/platform/mod.rs
+++ b/quinn/src/platform/mod.rs
@@ -37,8 +37,10 @@ pub trait UdpExt {
 /// The capabilities a UDP socket suppports on a certain platform
 #[derive(Debug, Clone, Copy)]
 pub struct UdpCapabilities {
-    /// Whether the platform supports Generic Send Offload (GSO)
-    pub gso: bool,
+    /// The maximum amount of segments which can be transmitted if a platform
+    /// supports Generic Send Offload (GSO).
+    /// This is 1 if the platform doesn't support GSO.
+    pub max_gso_segments: usize,
 }
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
This set of changes will automatically activate GSO on Linux. In order to do this, the platform is queried for the maximum amount of supported segments per transmit call. This amount is capped at a certain level, and then passed to the `poll_transmit` call.