### PR TITLE
Use a cheaper hash function

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -27,6 +27,7 @@ native-certs = ["rustls-native-certs"]
 [dependencies]
 arbitrary = { version = "0.4.5", features = ["derive"], optional = true }
 bytes = "1"
+fxhash = "0.2.1"
 ct-logs = { version = "0.8", optional = true }
 rand = "0.8"
 ring = { version = "0.16.7", optional = true }

--- a/quinn-proto/src/connection/cid_state.rs
+++ b/quinn-proto/src/connection/cid_state.rs
@@ -1,9 +1,10 @@
 //! Maintain the state of local connection IDs
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::VecDeque,
     time::{Duration, Instant},
 };
 
+use fxhash::FxHashSet;
 use tracing::{debug, trace};
 
 use crate::{shared::IssuedCid, TransportError};
@@ -15,7 +16,7 @@ pub struct CidState {
     /// Number of local connection IDs that have been issued in NEW_CONNECTION_ID frames.
     issued: u64,
     /// Sequence numbers of local connection IDs not yet retired by the peer
-    active_seq: HashSet<u64>,
+    active_seq: FxHashSet<u64>,
     /// Sequence number the peer has already retired all CIDs below at our request via `retire_prior_to`
     prev_retire_seq: u64,
     /// Sequence number to set in retire_prior_to field in NEW_CONNECTION_ID frame
@@ -28,7 +29,7 @@ pub struct CidState {
 
 impl CidState {
     pub(crate) fn new(cid_len: usize, cid_lifetime: Option<Duration>, now: Instant) -> Self {
-        let mut active_seq = HashSet::new();
+        let mut active_seq = FxHashSet::default();
         // Add sequence number of CID used in handshaking into tracking set
         active_seq.insert(0);
         let mut this = CidState {

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -1,10 +1,12 @@
 use std::{
     cmp,
-    collections::{BTreeMap, HashSet, VecDeque},
+    collections::{BTreeMap, VecDeque},
     mem,
     ops::{Index, IndexMut},
     time::Instant,
 };
+
+use fxhash::FxHashSet;
 
 use super::assembler::Assembler;
 use super::streams::ShouldTransmit;
@@ -235,7 +237,7 @@ pub struct Retransmits {
     pub(crate) max_bi_stream_id: bool,
     pub(crate) reset_stream: Vec<(StreamId, VarInt)>,
     pub(crate) stop_sending: Vec<frame::StopSending>,
-    pub(crate) max_stream_data: HashSet<StreamId>,
+    pub(crate) max_stream_data: FxHashSet<StreamId>,
     pub(crate) crypto: VecDeque<frame::Crypto>,
     pub(crate) new_cids: Vec<IssuedCid>,
     pub(crate) retire_cids: Vec<u64>,
@@ -286,7 +288,7 @@ impl Default for Retransmits {
             max_bi_stream_id: false,
             reset_stream: Vec::new(),
             stop_sending: Vec::new(),
-            max_stream_data: HashSet::new(),
+            max_stream_data: FxHashSet::default(),
             crypto: VecDeque::new(),
             new_cids: Vec::new(),
             retire_cids: Vec::new(),

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -1,10 +1,11 @@
 use std::{
-    collections::{binary_heap::PeekMut, hash_map, BinaryHeap, HashMap, VecDeque},
+    collections::{binary_heap::PeekMut, hash_map, BinaryHeap, VecDeque},
     convert::TryFrom,
     mem,
 };
 
 use bytes::BufMut;
+use fxhash::FxHashMap;
 use tracing::{debug, trace};
 
 use super::{
@@ -22,8 +23,8 @@ use crate::{
 pub struct StreamsState {
     pub(super) side: Side,
     // Set of streams that are currently open, or could be immediately opened by the peer
-    pub(super) send: HashMap<StreamId, Send>,
-    pub(super) recv: HashMap<StreamId, Recv>,
+    pub(super) send: FxHashMap<StreamId, Send>,
+    pub(super) recv: FxHashMap<StreamId, Recv>,
     pub(super) next: [u64; 2],
     // Locally initiated
     pub(super) max: [u64; 2],
@@ -88,8 +89,8 @@ impl StreamsState {
     ) -> Self {
         let mut this = Self {
             side,
-            send: HashMap::default(),
-            recv: HashMap::default(),
+            send: FxHashMap::default(),
+            recv: FxHashMap::default(),
             next: [0, 0],
             max: [0, 0],
             max_remote: [max_remote_bi.into(), max_remote_uni.into()],

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -31,6 +31,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 bytes = "1"
 futures = "0.3.8"
+fxhash = "0.2.1"
 libc = "0.2.69"
 mio = { version = "0.7.7", features = ["net"] }
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.7" }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     fmt,
     future::Future,
     mem,
@@ -15,6 +14,7 @@ use futures::{
     channel::{mpsc, oneshot},
     FutureExt, StreamExt,
 };
+use fxhash::FxHashMap;
 use proto::{ConnectionError, ConnectionHandle, ConnectionStats, Dir, StreamEvent, StreamId};
 use thiserror::Error;
 use tokio::time::{sleep_until, Instant as TokioInstant, Sleep};
@@ -708,15 +708,15 @@ where
             timer_deadline: None,
             conn_events,
             endpoint_events,
-            blocked_writers: HashMap::new(),
-            blocked_readers: HashMap::new(),
+            blocked_writers: FxHashMap::default(),
+            blocked_readers: FxHashMap::default(),
             uni_opening: Broadcast::new(),
             bi_opening: Broadcast::new(),
             incoming_uni_streams_reader: None,
             incoming_bi_streams_reader: None,
             datagram_reader: None,
-            finishing: HashMap::new(),
-            stopped: HashMap::new(),
+            finishing: FxHashMap::default(),
+            stopped: FxHashMap::default(),
             error: None,
             ref_count: 0,
         })))
@@ -780,15 +780,15 @@ where
     timer_deadline: Option<TokioInstant>,
     conn_events: mpsc::UnboundedReceiver<ConnectionEvent>,
     endpoint_events: mpsc::UnboundedSender<(ConnectionHandle, EndpointEvent)>,
-    pub(crate) blocked_writers: HashMap<StreamId, Waker>,
-    pub(crate) blocked_readers: HashMap<StreamId, Waker>,
+    pub(crate) blocked_writers: FxHashMap<StreamId, Waker>,
+    pub(crate) blocked_readers: FxHashMap<StreamId, Waker>,
     uni_opening: Broadcast,
     bi_opening: Broadcast,
     incoming_uni_streams_reader: Option<Waker>,
     incoming_bi_streams_reader: Option<Waker>,
     datagram_reader: Option<Waker>,
-    pub(crate) finishing: HashMap<StreamId, oneshot::Sender<Option<WriteError>>>,
-    pub(crate) stopped: HashMap<StreamId, Waker>,
+    pub(crate) finishing: FxHashMap<StreamId, oneshot::Sender<Option<WriteError>>>,
+    pub(crate) stopped: FxHashMap<StreamId, Waker>,
     /// Always set to Some before the connection becomes drained
     pub(crate) error: Option<ConnectionError>,
     /// Number of live handles that can be used to initiate or handle I/O; excludes the driver

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::VecDeque,
     future::Future,
     io,
     io::IoSliceMut,
@@ -14,6 +14,7 @@ use std::{
 
 use bytes::Bytes;
 use futures::{channel::mpsc, StreamExt};
+use fxhash::FxHashMap;
 use proto::{self as proto, generic::ClientConfig, ConnectError, ConnectionHandle, DatagramEvent};
 
 use crate::{
@@ -389,7 +390,7 @@ where
 #[derive(Debug)]
 struct ConnectionSet {
     /// Senders for communicating with the endpoint's connections
-    senders: HashMap<ConnectionHandle, mpsc::UnboundedSender<ConnectionEvent>>,
+    senders: FxHashMap<ConnectionHandle, mpsc::UnboundedSender<ConnectionEvent>>,
     /// Stored to give out clones to new ConnectionInners
     sender: mpsc::UnboundedSender<(ConnectionHandle, EndpointEvent)>,
     /// Set if the endpoint has been manually closed
@@ -493,7 +494,7 @@ where
             incoming_reader: None,
             driver: None,
             connections: ConnectionSet {
-                senders: HashMap::new(),
+                senders: FxHashMap::default(),
                 sender,
                 close: None,
             },


### PR DESCRIPTION
Rusts default HashMap and HashSet use siphash as a hash method to protect again malicious input. The downside of siphash is that it is slightly more expensive than a more primitive mechanism. The siphash operations currently show up in quinn flamegraphs - even if they only act on 8byte input data like Stream IDs.

The security properties of siphash are not really required in the context of quic, where the hashmaps are used with 2 key types:
- Stream IDs: The valid range for those is predetermined by the maximum concurrent stream setting. The peer can't pick from a bigger range in order to get more hashes into the same bucket. Besides this, the risk of resource exhaustion via purely creating more requests/streams is already much higher than exhaustion of the pure maps.
- Connection IDs: Connection IDs which are inserted into tracking data structures are created locally. The peer has no control over them.

Perf implications: This removes a couple of 0.2% CPU time instances in https://gist.githubusercontent.com/Matthias247/47dc290dde72e2e2f581a114234e8382/raw/c7afb63f0eeae4d3c7f8429d54eb6cdeb47df7f3/8x_gso.svg, which add up to around 1.2%

The impact in the bulk application is hard to measure, but but it might be somewhere in the 1% range.

Some runs without:
```
Sent 10737418240 bytes on 1 streams in 18.98s (539.53 MiB/s)
Sent 10737418240 bytes on 1 streams in 18.92s (541.30 MiB/s)
Sent 10737418240 bytes on 1 streams in 18.80s (544.77 MiB/s)
```

Some runs with the change:
```
Sent 10737418240 bytes on 1 streams in 18.75s (546.18 MiB/s)
Sent 10737418240 bytes on 1 streams in 18.54s (552.32 MiB/s)
```