### PR TITLE
Fix stream leak on stop after finish

### DIFF
--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -382,7 +382,7 @@ impl StreamsState {
                 Some(x) => x,
                 None => continue,
             };
-            if !rs.is_receiving() {
+            if !rs.receiving_unknown_size() {
                 continue;
             }
             retransmits.get_or_create().max_stream_data.insert(id);

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -1089,4 +1089,30 @@ mod tests {
         assert_eq!(meta[1].id, id_mid);
         assert_eq!(meta[2].id, id_low);
     }
+
+    #[test]
+    fn stop_finished() {
+        let mut client = make(Side::Client);
+        let id = StreamId::new(Side::Server, Dir::Uni, 0);
+        // Server finishes stream
+        let _ = client
+            .received(
+                frame::Stream {
+                    id,
+                    offset: 0,
+                    fin: true,
+                    data: Bytes::from_static(&[0; 32]),
+                },
+                32,
+            )
+            .unwrap();
+        let mut pending = Retransmits::default();
+        let mut stream = RecvStream {
+            id,
+            state: &mut client,
+            pending: &mut pending,
+        };
+        stream.stop(0u32.into()).unwrap();
+        assert!(client.recv.get_mut(&id).is_none(), "stream is freed");
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/quinn-rs/quinn/issues/1061. This will deadlock connections after the maximum concurrent number of streams is reached, so we should probably backport to 0.7.