### PR TITLE
Re-export `ConfigError`

### DIFF
--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -60,8 +60,9 @@ mod recv_stream;
 mod send_stream;
 
 pub use proto::{
-    crypto, ApplicationClose, Certificate, CertificateChain, Chunk, ConnectError, ConnectionClose,
-    ConnectionError, ParseError, PrivateKey, StreamId, Transmit, TransportConfig, VarInt,
+    crypto, ApplicationClose, Certificate, CertificateChain, Chunk, ConfigError, ConnectError,
+    ConnectionClose, ConnectionError, ParseError, PrivateKey, StreamId, Transmit, TransportConfig,
+    VarInt,
 };
 
 pub use crate::builders::EndpointError;


### PR DESCRIPTION
Specifically `TransportConfig::max_concurrent_bidi_streams` and `TransportConfig::max_concurrent_uni_streams` return `quinn_proto::ConfigError`.

This prevents consumers of `quinn` having to bring in `quinn-proto` just to use `ConfigError`, for example in their custom error type.