### PR TITLE
Remove link to QUIC protocol page

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -6,4 +6,3 @@
     - [Certificate Configuration](quinn/certificate.md)
     - [Connection Setup](quinn/set-up-connection.md)
     - [Data Transfer](quinn/data-transfer.md)
-- [The QUIC protocol](quic.md)


### PR DESCRIPTION
This one is already mentioned under 'QUIC introduction'.