### PR TITLE
Print perf_client RPS in floating point format

### DIFF
--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -453,8 +453,8 @@ impl Stats {
 
         println!("Overall stats:");
         println!(
-            "RPS: {} ({} requests in {:4.2?})",
-            rps as usize, self.requests, dt,
+            "RPS: {:.2} ({} requests in {:4.2?})",
+            rps, self.requests, dt,
         );
         println!(
             "Success rate: {:4.2}%",


### PR DESCRIPTION
For large requests and high latency connections the number
showed 0 most of the time which isn't too helpful.