### PR TITLE
Backport "Replace deprecated collections::Bound with ops::Bound" to 0.7

### DIFF
--- a/quinn-proto/src/range_set.rs
+++ b/quinn-proto/src/range_set.rs
@@ -1,11 +1,11 @@
 use std::{
     cmp,
     cmp::Ordering,
-    collections::{
-        btree_map, BTreeMap,
+    collections::{btree_map, BTreeMap},
+    ops::{
         Bound::{Excluded, Included},
+        Range,
     },
-    ops::Range,
 };
 
 /// A set of u64 values optimized for long runs and random insert/delete/contains


### PR DESCRIPTION
(cherry picked from commit ab61ef89f534e0c9ce82379c0b954591e5f2d99a)