### PR TITLE
Lazily initialize Endpoint::default_client_config

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -34,6 +34,7 @@ futures = "0.3.8"
 fxhash = "0.2.1"
 libc = "0.2.69"
 mio = { version = "0.7.7", features = ["net"] }
+once_cell = "1.7.2"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.7" }
 rustls = { version = "0.19", features = ["quic"], optional = true }
 socket2 = "0.3"

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -1,5 +1,6 @@
 use std::{io, net::SocketAddr, sync::Arc};
 
+use once_cell::sync::OnceCell;
 use proto::{
     generic::{ClientConfig, EndpointConfig, ServerConfig},
     ConnectionIdGenerator,
@@ -82,7 +83,12 @@ where
         Ok((
             Endpoint {
                 inner: rc.clone(),
-                default_client_config: self.default_client_config.unwrap_or_default(),
+                // If a default client config hasn't been specified explicitly, leave the OnceCell
+                // empty so `Endpoint` can initialize it iff needed.
+                default_client_config: self
+                    .default_client_config
+                    .map(OnceCell::from)
+                    .unwrap_or_default(),
             },
             Incoming::new(rc),
         ))


### PR DESCRIPTION
Pure servers never need this. once_cell is already a transitive dep, and is expected to eventually land in std, so it's free to add.

Fixes #1079.

I realized after writing this that a perhaps more natural fix for pure servers wasting time on certificate loading is to disable the `native-certs` feature, so I'm not sure this is needed. Still, this is a small change, so worth considering. Thoughts?