### PR TITLE
Chunks fixes

### DIFF
--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -9,10 +9,9 @@ use std::{
 use fxhash::FxHashSet;
 
 use super::assembler::Assembler;
-use super::streams::ShouldTransmit;
 use crate::{
-    crypto, crypto::Keys, frame, packet::SpaceId, range_set::RangeSet, shared::IssuedCid, Dir,
-    StreamId, VarInt,
+    crypto, crypto::Keys, frame, packet::SpaceId, range_set::RangeSet, shared::IssuedCid, StreamId,
+    VarInt,
 };
 
 pub(crate) struct PacketSpace<S>
@@ -245,27 +244,6 @@ pub struct Retransmits {
 }
 
 impl Retransmits {
-    pub(crate) fn post_read(
-        &mut self,
-        id: StreamId,
-        max_data: ShouldTransmit,
-        max_stream_data: ShouldTransmit,
-        max_dirty: bool,
-    ) {
-        if max_data.should_transmit() {
-            self.max_data = true;
-        }
-        if max_stream_data.should_transmit() {
-            self.max_stream_data.insert(id);
-        }
-        if max_dirty {
-            match id.dir() {
-                Dir::Uni => self.max_uni_stream_id = true,
-                Dir::Bi => self.max_bi_stream_id = true,
-            }
-        }
-    }
-
     pub fn is_empty(&self) -> bool {
         !self.max_data
             && !self.max_uni_stream_id

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -309,21 +309,19 @@ impl<'a> Chunks<'a> {
             !drop || matches!(state, ChunksState::Finalized),
             "finalize must be called before drop"
         );
-        let mut should_transmit = match state {
-            ChunksState::Readable(mut rs) => {
-                let (_, max_stream_data) = rs.max_stream_data(self.streams.stream_receive_window);
-                self.pending
-                    .post_read(self.id, ShouldTransmit(false), max_stream_data, false);
-                self.streams.recv.insert(self.id, rs);
-                max_stream_data.0
-            }
-            ChunksState::Finished => false,
-            ChunksState::Reset(_) => true,
-            ChunksState::Finalized => {
-                // Noop on repeated calls
-                return ShouldTransmit(false);
-            }
-        };
+        if let ChunksState::Finalized = state {
+            // Noop on repeated calls
+            return ShouldTransmit(false);
+        }
+
+        let mut should_transmit = matches!(state, ChunksState::Reset(_));
+        if let ChunksState::Readable(mut rs) = state {
+            let (_, max_stream_data) = rs.max_stream_data(self.streams.stream_receive_window);
+            self.pending
+                .post_read(self.id, ShouldTransmit(false), max_stream_data, false);
+            self.streams.recv.insert(self.id, rs);
+            should_transmit |= max_stream_data.0
+        }
 
         // Issue connection-level flow control credit for any data we read regardless of state
         let max_data = self.streams.add_read_credits(self.read);

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -299,7 +299,7 @@ impl<'a> Chunks<'a> {
             return ShouldTransmit(false);
         }
 
-        let mut should_transmit = matches!(state, ChunksState::Reset(_));
+        let mut should_transmit = false;
         // We issue additional stream ID credit iff a remotely-initiated stream stream is finished or reset
         if matches!(state, ChunksState::Finished | ChunksState::Reset(_))
             && self.streams.side != self.id.initiator()

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -308,6 +308,7 @@ impl<'a> Chunks<'a> {
                 Dir::Uni => self.pending.max_uni_stream_id = true,
                 Dir::Bi => self.pending.max_bi_stream_id = true,
             }
+            should_transmit = true;
         }
 
         // If the stream hasn't finished, we may need to issue stream-level flow control credit

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -246,8 +246,8 @@ impl<'a> Chunks<'a> {
                 self.state = ChunksState::Error(e.clone(), st);
                 return Err(e);
             }
-            ChunksState::Finished(st) => {
-                self.state = ChunksState::Finished(st);
+            ChunksState::Finished => {
+                self.state = ChunksState::Finished;
                 return Ok(None);
             }
             ChunksState::Finalized => panic!("must not call next() after finalize()"),
@@ -284,7 +284,7 @@ impl<'a> Chunks<'a> {
                         ShouldTransmit(false),
                         max_streams_dirty,
                     );
-                    self.state = ChunksState::Finished(ShouldTransmit(true));
+                    self.state = ChunksState::Finished;
                     Ok(None)
                 } else {
                     let should_transmit =
@@ -312,7 +312,11 @@ impl<'a> Chunks<'a> {
                 self.streams.recv.insert(self.id, rs);
                 should_transmit
             }
-            ChunksState::Finished(should_transmit) | ChunksState::Error(_, should_transmit) => {
+            ChunksState::Finished => {
+                debug_assert!(!drop);
+                ShouldTransmit(true)
+            }
+            ChunksState::Error(_, should_transmit) => {
                 debug_assert!(!drop);
                 should_transmit
             }
@@ -343,7 +347,7 @@ impl<'a> Drop for Chunks<'a> {
 enum ChunksState {
     Readable(Recv),
     Error(ReadError, ShouldTransmit),
-    Finished(ShouldTransmit),
+    Finished,
     Finalized,
 }
 

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -314,7 +314,10 @@ impl<'a> Chunks<'a> {
             }
             ChunksState::Finished => {
                 debug_assert!(!drop);
-                ShouldTransmit(true)
+                // MAX_DATA may need to be issued, but MAX_STREAM_DATA is pointless
+                let max_data = self.streams.add_read_credits(self.read);
+                self.pending.max_data |= max_data.0;
+                max_data
             }
             ChunksState::Error(_, should_transmit) => {
                 debug_assert!(!drop);

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -304,9 +304,12 @@ impl<'a> Chunks<'a> {
 
     fn finalize_inner(&mut self, drop: bool) -> ShouldTransmit {
         let state = mem::replace(&mut self.state, ChunksState::Finalized);
+        debug_assert!(
+            !drop || matches!(state, ChunksState::Finalized),
+            "finalize must be called before drop"
+        );
         match state {
             ChunksState::Readable(mut rs) => {
-                debug_assert!(!drop);
                 let (_, max_stream_data) = rs.max_stream_data(self.streams.stream_receive_window);
                 let max_data = self.streams.add_read_credits(self.read);
                 self.pending
@@ -315,16 +318,12 @@ impl<'a> Chunks<'a> {
                 ShouldTransmit(max_stream_data.0 | max_data.0)
             }
             ChunksState::Finished => {
-                debug_assert!(!drop);
                 // MAX_DATA may need to be issued, but MAX_STREAM_DATA is pointless
                 let max_data = self.streams.add_read_credits(self.read);
                 self.pending.max_data |= max_data.0;
                 max_data
             }
-            ChunksState::Reset(_) => {
-                debug_assert!(!drop);
-                ShouldTransmit(true)
-            }
+            ChunksState::Reset(_) => ShouldTransmit(true),
             ChunksState::Finalized => ShouldTransmit(false),
         }
     }

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -263,6 +263,7 @@ impl<'a> Chunks<'a> {
         let max_streams_dirty = self.streams.side != self.id.initiator();
         match rs.state {
             RecvState::ResetRecvd { error_code, .. } => {
+                debug_assert_eq!(self.read, 0, "reset streams have empty buffers");
                 self.streams.stream_freed(self.id, StreamHalf::Recv);
                 self.pending.post_read(
                     self.id,
@@ -308,24 +309,27 @@ impl<'a> Chunks<'a> {
             !drop || matches!(state, ChunksState::Finalized),
             "finalize must be called before drop"
         );
-        match state {
+        let mut should_transmit = match state {
             ChunksState::Readable(mut rs) => {
                 let (_, max_stream_data) = rs.max_stream_data(self.streams.stream_receive_window);
-                let max_data = self.streams.add_read_credits(self.read);
                 self.pending
-                    .post_read(self.id, max_data, max_stream_data, false);
+                    .post_read(self.id, ShouldTransmit(false), max_stream_data, false);
                 self.streams.recv.insert(self.id, rs);
-                ShouldTransmit(max_stream_data.0 | max_data.0)
+                max_stream_data.0
             }
-            ChunksState::Finished => {
-                // MAX_DATA may need to be issued, but MAX_STREAM_DATA is pointless
-                let max_data = self.streams.add_read_credits(self.read);
-                self.pending.max_data |= max_data.0;
-                max_data
+            ChunksState::Finished => false,
+            ChunksState::Reset(_) => true,
+            ChunksState::Finalized => {
+                // Noop on repeated calls
+                return ShouldTransmit(false);
             }
-            ChunksState::Reset(_) => ShouldTransmit(true),
-            ChunksState::Finalized => ShouldTransmit(false),
-        }
+        };
+
+        // Issue connection-level flow control credit for any data we read regardless of state
+        let max_data = self.streams.add_read_credits(self.read);
+        self.pending.max_data |= max_data.0;
+        should_transmit |= max_data.0;
+        ShouldTransmit(should_transmit)
     }
 }
 

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -814,7 +814,8 @@ mod tests {
             MESSAGE_SIZE
         );
         assert!(chunks.next(0).unwrap().is_none());
-        let _ = chunks.finalize();
+        let should_transmit = chunks.finalize();
+        assert!(should_transmit.0);
         assert!(pending.max_uni_stream_id);
         assert_eq!(client.local_max_data - initial_max, MESSAGE_SIZE as u64);
     }

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -862,6 +862,22 @@ mod tests {
                 .unwrap(),
             ShouldTransmit(false)
         );
+
+        assert_eq!(client.data_recvd, 4096);
+        assert_eq!(client.local_max_data - initial_max, 4096);
+
+        // Ensure reading after a reset doesn't issue redundant credit
+        let mut recv = RecvStream {
+            id,
+            state: &mut client,
+            pending: &mut pending,
+        };
+        let mut chunks = recv.read(true).unwrap();
+        assert_eq!(
+            chunks.next(1024).unwrap_err(),
+            crate::ReadError::Reset(0u32.into())
+        );
+        let _ = chunks.finalize();
         assert_eq!(client.data_recvd, 4096);
         assert_eq!(client.local_max_data - initial_max, 4096);
     }

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -779,6 +779,47 @@ mod tests {
     }
 
     #[test]
+    fn trivial_flow_control() {
+        let mut client = make(Side::Client);
+        let id = StreamId::new(Side::Server, Dir::Uni, 0);
+        let initial_max = client.local_max_data;
+        const MESSAGE_SIZE: usize = 2048;
+        assert_eq!(
+            client
+                .received(
+                    frame::Stream {
+                        id,
+                        offset: 0,
+                        fin: true,
+                        data: Bytes::from_static(&[0; MESSAGE_SIZE]),
+                    },
+                    2048
+                )
+                .unwrap(),
+            ShouldTransmit(false)
+        );
+        assert_eq!(client.data_recvd, 2048);
+        assert_eq!(client.local_max_data - initial_max, 0);
+
+        let mut pending = Retransmits::default();
+        let mut recv = RecvStream {
+            id,
+            state: &mut client,
+            pending: &mut pending,
+        };
+
+        let mut chunks = recv.read(true).unwrap();
+        assert_eq!(
+            chunks.next(MESSAGE_SIZE).unwrap().unwrap().bytes.len(),
+            MESSAGE_SIZE
+        );
+        assert!(chunks.next(0).unwrap().is_none());
+        let _ = chunks.finalize();
+        assert!(pending.max_uni_stream_id);
+        assert_eq!(client.local_max_data - initial_max, MESSAGE_SIZE as u64);
+    }
+
+    #[test]
     fn reset_flow_control() {
         let mut client = make(Side::Client);
         let id = StreamId::new(Side::Server, Dir::Uni, 0);

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -982,12 +982,14 @@ fn test_flow_control(config: TransportConfig, window_size: usize) {
 
     // Stream reset before read
     let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
+    info!("writing");
     assert_eq!(pair.client_send(client_ch, s).write(&msg), Ok(window_size));
     assert_eq!(
         pair.client_send(client_ch, s).write(&msg[window_size..]),
         Err(WriteError::Blocked)
     );
     pair.drive();
+    info!("resetting");
     pair.client_send(client_ch, s).reset(VarInt(42)).unwrap();
     pair.drive();
 
@@ -1000,6 +1002,7 @@ fn test_flow_control(config: TransportConfig, window_size: usize) {
     let _ = chunks.finalize();
 
     // Happy path
+    info!("writing");
     let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
     assert_eq!(pair.client_send(client_ch, s).write(&msg), Ok(window_size));
     assert_eq!(
@@ -1029,8 +1032,10 @@ fn test_flow_control(config: TransportConfig, window_size: usize) {
     }
     let _ = chunks.finalize();
 
+    info!("finished reading");
     assert_eq!(cursor, window_size);
     pair.drive();
+    info!("writing");
     assert_eq!(pair.client_send(client_ch, s).write(&msg), Ok(window_size));
     assert_eq!(
         pair.client_send(client_ch, s).write(&msg[window_size..]),
@@ -1059,6 +1064,7 @@ fn test_flow_control(config: TransportConfig, window_size: usize) {
     }
     assert_eq!(cursor, window_size);
     let _ = chunks.finalize();
+    info!("finished reading");
 }
 
 #[test]


### PR DESCRIPTION
This should turn into a point release, since the current behavior will cause long-lived connections to become stuck on connection-level flow control.