### PR TITLE
Use an array-based RangeSet for tracking outgoing ACKs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,16 +12,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, beta, 1.46.0]
+        rust: [stable, beta, 1.47.0]
         exclude:
           - os: macos-latest
             rust: beta
           - os: macos-latest
-            rust: 1.46.0
+            rust: 1.47.0
           - os: windows-latest
             rust: beta
           - os: windows-latest
-            rust: 1.46.0
+            rust: 1.47.0
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This library is at [draft 32][current-draft].
 - Application-layer datagrams for small, unreliable messages
 - Future-based async API
 - Experimental HTTP over QUIC
-- The minimum supported Rust version is 1.46.0
+- The minimum supported Rust version is 1.47.0
 
 ## Overview
 

--- a/quinn-proto/src/cid_queue.rs
+++ b/quinn-proto/src/cid_queue.rs
@@ -49,8 +49,6 @@ impl CidQueue {
     }
 
     /// Returns the possibly-empty range of newly retired CIDs
-    // clippy will stop warning in 1.46+, https://github.com/rust-lang/rust-clippy/pull/5692
-    #[allow(clippy::reversed_empty_ranges)]
     pub fn retire_prior_to(&mut self, sequence: u64) -> Range<u64> {
         let n = match sequence.checked_sub(self.offset) {
             None => return 0..0,

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     frame::{Close, Datagram, FrameStruct},
     is_supported_version,
     packet::{Header, LongType, Packet, PartialDecode, SpaceId},
-    range_set::RangeSet,
+    range_set::ArrayRangeSet,
     shared::{
         ConnectionEvent, ConnectionEventInner, ConnectionId, EcnCodepoint, EndpointEvent,
         EndpointEventInner, IssuedCid,
@@ -3138,7 +3138,7 @@ struct ZeroRttCrypto<S: crypto::Session> {
 #[derive(Default)]
 struct SentFrames {
     retransmits: ThinRetransmits,
-    acks: RangeSet,
+    acks: ArrayRangeSet,
     stream_frames: StreamMetaVec,
     requires_padding: bool,
 }

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -10,8 +10,8 @@ use fxhash::FxHashSet;
 
 use super::assembler::Assembler;
 use crate::{
-    crypto, crypto::Keys, frame, packet::SpaceId, range_set::RangeSet, shared::IssuedCid, StreamId,
-    VarInt,
+    crypto, crypto::Keys, frame, packet::SpaceId, range_set::ArrayRangeSet, shared::IssuedCid,
+    StreamId, VarInt,
 };
 
 pub(crate) struct PacketSpace<S>
@@ -26,7 +26,7 @@ where
     /// Data to send
     pub(crate) pending: Retransmits,
     /// Packet numbers to acknowledge
-    pub(crate) pending_acks: RangeSet,
+    pub(crate) pending_acks: ArrayRangeSet,
     /// Set iff we have received a non-ack frame since the last ack-only packet we sent
     pub(crate) permit_ack_only: bool,
 
@@ -79,7 +79,7 @@ where
             rx_packet: 0,
 
             pending: Retransmits::default(),
-            pending_acks: RangeSet::new(),
+            pending_acks: ArrayRangeSet::new(),
             permit_ack_only: false,
 
             next_packet_number: 0,
@@ -217,7 +217,7 @@ pub(crate) struct SentPacket {
     pub(crate) size: u16,
     /// Whether an acknowledgement is expected directly in response to this packet.
     pub(crate) ack_eliciting: bool,
-    pub(crate) acks: RangeSet,
+    pub(crate) acks: ArrayRangeSet,
     /// Data which needs to be retransmitted in case the packet is lost.
     /// The data is boxed to minimize `SentPacket` size for the typical case of
     /// packets only containing ACKs and STREAM frames.

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -8,7 +8,7 @@ use tinyvec::TinyVec;
 
 use crate::{
     coding::{self, BufExt, BufMutExt, UnexpectedEnd},
-    range_set::RangeSet,
+    range_set::ArrayRangeSet,
     shared::{ConnectionId, EcnCodepoint},
     Dir, ResetToken, StreamId, TransportError, TransportErrorCode, VarInt, MAX_CID_SIZE,
     RESET_TOKEN_SIZE,
@@ -342,7 +342,12 @@ impl<'a> IntoIterator for &'a Ack {
 }
 
 impl Ack {
-    pub fn encode<W: BufMut>(delay: u64, ranges: &RangeSet, ecn: Option<&EcnCounts>, buf: &mut W) {
+    pub fn encode<W: BufMut>(
+        delay: u64,
+        ranges: &ArrayRangeSet,
+        ecn: Option<&EcnCounts>,
+        buf: &mut W,
+    ) {
         let mut rest = ranges.iter().rev();
         let first = rest.next().unwrap();
         let largest = first.end - 1;
@@ -849,7 +854,7 @@ mod test {
     #[allow(clippy::range_plus_one)]
     fn ack_coding() {
         const PACKETS: &[u64] = &[1, 2, 3, 5, 10, 11, 14];
-        let mut ranges = RangeSet::new();
+        let mut ranges = ArrayRangeSet::new();
         for &packet in PACKETS {
             ranges.insert(packet..packet + 1);
         }

--- a/quinn-proto/src/range_set.rs
+++ b/quinn-proto/src/range_set.rs
@@ -56,7 +56,7 @@ impl RangeSet {
     }
 
     pub fn insert(&mut self, mut x: Range<u64>) -> bool {
-        if x.end == 0 || x.start == x.end {
+        if x.is_empty() {
             return false;
         }
         if let Some((start, end)) = self.pred(x.start) {
@@ -99,6 +99,10 @@ impl RangeSet {
     }
 
     pub fn remove(&mut self, x: Range<u64>) -> bool {
+        if x.is_empty() {
+            return false;
+        }
+
         let before = match self.pred(x.start) {
             Some((start, end)) if end > x.start => {
                 self.0.remove(&start);

--- a/quinn-proto/src/range_set/array_range_set.rs
+++ b/quinn-proto/src/range_set/array_range_set.rs
@@ -1,0 +1,209 @@
+use std::ops::Range;
+
+use tinyvec::TinyVec;
+
+/// A set of u64 values optimized for long runs and random insert/delete/contains
+///
+/// `ArrayRangeSet` uses an array representation, where each array entry represents
+/// a range.
+///
+/// The array-based RangeSet provides 2 benefits:
+/// - There exists an inline representation, which avoids the need of heap
+///   allocating ACK ranges for SentFrames for small ranges.
+/// - Iterating over ranges should usually be faster since there is only
+///   a single cache-friendly contiguous range.
+///
+/// `ArrayRangeSet` is especially useful for tracking ACK ranges where the amount
+/// of ranges is usually very low (since ACK numbers are in consecutive fashion
+/// unless reordering or packet loss occur).
+#[derive(Debug, Default)]
+pub struct ArrayRangeSet(TinyVec<[Range<u64>; ARRAY_RANGE_SET_INLINE_CAPACITY]>);
+
+/// The capacity of elements directly stored in [`ArrayRangeSet`]
+///
+/// An inline capacity of 2 is chosen to keep `SentFrame` below 128 bytes.
+const ARRAY_RANGE_SET_INLINE_CAPACITY: usize = 2;
+
+impl Clone for ArrayRangeSet {
+    fn clone(&self) -> Self {
+        // tinyvec keeps the heap representation after clones.
+        // We rather prefer the inline representation for clones if possible,
+        // since clones (e.g. for storage in `SentFrames`) are rarely mutated
+        if self.0.is_inline() || self.0.len() > ARRAY_RANGE_SET_INLINE_CAPACITY {
+            return Self(self.0.clone());
+        }
+
+        let mut vec = TinyVec::new();
+        vec.extend_from_slice(self.0.as_slice());
+        Self(vec)
+    }
+}
+
+impl ArrayRangeSet {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = Range<u64>> + '_ {
+        self.0.iter().cloned()
+    }
+
+    pub fn elts(&self) -> impl Iterator<Item = u64> + '_ {
+        self.iter().flatten()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn contains(&self, x: u64) -> bool {
+        for range in self.0.iter() {
+            if range.start > x {
+                // We only get here if there was no prior range that contained x
+                return false;
+            } else if range.contains(&x) {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn subtract(&mut self, other: &ArrayRangeSet) {
+        // TODO: This can potentially be made more efficient, since the we know
+        // individual ranges are not overlapping, and the next range must start
+        // after the last one finished
+        for range in &other.0 {
+            self.remove(range.clone());
+        }
+    }
+
+    pub fn insert_one(&mut self, x: u64) -> bool {
+        self.insert(x..x + 1)
+    }
+
+    pub fn insert(&mut self, x: Range<u64>) -> bool {
+        let mut result = false;
+
+        if x.is_empty() {
+            // Don't try to deal with ranges where x.end <= x.start
+            return false;
+        }
+
+        let mut idx = 0;
+        while idx != self.0.len() {
+            let range = &mut self.0[idx];
+
+            if range.start > x.end {
+                // The range is fully before this range and therefore not extensible.
+                // Add a new range to the left
+                self.0.insert(idx, x);
+                return true;
+            } else if range.start > x.start {
+                // The new range starts before this range but overlaps.
+                // Extend the current range to the left
+                // Note that we don't have to merge a potential left range, since
+                // this case would have been captured by merging the right range
+                // in the previous loop iteration
+                result = true;
+                range.start = x.start;
+            }
+
+            // At this point we have handled all parts of the new range which
+            // are in front of the current range. Now we handle everything from
+            // the start of the current range
+
+            if x.end <= range.end {
+                // Fully contained
+                return result;
+            } else if x.start <= range.end {
+                // Extend the current range to the end of the new range.
+                // Since it's not contained it must be bigger
+                range.end = x.end;
+
+                // Merge all follow-up ranges which overlap
+                while idx != self.0.len() - 1 {
+                    let curr = self.0[idx].clone();
+                    let next = self.0[idx + 1].clone();
+                    if curr.end >= next.start {
+                        self.0[idx].end = next.end.max(curr.end);
+                        self.0.remove(idx + 1);
+                    } else {
+                        break;
+                    }
+                }
+
+                return true;
+            }
+
+            idx += 1;
+        }
+
+        // Insert a range at the end
+        self.0.push(x);
+        true
+    }
+
+    pub fn remove(&mut self, x: Range<u64>) -> bool {
+        let mut result = false;
+
+        if x.is_empty() {
+            // Don't try to deal with ranges where x.end <= x.start
+            return false;
+        }
+
+        let mut idx = 0;
+        while idx != self.0.len() && x.start != x.end {
+            let range = self.0[idx].clone();
+
+            if x.end <= range.start {
+                // The range is fully before this range
+                return result;
+            } else if x.start >= range.end {
+                // The range is fully after this range
+                idx += 1;
+                continue;
+            }
+
+            // The range overlaps with this range
+            result = true;
+
+            let left = range.start..x.start;
+            let right = x.end..range.end;
+            if left.is_empty() && right.is_empty() {
+                self.0.remove(idx);
+            } else if left.is_empty() {
+                self.0[idx] = right;
+                idx += 1;
+            } else if right.is_empty() {
+                self.0[idx] = left;
+                idx += 1;
+            } else {
+                self.0[idx] = right;
+                self.0.insert(idx, left);
+                idx += 2;
+            }
+        }
+
+        result
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn pop_min(&mut self) -> Option<Range<u64>> {
+        if !self.0.is_empty() {
+            Some(self.0.remove(0))
+        } else {
+            None
+        }
+    }
+
+    pub fn min(&self) -> Option<u64> {
+        self.iter().next().map(|x| x.start)
+    }
+
+    pub fn max(&self) -> Option<u64> {
+        self.iter().rev().next().map(|x| x.end - 1)
+    }
+}

--- a/quinn-proto/src/range_set/btree_range_set.rs
+++ b/quinn-proto/src/range_set/btree_range_set.rs
@@ -317,98 +317,12 @@ impl Drop for Replace<'_> {
     }
 }
 
+/// This module contains tests which only apply for this `RangeSet` implementation
+///
+/// Tests which apply for all implementations can be found in the `tests.rs` module
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn merge_and_split() {
-        let mut set = RangeSet::new();
-        assert!(set.insert(0..2));
-        assert!(set.insert(2..4));
-        assert!(!set.insert(1..3));
-        assert_eq!(set.len(), 1);
-        assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 2, 3]);
-        assert!(!set.contains(4));
-        assert!(set.remove(2..3));
-        assert_eq!(set.len(), 2);
-        assert!(!set.contains(2));
-        assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 3]);
-    }
-
-    #[test]
-    fn double_merge_exact() {
-        let mut set = RangeSet::new();
-        assert!(set.insert(0..2));
-        assert!(set.insert(4..6));
-        assert_eq!(set.len(), 2);
-        assert!(set.insert(2..4));
-        assert_eq!(set.len(), 1);
-        assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 2, 3, 4, 5]);
-    }
-
-    #[test]
-    fn single_merge_low() {
-        let mut set = RangeSet::new();
-        assert!(set.insert(0..2));
-        assert!(set.insert(4..6));
-        assert_eq!(set.len(), 2);
-        assert!(set.insert(2..3));
-        assert_eq!(set.len(), 2);
-        assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 2, 4, 5]);
-    }
-
-    #[test]
-    fn single_merge_high() {
-        let mut set = RangeSet::new();
-        assert!(set.insert(0..2));
-        assert!(set.insert(4..6));
-        assert_eq!(set.len(), 2);
-        assert!(set.insert(3..4));
-        assert_eq!(set.len(), 2);
-        assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 3, 4, 5]);
-    }
-
-    #[test]
-    fn double_merge_wide() {
-        let mut set = RangeSet::new();
-        assert!(set.insert(0..2));
-        assert!(set.insert(4..6));
-        assert_eq!(set.len(), 2);
-        assert!(set.insert(1..5));
-        assert_eq!(set.len(), 1);
-        assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 2, 3, 4, 5]);
-    }
-
-    #[test]
-    fn double_remove() {
-        let mut set = RangeSet::new();
-        assert!(set.insert(0..2));
-        assert!(set.insert(4..6));
-        assert!(set.remove(1..5));
-        assert_eq!(set.len(), 2);
-        assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 5]);
-    }
-
-    #[test]
-    fn insert_multiple() {
-        let mut set = RangeSet::new();
-        assert!(set.insert(0..1));
-        assert!(set.insert(2..3));
-        assert!(set.insert(4..5));
-        assert!(set.insert(0..5));
-        assert_eq!(set.len(), 1);
-    }
-
-    #[test]
-    fn remove_multiple() {
-        let mut set = RangeSet::new();
-        assert!(set.insert(0..1));
-        assert!(set.insert(2..3));
-        assert!(set.insert(4..5));
-        assert!(set.remove(0..5));
-        assert!(set.is_empty());
-    }
 
     #[test]
     fn replace_contained() {
@@ -462,16 +376,5 @@ mod tests {
         assert_eq!(set.replace(0..2).collect::<Vec<_>>(), &[]);
         assert_eq!(set.len(), 1);
         assert_eq!(set.peek_min().unwrap(), 0..4);
-    }
-
-    #[test]
-    fn skip_empty_ranges() {
-        let mut set = RangeSet::new();
-        assert!(!set.insert(2..2));
-        assert_eq!(set.len(), 0);
-        assert!(!set.insert(4..4));
-        assert_eq!(set.len(), 0);
-        assert!(!set.insert(0..0));
-        assert_eq!(set.len(), 0);
     }
 }

--- a/quinn-proto/src/range_set/mod.rs
+++ b/quinn-proto/src/range_set/mod.rs
@@ -1,0 +1,7 @@
+mod array_range_set;
+mod btree_range_set;
+#[cfg(test)]
+mod tests;
+
+pub use array_range_set::ArrayRangeSet;
+pub use btree_range_set::RangeSet;

--- a/quinn-proto/src/range_set/tests.rs
+++ b/quinn-proto/src/range_set/tests.rs
@@ -1,0 +1,253 @@
+use std::ops::Range;
+
+use super::*;
+
+macro_rules! common_set_tests {
+    ($set_name:ident, $set_type:ident) => {
+        mod $set_name {
+            use super::*;
+
+            #[test]
+            fn merge_and_split() {
+                let mut set = $set_type::new();
+                assert!(set.insert(0..2));
+                assert!(set.insert(2..4));
+                assert!(!set.insert(1..3));
+                assert_eq!(set.len(), 1);
+                assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 2, 3]);
+                assert!(!set.contains(4));
+                assert!(set.remove(2..3));
+                assert_eq!(set.len(), 2);
+                assert!(!set.contains(2));
+                assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 3]);
+            }
+
+            #[test]
+            fn double_merge_exact() {
+                let mut set = $set_type::new();
+                assert!(set.insert(0..2));
+                assert!(set.insert(4..6));
+                assert_eq!(set.len(), 2);
+                assert!(set.insert(2..4));
+                assert_eq!(set.len(), 1);
+                assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 2, 3, 4, 5]);
+            }
+
+            #[test]
+            fn single_merge_low() {
+                let mut set = $set_type::new();
+                assert!(set.insert(0..2));
+                assert!(set.insert(4..6));
+                assert_eq!(set.len(), 2);
+                assert!(set.insert(2..3));
+                assert_eq!(set.len(), 2);
+                assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 2, 4, 5]);
+            }
+
+            #[test]
+            fn single_merge_high() {
+                let mut set = $set_type::new();
+                assert!(set.insert(0..2));
+                assert!(set.insert(4..6));
+                assert_eq!(set.len(), 2);
+                assert!(set.insert(3..4));
+                assert_eq!(set.len(), 2);
+                assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 3, 4, 5]);
+            }
+
+            #[test]
+            fn double_merge_wide() {
+                let mut set = $set_type::new();
+                assert!(set.insert(0..2));
+                assert!(set.insert(4..6));
+                assert_eq!(set.len(), 2);
+                assert!(set.insert(1..5));
+                assert_eq!(set.len(), 1);
+                assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 2, 3, 4, 5]);
+            }
+
+            #[test]
+            fn double_remove() {
+                let mut set = $set_type::new();
+                assert!(set.insert(0..2));
+                assert!(set.insert(4..6));
+                assert!(set.remove(1..5));
+                assert_eq!(set.len(), 2);
+                assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 5]);
+            }
+
+            #[test]
+            fn insert_multiple() {
+                let mut set = $set_type::new();
+                assert!(set.insert(0..1));
+                assert!(set.insert(2..3));
+                assert!(set.insert(4..5));
+                assert!(set.insert(0..5));
+                assert_eq!(set.len(), 1);
+            }
+
+            #[test]
+            fn remove_multiple() {
+                let mut set = $set_type::new();
+                assert!(set.insert(0..1));
+                assert!(set.insert(2..3));
+                assert!(set.insert(4..5));
+                assert!(set.remove(0..5));
+                assert!(set.is_empty());
+            }
+
+            #[test]
+            fn double_insert() {
+                let mut set = $set_type::new();
+                assert!(set.insert(0..2));
+                assert!(!set.insert(0..2));
+                assert!(set.insert(2..4));
+                assert!(!set.insert(2..4));
+                assert!(!set.insert(0..4));
+                assert!(!set.insert(1..2));
+                assert!(!set.insert(1..3));
+                assert!(!set.insert(1..4));
+                assert_eq!(set.len(), 1);
+            }
+
+            #[test]
+            fn skip_empty_ranges() {
+                let mut set = $set_type::new();
+                assert!(!set.insert(2..2));
+                assert_eq!(set.len(), 0);
+                assert!(!set.insert(4..4));
+                assert_eq!(set.len(), 0);
+                assert!(!set.insert(0..0));
+                assert_eq!(set.len(), 0);
+            }
+
+            #[test]
+            fn compare_insert_to_reference() {
+                const MAX_RANGE: u64 = 50;
+
+                for start in 0..=MAX_RANGE {
+                    for end in 0..=MAX_RANGE {
+                        println!("insert({}..{})", start, end);
+                        let (mut set, mut reference) = create_initial_sets(MAX_RANGE);
+                        assert_eq!(set.insert(start..end), reference.insert(start..end));
+                        assert_sets_equal(&set, &reference);
+                    }
+                }
+            }
+
+            #[test]
+            fn compare_remove_to_reference() {
+                const MAX_RANGE: u64 = 50;
+
+                for start in 0..=MAX_RANGE {
+                    for end in 0..=MAX_RANGE {
+                        println!("remove({}..{})", start, end);
+                        let (mut set, mut reference) = create_initial_sets(MAX_RANGE);
+                        assert_eq!(set.remove(start..end), reference.remove(start..end));
+                        assert_sets_equal(&set, &reference);
+                    }
+                }
+            }
+
+            fn create_initial_sets(max_range: u64) -> ($set_type, RefRangeSet) {
+                let mut set = $set_type::new();
+                let mut reference = RefRangeSet::new(max_range as usize);
+                assert_sets_equal(&set, &reference);
+
+                assert_eq!(set.insert(2..6), reference.insert(2..6));
+                assert_eq!(set.insert(10..14), reference.insert(10..14));
+                assert_eq!(set.insert(14..14), reference.insert(14..14));
+                assert_eq!(set.insert(18..19), reference.insert(18..19));
+                assert_eq!(set.insert(20..21), reference.insert(20..21));
+                assert_eq!(set.insert(22..24), reference.insert(22..24));
+                assert_eq!(set.insert(26..30), reference.insert(26..30));
+                assert_eq!(set.insert(34..38), reference.insert(34..38));
+                assert_eq!(set.insert(42..44), reference.insert(42..44));
+
+                assert_sets_equal(&set, &reference);
+
+                (set, reference)
+            }
+
+            fn assert_sets_equal(set: &$set_type, reference: &RefRangeSet) {
+                assert_eq!(set.len(), reference.len());
+                assert_eq!(set.is_empty(), reference.is_empty());
+                assert_eq!(set.elts().collect::<Vec<_>>()[..], reference.elts()[..]);
+            }
+        }
+    };
+}
+
+common_set_tests!(range_set, RangeSet);
+common_set_tests!(array_range_set, ArrayRangeSet);
+
+/// A very simple reference implementation of a RangeSet
+struct RefRangeSet {
+    data: Vec<bool>,
+}
+
+impl RefRangeSet {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            data: vec![false; capacity],
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        let mut last = false;
+        let mut count = 0;
+
+        for v in self.data.iter() {
+            if !last && *v {
+                count += 1;
+            }
+            last = *v;
+        }
+
+        count
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn insert(&mut self, x: Range<u64>) -> bool {
+        let mut result = false;
+
+        assert!(x.end <= self.data.len() as u64);
+
+        for i in x {
+            let i = i as usize;
+            if !self.data[i] {
+                result = true;
+                self.data[i] = true;
+            }
+        }
+
+        result
+    }
+
+    pub fn remove(&mut self, x: Range<u64>) -> bool {
+        let mut result = false;
+
+        assert!(x.end <= self.data.len() as u64);
+
+        for i in x {
+            let i = i as usize;
+            if self.data[i] {
+                result = true;
+                self.data[i] = false;
+            }
+        }
+
+        result
+    }
+
+    pub fn elts(&self) -> Vec<u64> {
+        self.data
+            .iter()
+            .enumerate()
+            .filter_map(|(i, e)| if *e { Some(i as u64) } else { None })
+            .collect()
+    }
+}


### PR DESCRIPTION
This change introduces a second `RangeSet` type which is based on a
linear array/vector instead of a tree. For the purpose of tracking
ACK ranges we usually should not have a big number of disjoint ranges,
since those would only occur with severe fragmentation. Therefore the
main benefit of a tree which is able to find ranges in the middle is
rarely used.

The array-based RangeSet provides 2 benefits:
- There exists an inline representation, which avoids the need of heap
  allocating ACK ranges for `SentFrames` for small ranges.
- Iterating over ranges should usually be faster since there is only
  a single cache-friendly contiguous range.

Performance differences:

With the `BTreeMap` based `RangeSet`:
```
Sent 1073741824 bytes on 1 streams in 1.90s (538.89 MiB/s)
```

With the `TinyVec` based `RangeSet`:
```
Sent 1073741824 bytes on 1 streams in 1.78s (574.73 MiB/s)
```