### PR TITLE
Fix overflow in `crypto_buffer_size`

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1529,8 +1529,8 @@ where
         }
 
         let space = &mut self.spaces[space];
-        let max = space.crypto_stream.bytes_read() + self.config.crypto_buffer_size as u64;
-        if end > max {
+        let max = end.saturating_sub(space.crypto_stream.bytes_read());
+        if max > self.config.crypto_buffer_size as u64 {
             return Err(TransportError::CRYPTO_BUFFER_EXCEEDED(""));
         }
 


### PR DESCRIPTION
Fix overflowing when doing things like `TransportConfig::crypto_buffer_size(usize::MAX)`.