### PR TITLE
Backport flow control fixes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,16 +12,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, beta, 1.45.0]
+        rust: [stable, beta, 1.46.0]
         exclude:
           - os: macos-latest
             rust: beta
           - os: macos-latest
-            rust: 1.45.0
+            rust: 1.46.0
           - os: windows-latest
             rust: beta
           - os: windows-latest
-            rust: 1.45.0
+            rust: 1.46.0
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,26 +50,11 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-          components: rustfmt, clippy
+          components: rustfmt
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
-      - uses: actions-rs/cargo@v1
-        if: always()
-        with:
-          command: clippy
-          args: --all-targets -- -D warnings
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: clippy
-      - name: lint fuzz
-        run: |
-          cd fuzz
-          cargo clippy -- -D warnings
 
   audit:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This library is at [draft 32][current-draft].
 - Application-layer datagrams for small, unreliable messages
 - Future-based async API
 - Experimental HTTP over QUIC
-- The minimum supported Rust version is 1.45.0
+- The minimum supported Rust version is 1.46.0
 
 ## Overview
 

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::mutex_atomic, clippy::eval_order_dependence)]
+#![type_length_limit = "2121396"]
 
 use std::{
     env,

--- a/interop/src/qif.rs
+++ b/interop/src/qif.rs
@@ -1,3 +1,5 @@
+#![type_length_limit = "2121396"]
+
 /// Offline QPACK interop test tool
 ///
 /// QIF - Quic Interop File

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -1,3 +1,5 @@
+#![type_length_limit = "2121396"]
+
 use std::{
     ascii, cmp,
     ffi::OsStr,

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -7,10 +7,9 @@ use std::{
 };
 
 use super::assembler::Assembler;
-use super::streams::ShouldTransmit;
 use crate::{
-    crypto, crypto::Keys, frame, packet::SpaceId, range_set::RangeSet, shared::IssuedCid, Dir,
-    StreamId, VarInt,
+    crypto, crypto::Keys, frame, packet::SpaceId, range_set::RangeSet, shared::IssuedCid, StreamId,
+    VarInt,
 };
 
 pub(crate) struct PacketSpace<S>
@@ -243,27 +242,6 @@ pub struct Retransmits {
 }
 
 impl Retransmits {
-    pub(crate) fn post_read(
-        &mut self,
-        id: StreamId,
-        max_data: ShouldTransmit,
-        max_stream_data: ShouldTransmit,
-        max_dirty: bool,
-    ) {
-        if max_data.should_transmit() {
-            self.max_data = true;
-        }
-        if max_stream_data.should_transmit() {
-            self.max_stream_data.insert(id);
-        }
-        if max_dirty {
-            match id.dir() {
-                Dir::Uni => self.max_uni_stream_id = true,
-                Dir::Bi => self.max_bi_stream_id = true,
-            }
-        }
-    }
-
     pub fn is_empty(&self) -> bool {
         !self.max_data
             && !self.max_uni_stream_id

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -242,9 +242,9 @@ impl<'a> Chunks<'a> {
     pub fn next(&mut self, max_length: usize) -> Result<Option<Chunk>, ReadError> {
         let mut rs = match mem::replace(&mut self.state, ChunksState::Finalized) {
             ChunksState::Readable(rs) => rs,
-            ChunksState::Error(e, st) => {
-                self.state = ChunksState::Error(e.clone(), st);
-                return Err(e);
+            ChunksState::Reset(error_code) => {
+                self.state = ChunksState::Reset(error_code);
+                return Err(ReadError::Reset(error_code));
             }
             ChunksState::Finished => {
                 self.state = ChunksState::Finished;
@@ -265,9 +265,8 @@ impl<'a> Chunks<'a> {
                 self.pending
                     .post_read(self.id, ShouldTransmit(false), ShouldTransmit(false), true);
 
-                let err = ReadError::Reset(error_code);
-                self.state = ChunksState::Error(err.clone(), ShouldTransmit(true));
-                Err(err)
+                self.state = ChunksState::Reset(error_code);
+                Err(ReadError::Reset(error_code))
             }
             RecvState::Recv { size } => {
                 if size == Some(rs.end) && rs.assembler.bytes_read() == rs.end {
@@ -281,10 +280,11 @@ impl<'a> Chunks<'a> {
                     self.state = ChunksState::Finished;
                     Ok(None)
                 } else {
-                    let should_transmit =
-                        Self::done(&mut rs, self.read, self.id, self.streams, self.pending);
-                    self.state = ChunksState::Error(ReadError::Blocked, should_transmit);
-                    self.streams.recv.insert(self.id, rs);
+                    // We don't need a distinct `ChunksState` variant for a blocked stream because
+                    // retrying a read harmlessly re-traces our steps back to returning
+                    // `Err(Blocked)` again. The buffers can't refill and the stream's own state
+                    // can't change so long as this `Chunks` exists.
+                    self.state = ChunksState::Readable(rs);
                     Err(ReadError::Blocked)
                 }
             }
@@ -313,9 +313,9 @@ impl<'a> Chunks<'a> {
                 self.pending.max_data |= max_data.0;
                 max_data
             }
-            ChunksState::Error(_, should_transmit) => {
+            ChunksState::Reset(_) => {
                 debug_assert!(!drop);
-                should_transmit
+                ShouldTransmit(true)
             }
             ChunksState::Finalized => ShouldTransmit(false),
         }
@@ -343,7 +343,7 @@ impl<'a> Drop for Chunks<'a> {
 
 enum ChunksState {
     Readable(Recv),
-    Error(ReadError, ShouldTransmit),
+    Reset(VarInt),
     Finished,
     Finalized,
 }

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -299,7 +299,7 @@ impl<'a> Chunks<'a> {
             return ShouldTransmit(false);
         }
 
-        let mut should_transmit = matches!(state, ChunksState::Reset(_));
+        let mut should_transmit = false;
         // We issue additional stream ID credit iff a remotely-initiated stream stream is finished or reset
         if matches!(state, ChunksState::Finished | ChunksState::Reset(_))
             && self.streams.side != self.id.initiator()

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -308,7 +308,10 @@ impl<'a> Chunks<'a> {
             }
             ChunksState::Finished => {
                 debug_assert!(!drop);
-                ShouldTransmit(true)
+                // MAX_DATA may need to be issued, but MAX_STREAM_DATA is pointless
+                let max_data = self.streams.add_read_credits(self.read);
+                self.pending.max_data |= max_data.0;
+                max_data
             }
             ChunksState::Error(_, should_transmit) => {
                 debug_assert!(!drop);

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -301,10 +301,12 @@ impl<'a> Chunks<'a> {
         match state {
             ChunksState::Readable(mut rs) => {
                 debug_assert!(!drop);
-                let should_transmit =
-                    Self::done(&mut rs, self.read, self.id, self.streams, self.pending);
+                let (_, max_stream_data) = rs.max_stream_data(self.streams.stream_receive_window);
+                let max_data = self.streams.add_read_credits(self.read);
+                self.pending
+                    .post_read(self.id, max_data, max_stream_data, false);
                 self.streams.recv.insert(self.id, rs);
-                should_transmit
+                ShouldTransmit(max_stream_data.0 | max_data.0)
             }
             ChunksState::Finished => {
                 debug_assert!(!drop);
@@ -319,19 +321,6 @@ impl<'a> Chunks<'a> {
             }
             ChunksState::Finalized => ShouldTransmit(false),
         }
-    }
-
-    fn done(
-        rs: &mut Recv,
-        read: u64,
-        id: StreamId,
-        streams: &mut StreamsState,
-        pending: &mut Retransmits,
-    ) -> ShouldTransmit {
-        let (_, max_stream_data) = rs.max_stream_data(streams.stream_receive_window);
-        let max_data = streams.add_read_credits(read);
-        pending.post_read(id, max_data, max_stream_data, false);
-        ShouldTransmit(max_stream_data.0 | max_data.0)
     }
 }
 

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -308,6 +308,7 @@ impl<'a> Chunks<'a> {
                 Dir::Uni => self.pending.max_uni_stream_id = true,
                 Dir::Bi => self.pending.max_bi_stream_id = true,
             }
+            should_transmit = true;
         }
 
         // If the stream hasn't finished, we may need to issue stream-level flow control credit

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -246,8 +246,8 @@ impl<'a> Chunks<'a> {
                 self.state = ChunksState::Error(e.clone(), st);
                 return Err(e);
             }
-            ChunksState::Finished(st) => {
-                self.state = ChunksState::Finished(st);
+            ChunksState::Finished => {
+                self.state = ChunksState::Finished;
                 return Ok(None);
             }
             ChunksState::Finalized => panic!("must not call next() after finalize()"),
@@ -278,7 +278,7 @@ impl<'a> Chunks<'a> {
                         ShouldTransmit(false),
                         true,
                     );
-                    self.state = ChunksState::Finished(ShouldTransmit(true));
+                    self.state = ChunksState::Finished;
                     Ok(None)
                 } else {
                     let should_transmit =
@@ -306,7 +306,11 @@ impl<'a> Chunks<'a> {
                 self.streams.recv.insert(self.id, rs);
                 should_transmit
             }
-            ChunksState::Finished(should_transmit) | ChunksState::Error(_, should_transmit) => {
+            ChunksState::Finished => {
+                debug_assert!(!drop);
+                ShouldTransmit(true)
+            }
+            ChunksState::Error(_, should_transmit) => {
                 debug_assert!(!drop);
                 should_transmit
             }
@@ -337,7 +341,7 @@ impl<'a> Drop for Chunks<'a> {
 enum ChunksState {
     Readable(Recv),
     Error(ReadError, ShouldTransmit),
-    Finished(ShouldTransmit),
+    Finished,
     Finalized,
 }
 

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -263,21 +263,12 @@ impl<'a> Chunks<'a> {
             RecvState::ResetRecvd { error_code, .. } => {
                 debug_assert_eq!(self.read, 0, "reset streams have empty buffers");
                 self.streams.stream_freed(self.id, StreamHalf::Recv);
-                self.pending
-                    .post_read(self.id, ShouldTransmit(false), ShouldTransmit(false), true);
-
                 self.state = ChunksState::Reset(error_code);
                 Err(ReadError::Reset(error_code))
             }
             RecvState::Recv { size } => {
                 if size == Some(rs.end) && rs.assembler.bytes_read() == rs.end {
                     self.streams.stream_freed(self.id, StreamHalf::Recv);
-                    self.pending.post_read(
-                        self.id,
-                        ShouldTransmit(false),
-                        ShouldTransmit(false),
-                        true,
-                    );
                     self.state = ChunksState::Finished;
                     Ok(None)
                 } else {
@@ -309,13 +300,21 @@ impl<'a> Chunks<'a> {
         }
 
         let mut should_transmit = matches!(state, ChunksState::Reset(_));
+        let mut max_stream_data = false;
+        let stream_id_issued = matches!(state, ChunksState::Finished | ChunksState::Reset(_))
+            && self.streams.side != self.id.initiator();
         if let ChunksState::Readable(mut rs) = state {
-            let (_, max_stream_data) = rs.max_stream_data(self.streams.stream_receive_window);
-            self.pending
-                .post_read(self.id, ShouldTransmit(false), max_stream_data, false);
+            let (_, msd) = rs.max_stream_data(self.streams.stream_receive_window);
+            max_stream_data |= msd.0;
+            should_transmit |= msd.0;
             self.streams.recv.insert(self.id, rs);
-            should_transmit |= max_stream_data.0
         }
+        self.pending.post_read(
+            self.id,
+            ShouldTransmit(false),
+            ShouldTransmit(max_stream_data),
+            stream_id_issued,
+        );
 
         // Issue connection-level flow control credit for any data we read regardless of state
         let max_data = self.streams.add_read_credits(self.read);

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -813,7 +813,8 @@ mod tests {
             MESSAGE_SIZE
         );
         assert!(chunks.next(0).unwrap().is_none());
-        let _ = chunks.finalize();
+        let should_transmit = chunks.finalize();
+        assert!(should_transmit.0);
         assert!(pending.max_uni_stream_id);
         assert_eq!(client.local_max_data - initial_max, MESSAGE_SIZE as u64);
     }

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -861,6 +861,22 @@ mod tests {
                 .unwrap(),
             ShouldTransmit(false)
         );
+
+        assert_eq!(client.data_recvd, 4096);
+        assert_eq!(client.local_max_data - initial_max, 4096);
+
+        // Ensure reading after a reset doesn't issue redundant credit
+        let mut recv = RecvStream {
+            id,
+            state: &mut client,
+            pending: &mut pending,
+        };
+        let mut chunks = recv.read(true).unwrap();
+        assert_eq!(
+            chunks.next(1024).unwrap_err(),
+            crate::ReadError::Reset(0u32.into())
+        );
+        let _ = chunks.finalize();
         assert_eq!(client.data_recvd, 4096);
         assert_eq!(client.local_max_data - initial_max, 4096);
     }

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -981,12 +981,14 @@ fn test_flow_control(config: TransportConfig, window_size: usize) {
 
     // Stream reset before read
     let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
+    info!("writing");
     assert_eq!(pair.client_send(client_ch, s).write(&msg), Ok(window_size));
     assert_eq!(
         pair.client_send(client_ch, s).write(&msg[window_size..]),
         Err(WriteError::Blocked)
     );
     pair.drive();
+    info!("resetting");
     pair.client_send(client_ch, s).reset(VarInt(42)).unwrap();
     pair.drive();
 
@@ -999,6 +1001,7 @@ fn test_flow_control(config: TransportConfig, window_size: usize) {
     let _ = chunks.finalize();
 
     // Happy path
+    info!("writing");
     let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
     assert_eq!(pair.client_send(client_ch, s).write(&msg), Ok(window_size));
     assert_eq!(
@@ -1028,8 +1031,10 @@ fn test_flow_control(config: TransportConfig, window_size: usize) {
     }
     let _ = chunks.finalize();
 
+    info!("finished reading");
     assert_eq!(cursor, window_size);
     pair.drive();
+    info!("writing");
     assert_eq!(pair.client_send(client_ch, s).write(&msg), Ok(window_size));
     assert_eq!(
         pair.client_send(client_ch, s).write(&msg[window_size..]),
@@ -1058,6 +1063,7 @@ fn test_flow_control(config: TransportConfig, window_size: usize) {
     }
     assert_eq!(cursor, window_size);
     let _ = chunks.finalize();
+    info!("finished reading");
 }
 
 #[test]

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -11,6 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use assert_matches::assert_matches;
 use lazy_static::lazy_static;
 use rustls::KeyLogFile;
 use tracing::{info_span, trace};


### PR DESCRIPTION
Backports changes from https://github.com/quinn-rs/quinn/pull/1087. We could maybe strip this down to just 
a095410a50e5182aa76e8d8c8acacb5baf1b30b4, but the refactoring makes me more confident in correctness and the more minor fixes along the way shouldn't hurt, and if we have to touch this again it'll be easier without divergence.

I'll prepare a point release once this is merged.