### PR TITLE
Improve connection event ordering consistency

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -341,12 +341,12 @@ where
     /// - a call was made to `handle_timeout`
     #[must_use]
     pub fn poll(&mut self) -> Option<Event> {
-        if let Some(event) = self.streams.poll() {
-            return Some(Event::Stream(event));
-        }
-
         if let Some(x) = self.events.pop_front() {
             return Some(x);
+        }
+
+        if let Some(event) = self.streams.poll() {
+            return Some(Event::Stream(event));
         }
 
         if let Some(err) = self.error.take() {


### PR DESCRIPTION
Ensures that 1-RTT stream events are delivered after `Event::Connected`, without interfering with the placement of connection errors at the end of the event stream.

Fixes #1094. Moots #1096.