### PR TITLE
Allow read_handshake to return keys.

### DIFF
--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -80,7 +80,7 @@ pub trait Session: Send + Sized {
     /// to send to the peer.
     ///
     /// On success, returns `true` iff `self.handshake_data()` has been populated.
-    fn read_handshake(&mut self, buf: &[u8]) -> Result<bool, TransportError>;
+    fn read_handshake(&mut self, buf: &[u8]) -> Result<(bool, Option<Keys<Self>>), TransportError>;
 
     /// The peer's QUIC transport parameters
     ///

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -110,7 +110,7 @@ impl crypto::Session for TlsSession {
         }
     }
 
-    fn read_handshake(&mut self, buf: &[u8]) -> Result<bool, TransportError> {
+    fn read_handshake(&mut self, buf: &[u8]) -> Result<(bool, Option<Keys<Self>>), TransportError> {
         self.read_hs(buf).map_err(|e| {
             if let Some(alert) = self.get_alert() {
                 TransportError {
@@ -140,10 +140,10 @@ impl crypto::Session for TlsSession {
                         reason: "ALPN negotiation failed".into(),
                     });
                 }
-                return Ok(true);
+                return Ok((true, None));
             }
         }
-        Ok(false)
+        Ok((false, None))
     }
 
     fn transport_parameters(&self) -> Result<Option<TransportParameters>, TransportError> {


### PR DESCRIPTION
This allows `quinn-noise` to work.