### PR TITLE
Allow overriding supported versions in EndpointConfig.

### DIFF
--- a/fuzz/fuzz_targets/packet.rs
+++ b/fuzz/fuzz_targets/packet.rs
@@ -10,7 +10,7 @@ use proto::{
 
 fuzz_target!(|data: PacketParams| {
     let len = data.buf.len();
-    let supported_versions: Vec<_> = DEFAULT_SUPPORTED_VERSIONS.into_iter().collect();
+    let supported_versions = DEFAULT_SUPPORTED_VERSIONS.to_vec();
     if let Ok(decoded) = PartialDecode::new(data.buf, data.local_cid_len, &supported_versions) {
         match decoded.1 {
             Some(x) => assert_eq!(len, decoded.0.len() + x.len()),

--- a/fuzz/fuzz_targets/packet.rs
+++ b/fuzz/fuzz_targets/packet.rs
@@ -6,7 +6,7 @@ extern crate proto;
 
 fuzz_target!(|data: PacketParams| {
     let len = data.buf.len();
-    if let Ok(decoded) = PartialDecode::new(data.buf, data.local_cid_len) {
+    if let Ok(decoded) = PartialDecode::new(data.buf, data.local_cid_len, proto::DEFAULT_VERSION) {
         match decoded.1 {
             Some(x) => assert_eq!(len, decoded.0.len() + x.len()),
             None => assert_eq!(len, decoded.0.len()),

--- a/fuzz/fuzz_targets/packet.rs
+++ b/fuzz/fuzz_targets/packet.rs
@@ -11,9 +11,7 @@ use proto::{
 fuzz_target!(|data: PacketParams| {
     let len = data.buf.len();
     let supported_versions: Vec<_> = DEFAULT_SUPPORTED_VERSIONS.into_iter().collect();
-    if let Ok(decoded) =
-        PartialDecode::new(data.buf, data.local_cid_len, &supported_versions)
-    {
+    if let Ok(decoded) = PartialDecode::new(data.buf, data.local_cid_len, &supported_versions) {
         match decoded.1 {
             Some(x) => assert_eq!(len, decoded.0.len() + x.len()),
             None => assert_eq!(len, decoded.0.len()),

--- a/fuzz/fuzz_targets/packet.rs
+++ b/fuzz/fuzz_targets/packet.rs
@@ -1,12 +1,18 @@
 #![no_main]
 
-use libfuzzer_sys::fuzz_target;
-use proto::fuzzing::{PacketParams, PartialDecode};
 extern crate proto;
+
+use libfuzzer_sys::fuzz_target;
+use proto::{
+    fuzzing::{PacketParams, PartialDecode},
+    DEFAULT_SUPPORTED_VERSIONS,
+};
 
 fuzz_target!(|data: PacketParams| {
     let len = data.buf.len();
-    if let Ok(decoded) = PartialDecode::new(data.buf, data.local_cid_len, proto::DEFAULT_VERSION) {
+    if let Ok(decoded) =
+        PartialDecode::new(data.buf, data.local_cid_len, DEFAULT_SUPPORTED_VERSIONS)
+    {
         match decoded.1 {
             Some(x) => assert_eq!(len, decoded.0.len() + x.len()),
             None => assert_eq!(len, decoded.0.len()),

--- a/fuzz/fuzz_targets/packet.rs
+++ b/fuzz/fuzz_targets/packet.rs
@@ -10,8 +10,9 @@ use proto::{
 
 fuzz_target!(|data: PacketParams| {
     let len = data.buf.len();
+    let supported_versions: Vec<_> = DEFAULT_SUPPORTED_VERSIONS.into_iter().collect();
     if let Ok(decoded) =
-        PartialDecode::new(data.buf, data.local_cid_len, DEFAULT_SUPPORTED_VERSIONS)
+        PartialDecode::new(data.buf, data.local_cid_len, &supported_versions)
     {
         match decoded.1 {
             Some(x) => assert_eq!(len, decoded.0.len() + x.len()),

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -367,7 +367,7 @@ where
         self.max_udp_payload_size.into()
     }
 
-    /// Override the supported quic versions.
+    /// Override supported QUIC versions
     pub fn supported_versions(
         &mut self,
         supported_versions: Vec<u32>,

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -1,4 +1,6 @@
-use std::{convert::TryInto, fmt, num::TryFromIntError, sync::Arc, time::Duration};
+use std::{
+    convert::TryInto, fmt, num::TryFromIntError, ops::RangeInclusive, sync::Arc, time::Duration,
+};
 
 use rand::RngCore;
 use thiserror::Error;
@@ -9,7 +11,7 @@ use crate::{
     cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator},
     congestion,
     crypto::{self, ClientConfig as _, HandshakeTokenKey as _, HmacKey as _, ServerConfig as _},
-    VarInt, VarIntBoundsExceeded,
+    VarInt, VarIntBoundsExceeded, DEFAULT_VERSION,
 };
 
 /// Parameters governing the core QUIC state machine
@@ -299,6 +301,7 @@ where
     /// Create a cid generator for local cid in Endpoint struct
     pub(crate) connection_id_generator_factory:
         Arc<dyn Fn() -> Box<dyn ConnectionIdGenerator> + Send + Sync>,
+    pub(crate) supported_versions: RangeInclusive<u32>,
 }
 
 impl<S> EndpointConfig<S>
@@ -313,6 +316,7 @@ where
             reset_key: Arc::new(reset_key),
             max_udp_payload_size: 1480u32.into(), // Typical internet MTU minus IPv4 and UDP overhead, rounded up to a multiple of 8
             connection_id_generator_factory: Arc::new(cid_factory),
+            supported_versions: DEFAULT_VERSION,
         }
     }
 
@@ -362,6 +366,12 @@ where
     pub fn get_max_udp_payload_size(&self) -> u64 {
         self.max_udp_payload_size.into()
     }
+
+    /// Override the supported quic versions.
+    pub fn supported_versions(&mut self, supported_versions: RangeInclusive<u32>) -> &mut Self {
+        self.supported_versions = supported_versions;
+        self
+    }
 }
 
 impl<S: crypto::Session> fmt::Debug for EndpointConfig<S> {
@@ -370,6 +380,7 @@ impl<S: crypto::Session> fmt::Debug for EndpointConfig<S> {
             .field("reset_key", &"[ elided ]")
             .field("max_udp_payload_size", &self.max_udp_payload_size)
             .field("cid_generator_factory", &"[ elided ]")
+            .field("supported_versions", &self.supported_versions)
             .finish()
     }
 }
@@ -391,6 +402,7 @@ impl<S: crypto::Session> Clone for EndpointConfig<S> {
             reset_key: self.reset_key.clone(),
             max_udp_payload_size: self.max_udp_payload_size,
             connection_id_generator_factory: self.connection_id_generator_factory.clone(),
+            supported_versions: self.supported_versions.clone(),
         }
     }
 }

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -315,8 +315,8 @@ where
             reset_key: Arc::new(reset_key),
             max_udp_payload_size: 1480u32.into(), // Typical internet MTU minus IPv4 and UDP overhead, rounded up to a multiple of 8
             connection_id_generator_factory: Arc::new(cid_factory),
-            initial_version: *DEFAULT_SUPPORTED_VERSIONS.start(),
-            supported_versions: DEFAULT_SUPPORTED_VERSIONS.into_iter().collect(),
+            initial_version: DEFAULT_SUPPORTED_VERSIONS[0],
+            supported_versions: DEFAULT_SUPPORTED_VERSIONS.to_vec(),
         }
     }
 

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -368,16 +368,17 @@ where
     }
 
     /// Override the supported quic versions.
-    pub fn supported_versions(&mut self, supported_versions: Vec<u32>) -> &mut Self {
+    pub fn supported_versions(
+        &mut self,
+        supported_versions: Vec<u32>,
+        initial_version: u32,
+    ) -> Result<&mut Self, ConfigError> {
+        if !supported_versions.contains(&initial_version) {
+            return Err(ConfigError::OutOfBounds);
+        }
         self.supported_versions = supported_versions;
-        self.initial_version = self.supported_versions[0];
-        self
-    }
-
-    /// Override the initial version.
-    pub fn initial_version(&mut self, initial_version: u32) -> &mut Self {
         self.initial_version = initial_version;
-        self
+        Ok(self)
     }
 }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2092,10 +2092,11 @@ where
                 if self.total_authed_packets > 1 {
                     return Ok(());
                 }
-                if packet.payload.chunks(4).any(|x| {
+                let supported = packet.payload.chunks(4).any(|x| {
                     self.supported_versions
                         .contains(&u32::from_be_bytes(x.try_into().unwrap()))
-                }) {
+                });
+                if supported {
                     return Ok(());
                 }
                 debug!("remote doesn't support our version");

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1,7 +1,7 @@
 use std::{
     cmp,
     collections::{BTreeMap, VecDeque},
-    convert::TryInto,
+    convert::TryFrom,
     fmt, io, mem,
     net::{IpAddr, SocketAddr},
     sync::Arc,
@@ -2090,7 +2090,10 @@ where
                 let supported = packet
                     .payload
                     .chunks(4)
-                    .any(|x| self.version == u32::from_be_bytes(x.try_into().unwrap()));
+                    .any(|x| match <[u8; 4]>::try_from(x) {
+                        Ok(version) => self.version == u32::from_be_bytes(version),
+                        Err(_) => false,
+                    });
                 if supported {
                     return Ok(());
                 }

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -38,6 +38,7 @@ impl PacketBuilder {
         datagram_start: usize,
         ack_eliciting: bool,
         conn: &mut Connection<S>,
+        version: u32,
     ) -> Option<PacketBuilder> {
         // Initiate key update if we're approaching the confidentiality limit
         let confidentiality_limit = conn.spaces[space_id]
@@ -94,12 +95,14 @@ impl PacketBuilder {
                 src_cid: conn.handshake_cid,
                 dst_cid: conn.rem_cids.active(),
                 number,
+                version,
             },
             SpaceId::Handshake => Header::Long {
                 ty: LongType::Handshake,
                 src_cid: conn.handshake_cid,
                 dst_cid: conn.rem_cids.active(),
                 number,
+                version,
             },
             SpaceId::Initial => Header::Initial {
                 src_cid: conn.handshake_cid,
@@ -109,6 +112,7 @@ impl PacketBuilder {
                     _ => Bytes::new(),
                 },
                 number,
+                version,
             },
         };
         let partial_encode = header.encode(buffer);

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -481,7 +481,6 @@ where
             tls,
             self.local_cid_generator.as_ref(),
             now,
-            self.config.supported_versions.clone(),
             self.config.initial_version,
         );
         let id = self.connections.insert(ConnectionMeta {

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -169,7 +169,7 @@ where
         let (first_decode, remaining) = match PartialDecode::new(
             data,
             self.local_cid_generator.cid_len(),
-            self.config.supported_versions.clone(),
+            &self.config.supported_versions,
         ) {
             Ok(x) => x,
             Err(PacketDecodeError::UnsupportedVersion {
@@ -196,7 +196,7 @@ where
                 } else {
                     buf.write::<u32>(0x0a1a_2a4a);
                 }
-                buf.write(*self.config.supported_versions.start()); // supported version
+                buf.write(self.config.initial_version); // supported version
                 self.transmits.push_back(Transmit {
                     destination: remote,
                     ecn: None,
@@ -482,6 +482,7 @@ where
             self.local_cid_generator.as_ref(),
             now,
             self.config.supported_versions.clone(),
+            self.config.initial_version,
         );
         let id = self.connections.insert(ConnectionMeta {
             init_cid,
@@ -596,7 +597,7 @@ where
                 let header = Header::Retry {
                     src_cid: temp_loc_cid,
                     dst_cid: src_cid,
-                    version: *self.config.supported_versions.start(),
+                    version: self.config.initial_version,
                 };
 
                 let mut buf = Vec::new();
@@ -689,7 +690,7 @@ where
             src_cid: *local_id,
             number,
             token: Bytes::new(),
-            version: *self.config.supported_versions.start(),
+            version: self.config.initial_version,
         };
 
         let mut buf = Vec::<u8>::new();

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -149,7 +149,8 @@ pub mod fuzzing {
 }
 
 /// The QUIC protocol version implemented.
-pub const DEFAULT_SUPPORTED_VERSIONS: std::ops::RangeInclusive<u32> = 0xff00_001d..=0xff00_0020;
+pub const DEFAULT_SUPPORTED_VERSIONS: &[u32] =
+    &[0xff00_001d, 0xff00_001e, 0xff00_001f, 0xff00_0020];
 
 /// Whether an endpoint was the initiator of a connection
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -19,7 +19,6 @@
 #![allow(clippy::too_many_arguments)]
 
 use std::{
-    convert::TryInto,
     fmt,
     net::{IpAddr, SocketAddr},
     ops,
@@ -150,12 +149,7 @@ pub mod fuzzing {
 }
 
 /// The QUIC protocol version implemented
-const VERSION: std::ops::RangeInclusive<u32> = 0xff00_001d..=0xff00_0020;
-
-/// Whether a 4-byte slice represents a supported version number
-fn is_supported_version(x: &[u8]) -> bool {
-    VERSION.contains(&u32::from_be_bytes(x.try_into().unwrap()))
-}
+const DEFAULT_VERSION: std::ops::RangeInclusive<u32> = 0xff00_001d..=0xff00_0020;
 
 /// Whether an endpoint was the initiator of a connection
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -148,8 +148,8 @@ pub mod fuzzing {
     }
 }
 
-/// The QUIC protocol version implemented
-pub const DEFAULT_VERSION: std::ops::RangeInclusive<u32> = 0xff00_001d..=0xff00_0020;
+/// The QUIC protocol version implemented.
+pub const DEFAULT_SUPPORTED_VERSIONS: std::ops::RangeInclusive<u32> = 0xff00_001d..=0xff00_0020;
 
 /// Whether an endpoint was the initiator of a connection
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -149,7 +149,7 @@ pub mod fuzzing {
 }
 
 /// The QUIC protocol version implemented
-const DEFAULT_VERSION: std::ops::RangeInclusive<u32> = 0xff00_001d..=0xff00_0020;
+pub const DEFAULT_VERSION: std::ops::RangeInclusive<u32> = 0xff00_001d..=0xff00_0020;
 
 /// Whether an endpoint was the initiator of a connection
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -1,11 +1,16 @@
-use std::{cmp::Ordering, io, ops::Range, str};
+use std::{
+    cmp::Ordering,
+    io,
+    ops::{Range, RangeInclusive},
+    str,
+};
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use thiserror::Error;
 
 use crate::{
     coding::{self, BufExt, BufMutExt},
-    crypto, ConnectionId, VERSION,
+    crypto, ConnectionId,
 };
 
 // Due to packet number encryption, it is impossible to fully decode a header
@@ -29,9 +34,10 @@ impl PartialDecode {
     pub fn new(
         bytes: BytesMut,
         local_cid_len: usize,
+        versions: RangeInclusive<u32>,
     ) -> Result<(Self, Option<BytesMut>), PacketDecodeError> {
         let mut buf = io::Cursor::new(bytes);
-        let plain_header = PlainHeader::decode(&mut buf, local_cid_len)?;
+        let plain_header = PlainHeader::decode(&mut buf, local_cid_len, versions)?;
         let dgram_len = buf.get_ref().len();
         let packet_len = plain_header
             .payload_len()
@@ -124,6 +130,7 @@ impl PartialDecode {
                     src_cid,
                     token,
                     number,
+                    version: Default::default(),
                 },
                 header_data,
                 payload: bytes,
@@ -141,8 +148,13 @@ impl PartialDecode {
                 dst_cid,
                 src_cid,
                 number: Self::decrypt_header(&mut buf, header_crypto.unwrap())?,
+                version: Default::default(),
             },
-            Retry { dst_cid, src_cid } => Header::Retry { dst_cid, src_cid },
+            Retry { dst_cid, src_cid } => Header::Retry {
+                dst_cid,
+                src_cid,
+                version: Default::default(),
+            },
             Short { spin, dst_cid, .. } => {
                 let number = Self::decrypt_header(&mut buf, header_crypto.unwrap())?;
                 let key_phase = buf.get_ref()[0] & KEY_PHASE_BIT != 0;
@@ -219,16 +231,19 @@ pub(crate) enum Header {
         src_cid: ConnectionId,
         token: Bytes,
         number: PacketNumber,
+        version: u32,
     },
     Long {
         ty: LongType,
         dst_cid: ConnectionId,
         src_cid: ConnectionId,
         number: PacketNumber,
+        version: u32,
     },
     Retry {
         dst_cid: ConnectionId,
         src_cid: ConnectionId,
+        version: u32,
     },
     Short {
         spin: bool,
@@ -253,9 +268,10 @@ impl Header {
                 ref src_cid,
                 ref token,
                 number,
+                version,
             } => {
                 w.write(u8::from(LongHeaderType::Initial) | number.tag());
-                w.write(*VERSION.start());
+                w.write(version);
                 dst_cid.encode_long(w);
                 src_cid.encode_long(w);
                 w.write_var(token.len() as u64);
@@ -273,9 +289,10 @@ impl Header {
                 ref dst_cid,
                 ref src_cid,
                 number,
+                version,
             } => {
                 w.write(u8::from(LongHeaderType::Standard(ty)) | number.tag());
-                w.write(*VERSION.start());
+                w.write(version);
                 dst_cid.encode_long(w);
                 src_cid.encode_long(w);
                 w.write::<u16>(0); // Placeholder for payload length; see `set_payload_length`
@@ -289,9 +306,10 @@ impl Header {
             Retry {
                 ref dst_cid,
                 ref src_cid,
+                version,
             } => {
                 w.write(u8::from(LongHeaderType::Retry));
-                w.write(*VERSION.start());
+                w.write(version);
                 dst_cid.encode_long(w);
                 src_cid.encode_long(w);
                 PartialEncode {
@@ -504,6 +522,7 @@ impl PlainHeader {
     fn decode(
         buf: &mut io::Cursor<BytesMut>,
         local_cid_len: usize,
+        versions: RangeInclusive<u32>,
     ) -> Result<Self, PacketDecodeError> {
         let first = buf.get::<u8>()?;
         if first & LONG_HEADER_FORM == 0 {
@@ -535,7 +554,7 @@ impl PlainHeader {
                 });
             }
 
-            if !VERSION.contains(&version) {
+            if !versions.contains(&version) {
                 return Err(PacketDecodeError::UnsupportedVersion {
                     src_cid,
                     dst_cid,
@@ -762,6 +781,7 @@ impl SpaceId {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DEFAULT_VERSION;
     use hex_literal::hex;
     use std::io;
 
@@ -814,6 +834,7 @@ mod tests {
             src_cid: ConnectionId::new(&[]),
             dst_cid: dcid,
             token: Bytes::new(),
+            version: *DEFAULT_VERSION.start(),
         };
         let encode = header.encode(&mut buf);
         let header_len = buf.len();
@@ -837,7 +858,9 @@ mod tests {
         );
 
         let server = TlsSession::initial_keys(&dcid, Side::Server);
-        let decode = PartialDecode::new(buf.as_slice().into(), 0).unwrap().0;
+        let decode = PartialDecode::new(buf.as_slice().into(), 0, DEFAULT_VERSION)
+            .unwrap()
+            .0;
         let mut packet = decode.finish(Some(&server.header.remote)).unwrap();
         assert_eq!(
             packet.header_data[..],

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -110,6 +110,7 @@ impl PartialDecode {
             dst_cid,
             src_cid,
             token_pos,
+            version,
             ..
         } = plain_header
         {
@@ -125,7 +126,7 @@ impl PartialDecode {
                     src_cid,
                     token,
                     number,
-                    version: Default::default(),
+                    version,
                 },
                 header_data,
                 payload: bytes,

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -844,7 +844,7 @@ mod tests {
             src_cid: ConnectionId::new(&[]),
             dst_cid: dcid,
             token: Bytes::new(),
-            version: *DEFAULT_SUPPORTED_VERSIONS.start(),
+            version: DEFAULT_SUPPORTED_VERSIONS[0],
         };
         let encode = header.encode(&mut buf);
         let header_len = buf.len();
@@ -868,7 +868,7 @@ mod tests {
         );
 
         let server = TlsSession::initial_keys(&dcid, Side::Server);
-        let supported_versions: Vec<_> = DEFAULT_SUPPORTED_VERSIONS.into_iter().collect();
+        let supported_versions = DEFAULT_SUPPORTED_VERSIONS.to_vec();
         let decode = PartialDecode::new(buf.as_slice().into(), 0, &supported_versions)
             .unwrap()
             .0;

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -137,18 +137,23 @@ impl PartialDecode {
                 ty,
                 dst_cid,
                 src_cid,
+                version,
                 ..
             } => Header::Long {
                 ty,
                 dst_cid,
                 src_cid,
                 number: Self::decrypt_header(&mut buf, header_crypto.unwrap())?,
-                version: Default::default(),
+                version,
             },
-            Retry { dst_cid, src_cid } => Header::Retry {
+            Retry {
                 dst_cid,
                 src_cid,
-                version: Default::default(),
+                version,
+            } => Header::Retry {
+                dst_cid,
+                src_cid,
+                version,
             },
             Short { spin, dst_cid, .. } => {
                 let number = Self::decrypt_header(&mut buf, header_crypto.unwrap())?;
@@ -471,16 +476,19 @@ pub(crate) enum PlainHeader {
         src_cid: ConnectionId,
         token_pos: Range<usize>,
         len: u64,
+        version: u32,
     },
     Long {
         ty: LongType,
         dst_cid: ConnectionId,
         src_cid: ConnectionId,
         len: u64,
+        version: u32,
     },
     Retry {
         dst_cid: ConnectionId,
         src_cid: ConnectionId,
+        version: u32,
     },
     Short {
         first: u8,
@@ -569,14 +577,20 @@ impl PlainHeader {
                         src_cid,
                         token_pos: token_start..token_start + token_len,
                         len,
+                        version,
                     })
                 }
-                LongHeaderType::Retry => Ok(PlainHeader::Retry { dst_cid, src_cid }),
+                LongHeaderType::Retry => Ok(PlainHeader::Retry {
+                    dst_cid,
+                    src_cid,
+                    version,
+                }),
                 LongHeaderType::Standard(ty) => Ok(PlainHeader::Long {
                     ty,
                     dst_cid,
                     src_cid,
                     len: buf.get_var()?,
+                    version,
                 }),
             }
         }

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+    convert::TryInto,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
     time::{Duration, Instant},
@@ -40,7 +41,9 @@ fn version_negotiate_server() {
     if let Some(Transmit { contents, .. }) = io {
         assert_ne!(contents[0] & 0x80, 0);
         assert_eq!(&contents[1..15], hex!("00000000 04 00000000 04 00000000"));
-        assert!(contents[15..].chunks(4).any(is_supported_version));
+        assert!(contents[15..]
+            .chunks(4)
+            .any(|x| { DEFAULT_VERSION.contains(&u32::from_be_bytes(x.try_into().unwrap())) }));
     }
     assert_matches!(server.poll_transmit(), None);
 }

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -41,9 +41,9 @@ fn version_negotiate_server() {
     if let Some(Transmit { contents, .. }) = io {
         assert_ne!(contents[0] & 0x80, 0);
         assert_eq!(&contents[1..15], hex!("00000000 04 00000000 04 00000000"));
-        assert!(contents[15..]
-            .chunks(4)
-            .any(|x| { DEFAULT_VERSION.contains(&u32::from_be_bytes(x.try_into().unwrap())) }));
+        assert!(contents[15..].chunks(4).any(|x| {
+            DEFAULT_SUPPORTED_VERSIONS.contains(&u32::from_be_bytes(x.try_into().unwrap()))
+        }));
     }
     assert_matches!(server.poll_transmit(), None);
 }


### PR DESCRIPTION
Allows configuring the supported versions in `EndpointConfig`.

Closes #719 