### PR TITLE
Add generic connection support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,93 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1614513358,
+        "narHash": "sha256-LakhOx3S1dRjnh0b5Dg3mbZyH0ToC9I8Y2wKSkBaTzU=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5466c5bbece17adaab2d82fae80b46e807611bf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1620252427,
+        "narHash": "sha256-U1Q5QceuT4chJTJ1UOt7bZOn9Y2o5/7w27RISjqXoQw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d3ba49889a76539ea0f7d7285b203e7f81326ded",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1617325113,
+        "narHash": "sha256-GksR0nvGxfZ79T91UUtWjjccxazv6Yh/MvEJ82v1Xmw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "54c1e44240d8a527a8f4892608c4bce5440c3ecb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "utils": "utils"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1620268871,
+        "narHash": "sha256-eRj/gJIH6v41dVIoXhxLwikXRfoixfTT0wTulSgpqjk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a5441c5e42695b591f8d958e56bb6b4c3e8bfd5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1619345332,
+        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "quinn";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, rust-overlay, utils, ... }:
+    utils.lib.eachSystem (utils.lib.defaultSystems) (system: rec {
+      # `nix develop`
+      devShell = with import nixpkgs {
+        system = "${system}";
+        overlays = [ rust-overlay.overlay ];
+      };
+        mkShell {
+          nativeBuildInputs = [
+            # write rustfmt first to ensure we are using nightly rustfmt
+            rust-bin.nightly."2021-01-01".rustfmt
+            (rust-bin.stable.latest.default.override {
+              extensions = [ "rust-src" ];
+              targets = [ "x86_64-unknown-linux-musl" ];
+            })
+            rust-analyzer
+
+            binutils-unwrapped
+            cargo-cache
+          ];
+        };
+    });
+}

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -91,7 +91,7 @@ where
         EndpointError: From<<U as TryInto<T>>::Error>,
     {
         let socket = socket.try_into()?;
-        let addr = socket.local_ip_addr().map_err(EndpointError::Socket)?;
+        let addr = socket.local_addr().map_err(EndpointError::Socket)?;
         let rc = EndpointRef::new(
             socket,
             proto::generic::Endpoint::new(Arc::new(self.config), self.server_config.map(Arc::new)),

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -89,11 +89,12 @@ pub mod generic {
 
 /// Traits and implementations for underlying connection on which QUIC packets transmit.
 pub mod transport {
+    use crate::platform::SocketCapabilities;
     pub use crate::platform::{RecvMeta, UdpSocket};
     use proto::Transmit;
     use std::{
         io::{IoSliceMut, Result},
-        net::{IpAddr, SocketAddr},
+        net::SocketAddr,
         task::{Context, Poll},
     };
 
@@ -110,13 +111,15 @@ pub mod transport {
             meta: &mut [RecvMeta],
         ) -> Poll<Result<usize>>;
 
-        /// The socket address of the local endpoint, return `Unsupported`[`std::io::ErrorKind::Unsupported`]
+        /// The socket address of the local endpoint, return an arbitrary port with the IP address
         /// if the connection doesn't support socket address (e.g. ICMP)
         fn local_addr(&self) -> Result<SocketAddr>;
 
-        /// The IP address of the local endpoint.
-        fn local_ip_addr(&self) -> Result<IpAddr> {
-            self.local_addr().and_then(|x| Ok(x.ip()))
+        /// Returns the platforms (UDP) socket capabilities. Default to 1 for max_gso_segments.
+        fn caps() -> SocketCapabilities {
+            SocketCapabilities {
+                max_gso_segments: 1,
+            }
         }
     }
 }
@@ -139,21 +142,21 @@ mod rustls_impls {
     pub type ServerConfigBuilder = generic::ServerConfigBuilder<TlsSession>;
 
     /// A `Connecting` using rustls for the cryptography protocol
-    pub type Connecting = generic::Connecting<TlsSession>;
+    pub type Connecting = generic::Connecting<TlsSession, UdpSocket>;
     /// A `Connection` using rustls for the cryptography protocol
-    pub type Connection = generic::Connection<TlsSession>;
+    pub type Connection = generic::Connection<TlsSession, UdpSocket>;
     /// A `Datagrams` using rustls for the cryptography protocol
-    pub type Datagrams = generic::Datagrams<TlsSession>;
+    pub type Datagrams = generic::Datagrams<TlsSession, UdpSocket>;
     /// An `IncomingBiStreams` using rustls for the cryptography protocol
-    pub type IncomingBiStreams = generic::IncomingBiStreams<TlsSession>;
+    pub type IncomingBiStreams = generic::IncomingBiStreams<TlsSession, UdpSocket>;
     /// An `IncomingUniStreams` using rustls for the cryptography protocol
-    pub type IncomingUniStreams = generic::IncomingUniStreams<TlsSession>;
+    pub type IncomingUniStreams = generic::IncomingUniStreams<TlsSession, UdpSocket>;
     /// A `NewConnection` using rustls for the cryptography protocol
-    pub type NewConnection = generic::NewConnection<TlsSession>;
+    pub type NewConnection = generic::NewConnection<TlsSession, UdpSocket>;
     /// An `OpenBi` using rustls for the cryptography protocol
-    pub type OpenBi = generic::OpenBi<TlsSession>;
+    pub type OpenBi = generic::OpenBi<TlsSession, UdpSocket>;
     /// An `OpenUni` using rustls for the cryptography protocol
-    pub type OpenUni = generic::OpenUni<TlsSession>;
+    pub type OpenUni = generic::OpenUni<TlsSession, UdpSocket>;
 
     /// An `Endpoint` using rustls for the cryptography protocol and UDP socket for underlying connection.
     pub type Endpoint = generic::Endpoint<TlsSession, UdpSocket>;
@@ -161,15 +164,15 @@ mod rustls_impls {
     pub type Incoming = generic::Incoming<TlsSession, UdpSocket>;
 
     /// A `Read` using rustls for the cryptography protocol
-    pub type Read<'a> = generic::Read<'a, TlsSession>;
+    pub type Read<'a> = generic::Read<'a, TlsSession, UdpSocket>;
     /// A `ReadExact` using rustls for the cryptography protocol
-    pub type ReadExact<'a> = generic::ReadExact<'a, TlsSession>;
+    pub type ReadExact<'a> = generic::ReadExact<'a, TlsSession, UdpSocket>;
     /// A `ReadToEnd` using rustls for the cryptography protocol
-    pub type ReadToEnd = generic::ReadToEnd<TlsSession>;
+    pub type ReadToEnd = generic::ReadToEnd<TlsSession, UdpSocket>;
     /// A `RecvStream` using rustls for the cryptography protocol
-    pub type RecvStream = generic::RecvStream<TlsSession>;
+    pub type RecvStream = generic::RecvStream<TlsSession, UdpSocket>;
     /// A `SendStream` using rustls for the cryptography protocol
-    pub type SendStream = generic::SendStream<TlsSession>;
+    pub type SendStream = generic::SendStream<TlsSession, UdpSocket>;
 }
 
 #[cfg(feature = "rustls")]

--- a/quinn/src/platform/fallback.rs
+++ b/quinn/src/platform/fallback.rs
@@ -82,11 +82,4 @@ impl Socket for UdpSocket {
     }
 }
 
-/// Returns the platforms UDP socket capabilities
-pub fn caps() -> super::UdpCapabilities {
-    super::UdpCapabilities {
-        max_gso_segments: 1,
-    }
-}
-
 pub const BATCH_SIZE: usize = 1;

--- a/quinn/src/platform/mod.rs
+++ b/quinn/src/platform/mod.rs
@@ -19,11 +19,6 @@ mod imp;
 
 pub use imp::UdpSocket;
 
-/// Returns the platforms UDP socket capabilities
-pub fn caps() -> UdpCapabilities {
-    imp::caps()
-}
-
 /// Number of UDP packets to send/receive at a time
 pub const BATCH_SIZE: usize = imp::BATCH_SIZE;
 
@@ -33,9 +28,9 @@ pub trait UdpExt {
     fn recv_ext(&self, bufs: &mut [IoSliceMut<'_>], meta: &mut [RecvMeta]) -> io::Result<usize>;
 }
 
-/// The capabilities a UDP socket suppports on a certain platform
+/// The capabilities a (UDP) socket suppports on a certain platform
 #[derive(Debug, Clone, Copy)]
-pub struct UdpCapabilities {
+pub struct SocketCapabilities {
     /// The maximum amount of segments which can be transmitted if a platform
     /// supports Generic Send Offload (GSO).
     /// This is 1 if the platform doesn't support GSO.

--- a/quinn/src/platform/mod.rs
+++ b/quinn/src/platform/mod.rs
@@ -42,10 +42,14 @@ pub struct UdpCapabilities {
     pub max_gso_segments: usize,
 }
 
+/// Meta information regarding the received buffer
 #[derive(Debug, Copy, Clone)]
 pub struct RecvMeta {
+    /// The remote address where the buffer came from
     pub addr: SocketAddr,
+    /// The length of the buffer
     pub len: usize,
+    /// The ECN bit
     pub ecn: Option<EcnCodepoint>,
     /// The destination IP address which was encoded in this datagram
     pub dst_ip: Option<IpAddr>,

--- a/quinn/src/platform/unix.rs
+++ b/quinn/src/platform/unix.rs
@@ -16,7 +16,7 @@ use tokio::io::unix::AsyncFd;
 
 use crate::transport::Socket;
 
-use super::{cmsg, RecvMeta, UdpCapabilities};
+use super::{cmsg, RecvMeta, SocketCapabilities};
 
 #[cfg(target_os = "freebsd")]
 type IpTosTy = libc::c_uchar;
@@ -76,6 +76,10 @@ impl Socket for UdpSocket {
 
     fn local_addr(&self) -> io::Result<SocketAddr> {
         self.io.get_ref().local_addr()
+    }
+
+    fn caps() -> SocketCapabilities {
+        caps()
     }
 }
 
@@ -339,8 +343,7 @@ fn recv(
     Ok(1)
 }
 
-/// Returns the platforms UDP socket capabilities
-pub fn caps() -> UdpCapabilities {
+pub fn caps() -> SocketCapabilities {
     *CAPABILITIES
 }
 
@@ -543,8 +546,8 @@ mod gso {
 }
 
 lazy_static! {
-    static ref CAPABILITIES: UdpCapabilities = {
-        UdpCapabilities {
+    static ref CAPABILITIES: SocketCapabilities = {
+        SocketCapabilities {
             max_gso_segments: gso::max_gso_segments(),
         }
     };

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2018"
+# merge_imports=true
+report_fixme="Always"


### PR DESCRIPTION
This PR adds:
1. Nix flake which is used to create a reproducible developing environment (can be cherry-picked out if not appropriate)
2. Generic connection abstraction (i.e. support modify the raw packets before sending, support other connections like ICMP).

Though the connection is defined to be UDP per IETF draft, this PR still adds flexibility to users who want to somehow use other connection types and take the well-built foundation  of the `quinn`, but not do all the works starting from `quinn-proto`.

This is a breaking change, but the change is minimal (all current API callings are working, except the return type of `rebind` has been changed).