### PR TITLE
Ack frame `Debug` implementation

### DIFF
--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -1,5 +1,6 @@
 use std::{
-    fmt, io, mem,
+    fmt::{self, Write},
+    io, mem,
     ops::{Range, RangeInclusive},
 };
 
@@ -324,12 +325,34 @@ impl ApplicationClose {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Ack {
     pub largest: u64,
     pub delay: u64,
     pub additional: Bytes,
     pub ecn: Option<EcnCounts>,
+}
+
+impl fmt::Debug for Ack {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut ranges = "[".to_string();
+        let mut first = true;
+        for range in self.iter() {
+            if !first {
+                ranges.push(',');
+            }
+            write!(ranges, "{:?}", range).unwrap();
+            first = false;
+        }
+        ranges.push(']');
+
+        f.debug_struct("Ack")
+            .field("largest", &self.largest)
+            .field("delay", &self.delay)
+            .field("ecn", &self.ecn)
+            .field("ranges", &ranges)
+            .finish()
+    }
 }
 
 impl<'a> IntoIterator for &'a Ack {


### PR DESCRIPTION
This adds a manual `Debug` implementation for Ack frames, to make them understandable
in logs.

Old:
```
got frame Ack(Ack { largest: 11, delay: 0, additional: b"\x02", ecn: None })
```

New:
```
got frame Ack(Ack { largest: 9, delay: 0, ecn: None, ranges: "[8..=9]" }
```