### PR TITLE
Avoid allocations for CIDs

### DIFF
--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -538,7 +538,7 @@ impl PlainHeader {
             Ok(PlainHeader::Short {
                 first,
                 spin,
-                dst_cid: ConnectionId::new(&buf.copy_to_bytes(local_cid_len)),
+                dst_cid: ConnectionId::from_buf(buf, local_cid_len),
             })
         } else {
             let version = buf.get::<u32>()?;

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -431,7 +431,7 @@ fn decode_cid(len: usize, value: &mut Option<ConnectionId>, r: &mut impl Buf) ->
         return Err(Error::Malformed);
     }
 
-    *value = Some(ConnectionId::new(&r.copy_to_bytes(len)));
+    *value = Some(ConnectionId::from_buf(r, len));
     Ok(())
 }
 


### PR DESCRIPTION
When reading CIDs from packets the current code makes some short-lived
allocations due to the use of `copy_to_bytes`, which allocate for 1.5% of
CPU samples. This change avoids this.

**Before:**
```
Sent 1073741824 bytes on 1 streams in 1.72s (594.74 MiB/s)
```

**After:**
```
Sent 1073741824 bytes on 1 streams in 1.70s (602.78 MiB/s)
```