### PR TITLE
Print connection statistics in perf client and server

### DIFF
--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -51,6 +51,9 @@ struct Opt {
     /// Specify the local socket address
     #[structopt(long)]
     local_addr: Option<SocketAddr>,
+    /// Whether to print connection statistics
+    #[structopt(long)]
+    conn_stats: bool,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -162,6 +165,9 @@ async fn run(opt: Opt) -> Result<()> {
             {
                 let guard = stats.lock().unwrap();
                 guard.print();
+                if opt.conn_stats {
+                    println!("{:?}\n", connection.stats());
+                }
             }
         }
     };


### PR DESCRIPTION
This adds the `--conn-stats` flag to both CLI tools, which will print
the connection statistics together with other data every 2s.