### PR TITLE
quinn: only depend on rt-multi-thread as a dev-dependency

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -40,7 +40,7 @@ rustls = { version = "0.19", features = ["quic"], optional = true }
 socket2 = "0.4"
 thiserror = "1.0.21"
 tracing = "0.1.10"
-tokio = { version = "1.0.1", features = ["net", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1.0.1", features = ["net", "rt", "time"] }
 webpki = { version = "0.21", optional = true }
 
 [target.'cfg(unix)'.dependencies]
@@ -54,7 +54,7 @@ directories-next = "2"
 rand = "0.8"
 rcgen = "0.8"
 structopt = "0.3.0"
-tokio = { version = "1.0.1", features = ["rt", "time", "macros"] }
+tokio = { version = "1.0.1", features = ["rt", "rt-multi-thread", "time", "macros"] }
 tracing-subscriber = { version = "0.2.5", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }
 unwrap = "1.2.1"


### PR DESCRIPTION
Fixes #1136.