### PR TITLE
Add must_use warnings for all Future types

### DIFF
--- a/quinn-h3/src/client.rs
+++ b/quinn-h3/src/client.rs
@@ -289,6 +289,7 @@ impl Client {
 /// established [`Connection`].
 ///
 /// [`Connection`]: struct.Connection.html
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct Connecting {
     connecting: quinn::Connecting,
     settings: Settings,
@@ -510,6 +511,7 @@ impl Drop for Connection {
 
 /// Send a request
 #[pin_project(project = SendRequestProj)]
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct SendRequest<B, D> {
     conn: ConnectionRef,
     request: Option<Request<B>>,
@@ -675,6 +677,7 @@ enum SendRequestState<B, D> {
 /// [`Connection::send_request()`]: struct.Connection.htm#method.send_request
 /// [`Response`]: https://docs.rs/http/*/http/response/index.html
 /// [`RecvBody`]: ../struct.RecvBody.html
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct RecvResponse {
     state: RecvResponseState,
     conn: ConnectionRef,

--- a/quinn-h3/src/connection.rs
+++ b/quinn-h3/src/connection.rs
@@ -29,6 +29,7 @@ use crate::{
     Error, Settings,
 };
 
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub(crate) struct ConnectionDriver(pub(crate) ConnectionRef);
 
 impl Future for ConnectionDriver {

--- a/quinn-h3/src/data.rs
+++ b/quinn-h3/src/data.rs
@@ -33,6 +33,7 @@ use crate::{
 ///
 /// [`Sender::send_response`]: crate::server::Sender::send_response()
 #[pin_project(project = SendDataProj)]
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct SendData<B, P> {
     headers: Option<Header>,
     #[pin]
@@ -249,6 +250,7 @@ where
     }
 }
 
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct RecvData {
     state: RecvDataState,
     conn: ConnectionRef,
@@ -326,6 +328,7 @@ impl Future for RecvData {
     }
 }
 
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct DecodeHeaders {
     frame: Option<HeadersFrame>,
     conn: ConnectionRef,

--- a/quinn-h3/src/server.rs
+++ b/quinn-h3/src/server.rs
@@ -301,6 +301,7 @@ impl Stream for IncomingConnection {
 ///
 /// [`Stream`]: https://docs.rs/futures/*/futures/stream/trait.Stream.html
 /// [`IncomingRequest`]: struct.IncomingRequest.html
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct Connecting {
     connecting: quinn::Connecting,
     settings: Settings,
@@ -564,6 +565,7 @@ impl Stream for IncomingRequest {
 /// [`http_body::Body`]: https://docs.rs/http-body/*/http_body/trait.Body.html
 /// [`RecvBody`]: ../struct.RecvBody.html
 /// [`reject`]: #method.reject
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct RecvRequest {
     conn: ConnectionRef,
     recv: Option<RecvData>,

--- a/quinn-h3/src/streams.rs
+++ b/quinn-h3/src/streams.rs
@@ -45,6 +45,7 @@ impl TryFrom<(StreamType, RecvStream)> for NewUni {
     }
 }
 
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct RecvUni {
     inner: Option<RecvUniInner>,
 }
@@ -106,6 +107,7 @@ impl Future for RecvUni {
 
 pub struct PushStream(FrameStream);
 
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct SendUni {
     ty: StreamType,
     state: SendUniState,

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -31,6 +31,7 @@ use crate::{
 
 /// In-progress connection attempt future
 #[derive(Debug)]
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct Connecting<S>
 where
     S: proto::crypto::Session,
@@ -192,6 +193,7 @@ where
 ///
 /// For clients, the resulting value indicates if 0-RTT was accepted. For servers, the resulting
 /// value is meaningless.
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct ZeroRttAccepted(oneshot::Receiver<bool>);
 
 impl Future for ZeroRttAccepted {
@@ -617,6 +619,7 @@ where
 }
 
 /// A future that will resolve into an opened outgoing unidirectional stream
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct OpenUni<S>
 where
     S: proto::crypto::Session,
@@ -648,6 +651,7 @@ where
 }
 
 /// A future that will resolve into an opened outgoing bidirectional stream
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct OpenBi<S>
 where
     S: proto::crypto::Session,

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -307,6 +307,7 @@ impl<T> From<(Option<T>, Option<proto::ReadError>)> for ReadStatus<T> {
 /// Future produced by [`RecvStream::read_to_end()`].
 ///
 /// [`RecvStream::read_to_end()`]: crate::generic::RecvStream::read_to_end
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct ReadToEnd<S>
 where
     S: proto::crypto::Session,
@@ -466,6 +467,7 @@ impl From<ReadError> for io::Error {
 /// Future produced by [`RecvStream::read()`].
 ///
 /// [`RecvStream::read()`]: crate::generic::RecvStream::read
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct Read<'a, S>
 where
     S: proto::crypto::Session,
@@ -493,6 +495,7 @@ where
 /// Future produced by [`RecvStream::read_exact()`].
 ///
 /// [`RecvStream::read_exact()`]: crate::generic::RecvStream::read_exact
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct ReadExact<'a, S>
 where
     S: proto::crypto::Session,
@@ -535,6 +538,7 @@ pub enum ReadExactError {
 /// Future produced by [`RecvStream::read_chunk()`].
 ///
 /// [`RecvStream::read_chunk()`]: crate::generic::RecvStream::read_chunk
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct ReadChunk<'a, S>
 where
     S: proto::crypto::Session,
@@ -558,6 +562,7 @@ where
 /// Future produced by [`RecvStream::read_chunks()`].
 ///
 /// [`RecvStream::read_chunks()`]: crate::generic::RecvStream::read_chunks
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct ReadChunks<'a, S>
 where
     S: proto::crypto::Session,

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -291,6 +291,7 @@ where
 }
 
 /// Future produced by `SendStream::finish`
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct Finish<'a, S>
 where
     S: proto::crypto::Session,
@@ -310,6 +311,7 @@ where
 }
 
 /// Future produced by `SendStream::stopped`
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct Stopped<'a, S>
 where
     S: proto::crypto::Session,
@@ -331,6 +333,7 @@ where
 /// Future produced by [`SendStream::write()`].
 ///
 /// [`SendStream::write()`]: crate::generic::SendStream::write
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct Write<'a, S>
 where
     S: proto::crypto::Session,
@@ -354,6 +357,7 @@ where
 /// Future produced by [`SendStream::write_all()`].
 ///
 /// [`SendStream::write_all()`]: crate::generic::SendStream::write_all
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct WriteAll<'a, S>
 where
     S: proto::crypto::Session,
@@ -383,6 +387,7 @@ where
 /// Future produced by [`SendStream::write_chunks()`].
 ///
 /// [`SendStream::write_chunks()`]: crate::generic::SendStream::write_chunks
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct WriteChunks<'a, S>
 where
     S: proto::crypto::Session,
@@ -406,6 +411,7 @@ where
 /// Future produced by [`SendStream::write_chunk()`].
 ///
 /// [`SendStream::write_chunk()`]: crate::generic::SendStream::write_chunk
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct WriteChunk<'a, S>
 where
     S: proto::crypto::Session,
@@ -434,6 +440,7 @@ where
 /// Future produced by [`SendStream::write_all_chunks()`].
 ///
 /// [`SendStream::write_all_chunks()`]: crate::generic::SendStream::write_all_chunks
+#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct WriteAllChunks<'a, S>
 where
     S: proto::crypto::Session,


### PR DESCRIPTION
The warning message is taken verbatim from the futures crate.