### PR TITLE
Handle STOP_SENDING only once

### DIFF
--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -345,7 +345,7 @@ impl Ord for PendingLevel {
 }
 
 /// Application events about streams
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum StreamEvent {
     /// One or more new streams has been opened
     Opened {

--- a/quinn-proto/src/connection/streams/send.rs
+++ b/quinn-proto/src/connection/streams/send.rs
@@ -92,8 +92,16 @@ impl Send {
     }
 
     /// Handle STOP_SENDING
-    pub(super) fn stop(&mut self, error_code: VarInt) {
-        self.stop_reason = Some(error_code);
+    ///
+    /// Returns true if the stream was stopped due to this frame, and false
+    /// if it had been stopped before
+    pub(super) fn try_stop(&mut self, error_code: VarInt) -> bool {
+        if self.stop_reason.is_none() {
+            self.stop_reason = Some(error_code);
+            true
+        } else {
+            false
+        }
     }
 
     /// Returns whether the stream has been finished and all data has been acknowledged by the peer


### PR DESCRIPTION
This avoids duplicate emission of various events