### PR TITLE
Ack improvements

### DIFF
--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -113,7 +113,7 @@ impl RttEstimator {
         self.min = cmp::min(self.min, self.latest);
         // Based on RFC6298.
         if let Some(smoothed) = self.smoothed {
-            let adjusted_rtt = if self.min + ack_delay < self.latest {
+            let adjusted_rtt = if self.min + ack_delay <= self.latest {
                 self.latest - ack_delay
             } else {
                 self.latest

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -26,9 +26,7 @@ where
     /// Data to send
     pub(crate) pending: Retransmits,
     /// Packet numbers to acknowledge
-    pub(crate) pending_acks: ArrayRangeSet,
-    /// Set iff we have received a non-ack frame since the last ack-only packet we sent
-    pub(crate) permit_ack_only: bool,
+    pub(crate) pending_acks: PendingAcks,
 
     /// The packet number of the next packet that will be sent, if any.
     pub(crate) next_packet_number: u64,
@@ -79,8 +77,7 @@ where
             rx_packet: 0,
 
             pending: Retransmits::default(),
-            pending_acks: ArrayRangeSet::new(),
-            permit_ack_only: false,
+            pending_acks: PendingAcks::default(),
 
             next_packet_number: 0,
             largest_acked_packet: None,
@@ -149,7 +146,7 @@ where
     }
 
     pub(crate) fn can_send(&self) -> SendableFrames {
-        let acks = self.permit_ack_only && !self.pending_acks.is_empty();
+        let acks = self.pending_acks.can_send();
         let other = !self.pending.is_empty() || self.ping_pending;
 
         SendableFrames { acks, other }
@@ -435,6 +432,63 @@ impl SendableFrames {
         !self.acks && !self.other
     }
 }
+
+#[derive(Debug, Default)]
+pub(crate) struct PendingAcks {
+    permit_ack_only: bool,
+    ranges: ArrayRangeSet,
+}
+
+impl PendingAcks {
+    /// Whether any ACK frames can be sent
+    pub fn can_send(&self) -> bool {
+        self.permit_ack_only && !self.ranges.is_empty()
+    }
+
+    /// Should be called whenever an ACK eliciting frame was received
+    ///
+    /// This requires sending new outgoing ACKs
+    pub fn ack_eliciting_frame_received(&mut self) {
+        self.permit_ack_only = true;
+    }
+
+    /// Should be called whenever ACKs have been sent
+    ///
+    /// This will suppress sending further ACKs until additional ACK eliciting frames arrive
+    pub fn acks_sent(&mut self) {
+        // If we sent any acks, don't immediately resend them. Setting this even if ack_only is
+        // false needlessly prevents us from ACKing the next packet if it's ACK-only, but saves
+        // the need for subtler logic to avoid double-transmitting acks all the time.
+        // This reset needs to happen before we check whether more data
+        // is available in this space - because otherwise it would return
+        // `true` purely due to the ACKs
+        self.permit_ack_only = false;
+    }
+
+    /// Insert one packet that needs to be acknowledged
+    pub fn insert_one(&mut self, packet: u64) {
+        self.ranges.insert_one(packet);
+        if self.ranges.len() > MAX_ACK_BLOCKS {
+            self.ranges.pop_min();
+        }
+    }
+
+    /// Removes the given ACKs from the set of pending ACKs
+    pub fn subtract(&mut self, acks: &ArrayRangeSet) {
+        self.ranges.subtract(acks);
+        if self.ranges.is_empty() {
+            self.permit_ack_only = false;
+        }
+    }
+
+    /// Returns the set of currently pending ACK ranges
+    pub fn ranges(&self) -> &ArrayRangeSet {
+        &self.ranges
+    }
+}
+
+/// Ensures we can always fit all our ACKs in a single minimum-MTU packet with room to spare
+const MAX_ACK_BLOCKS: usize = 64;
 
 #[cfg(test)]
 mod test {

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -869,7 +869,7 @@ fn instant_close_2() {
 #[test]
 fn idle_timeout() {
     let _guard = subscribe();
-    const IDLE_TIMEOUT: Duration = Duration::from_millis(10);
+    const IDLE_TIMEOUT: Duration = Duration::from_millis(100);
     let server = ServerConfig {
         transport: Arc::new(TransportConfig {
             max_idle_timeout: Some(IDLE_TIMEOUT),

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -260,10 +260,10 @@ impl TestEndpoint {
         }
 
         while self.inbound.front().map_or(false, |x| x.0 <= now) {
-            let (_, ecn, packet) = self.inbound.pop_front().unwrap();
+            let (recv_time, ecn, packet) = self.inbound.pop_front().unwrap();
             if let Some((ch, event)) =
                 self.endpoint
-                    .handle(now, remote, None, ecn, packet.as_slice().into())
+                    .handle(recv_time, remote, None, ecn, packet.as_slice().into())
             {
                 match event {
                     DatagramEvent::NewConnection(conn) => {

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -139,7 +139,6 @@ impl TransportParameters {
                     .try_into()
                     .expect("setter guarantees this is in-bounds")
             }),
-            max_ack_delay: 0u32.into(),
             disable_active_migration: server_config.map_or(false, |c| !c.migration),
             active_connection_id_limit: if cid_gen.cid_len() == 0 {
                 2 // i.e. default, i.e. unsent


### PR DESCRIPTION
This change contains a first set of improvements to ACK handling, on the way to sending ACKs more efficiently.

In these changes the number of ACKs is actually not yet reduced, and the previous strategies are kept.
It however introduces some refactorings and prerequesites for adding ACK delay successfully:
1. The ACK state is moved into a separate struct
2. ACK delay is reported to peers, in order not to disturb RTT calculations in case ACK delay is applied
3. Pending ACKs are sent with `CONNECTION_CLOSE` frames