### PR TITLE
Fix Rust 1.53 clippy issues

### DIFF
--- a/quinn-h3/src/qpack/dynamic.rs
+++ b/quinn-h3/src/qpack/dynamic.rs
@@ -1090,7 +1090,7 @@ mod tests {
         }
 
         for idx in 1..4 {
-            assert_eq!(table.is_tracked(idx), true);
+            assert!(table.is_tracked(idx));
             assert_eq!(table.track_map.get(&1), Some(&1));
         }
         let track_blocks = table.track_blocks;

--- a/quinn-h3/src/qpack/prefix_string/encode.rs
+++ b/quinn-h3/src/qpack/prefix_string/encode.rs
@@ -85,17 +85,16 @@ fn write_bits(out: &mut [u8], pos: &BitWindow, value: u8) {
     debug_assert!(pos.bit < 8);
     debug_assert!(pos.count <= 8);
     debug_assert!(pos.count > 0);
+    debug_assert_eq!(out[pos.byte as usize] | PAD_LEFT[pos.bit as usize], 255);
 
     if (pos.bit + pos.count) <= 8 {
         // Bits to be written to fit in a single byte
-        debug_assert_eq!(out[pos.byte as usize] | PAD_LEFT[pos.bit as usize], 255);
         let pad_left = out[pos.byte as usize] | PAD_RIGHT[(8 - pos.bit) as usize];
         let shifted = value << (8 - pos.bit - pos.count) | PAD_LEFT[pos.bit as usize];
         let pad_right = PAD_RIGHT[(8 - pos.count - pos.bit) as usize];
         out[pos.byte as usize] = (pad_left & shifted) | pad_right;
     } else {
         // Bits to be written to span two bytes
-        debug_assert_eq!(out[pos.byte as usize] | PAD_LEFT[pos.bit as usize], 255);
         let split = 8 - pos.bit;
         let pad_left = out[pos.byte as usize] | PAD_RIGHT[split as usize];
         let shifted = (value >> (pos.count - split)) | PAD_LEFT[pos.bit as usize];

--- a/quinn-h3/src/qpack/vas.rs
+++ b/quinn-h3/src/qpack/vas.rs
@@ -273,16 +273,16 @@ mod tests {
     #[test]
     fn evicted() {
         let mut vas = VirtualAddressSpace::default();
-        assert_eq!(vas.evicted(0), false);
-        assert_eq!(vas.evicted(1), false);
+        assert!(!vas.evicted(0));
+        assert!(!vas.evicted(1));
         vas.add();
         vas.add();
-        assert_eq!(vas.evicted(1), false);
+        assert!(!vas.evicted(1));
         vas.drop();
-        assert_eq!(vas.evicted(0), false);
-        assert_eq!(vas.evicted(1), true);
-        assert_eq!(vas.evicted(2), false);
+        assert!(!vas.evicted(0));
+        assert!(vas.evicted(1));
+        assert!(!vas.evicted(2));
         vas.drop();
-        assert_eq!(vas.evicted(2), true);
+        assert!(vas.evicted(2));
     }
 }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -100,12 +100,14 @@ where
         // This lock borrows `self` and would normally be dropped at the end of this scope, so we'll
         // have to release it explicitly before returning `self` by value.
         let conn = (self.conn.as_mut().unwrap()).lock("into_0rtt");
-        if conn.inner.has_0rtt() || conn.inner.side().is_server() {
-            drop(conn);
+
+        let is_ok = conn.inner.has_0rtt() || conn.inner.side().is_server();
+        drop(conn);
+
+        if is_ok {
             let conn = self.conn.take().unwrap();
             Ok((NewConnection::new(conn), ZeroRttAccepted(self.connected)))
         } else {
-            drop(conn);
             Err(self)
         }
     }

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -330,7 +330,7 @@ async fn zero_rtt() {
         .await
         .expect("read_to_end");
     assert_eq!(msg, MSG);
-    assert_eq!(zero_rtt.await, true);
+    assert!(zero_rtt.await);
 
     drop(uni_streams);
 


### PR DESCRIPTION
Fixes two instances of
> warning: all if blocks contain the same code at the start