### PR TITLE
Upgrade to arbitrary 1 and crc 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "13:00"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,16 +12,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, beta, 1.47.0]
+        rust: [stable, beta, 1.51.0]
         exclude:
           - os: macos-latest
             rust: beta
           - os: macos-latest
-            rust: 1.47.0
+            rust: 1.51.0
           - os: windows-latest
             rust: beta
           - os: windows-latest
-            rust: 1.47.0
+            rust: 1.51.0
 
     runs-on: ${{ matrix.os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 Cargo.lock
 
 .idea
+.DS_Store
+.vscode

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = { version = "0.4.5", features = ["derive"] }
-libfuzzer-sys = "0.3"
+arbitrary = { version = "1.0.1", features = ["derive"] }
+libfuzzer-sys = "0.4.2"
 
 [dependencies.proto]
 features = ["arbitrary"]

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -25,7 +25,7 @@ tls-rustls = ["rustls", "webpki", "ring"]
 native-certs = ["rustls-native-certs"]
 
 [dependencies]
-arbitrary = { version = "0.4.5", features = ["derive"], optional = true }
+arbitrary = { version = "1.0.1", features = ["derive"], optional = true }
 bytes = "1"
 fxhash = "0.2.1"
 ct-logs = { version = "0.8", optional = true }

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -119,8 +119,8 @@ pub mod fuzzing {
     use arbitrary::{Arbitrary, Result, Unstructured};
     pub use bytes::{BufMut, BytesMut};
 
-    impl Arbitrary for TransportParameters {
-        fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
+    impl<'arbitrary> Arbitrary<'arbitrary> for TransportParameters {
+        fn arbitrary(u: &mut Unstructured<'arbitrary>) -> Result<Self> {
             Ok(TransportParameters {
                 initial_max_streams_bidi: u.arbitrary()?,
                 initial_max_streams_uni: u.arbitrary()?,
@@ -137,8 +137,8 @@ pub mod fuzzing {
         pub buf: BytesMut,
     }
 
-    impl Arbitrary for PacketParams {
-        fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
+    impl<'arbitrary> Arbitrary<'arbitrary> for PacketParams {
+        fn arbitrary(u: &mut Unstructured<'arbitrary>) -> Result<Self> {
             let local_cid_len: usize = u.int_in_range(0..=MAX_CID_SIZE)?;
             let bytes: Vec<u8> = Vec::arbitrary(u)?;
             let mut buf = BytesMut::new();

--- a/quinn-proto/src/varint.rs
+++ b/quinn-proto/src/varint.rs
@@ -133,8 +133,8 @@ impl fmt::Display for VarInt {
 }
 
 #[cfg(feature = "arbitrary")]
-impl Arbitrary for VarInt {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+impl<'arbitrary> Arbitrary<'arbitrary> for VarInt {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'arbitrary>) -> arbitrary::Result<Self> {
         Ok(VarInt(u.int_in_range(0..=VarInt::MAX.0)?))
     }
 }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -44,7 +44,7 @@ webpki = { version = "0.21", default-features = false, optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.22"
-crc = "1.8.1"
+crc = "2"
 bencher = "0.1.5"
 directories-next = "2"
 futures-util = { version = "0.3.11", default-features = false, features = ["async-await-macro"] }


### PR DESCRIPTION
Needs const generics, so this also updates the MSRV (which needs a bump for the rustls update, anyway).