### PR TITLE
Bounding UDP payload size to 1200 and renaming

### DIFF
--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -57,7 +57,7 @@ impl<'a, S: Session> Datagrams<'a, S> {
     /// Not necessarily the maximum size of received datagrams.
     pub fn max_size(&self) -> Option<usize> {
         // This is usually 1182 bytes, but we shouldn't document that without a doctest.
-        let max_size = self.conn.path.mtu as usize
+        let max_size = self.conn.path.max_udp_payload_size as usize
             - 1                 // flags byte
             - self.conn.rem_cids.active().len()
             - 4                 // worst-case packet number size

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -56,7 +56,7 @@ impl<'a, S: Session> Datagrams<'a, S> {
     ///
     /// Not necessarily the maximum size of received datagrams.
     pub fn max_size(&self) -> Option<usize> {
-        // This is usually 1182 bytes, but we shouldn't document that without a doctest.
+        // This is usually 1162 bytes, but we shouldn't document that without a doctest.
         let max_size = self.conn.path.max_udp_payload_size as usize
             - 1                 // flags byte
             - self.conn.rem_cids.active().len()

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -232,7 +232,9 @@ impl PacketBuilder {
         );
 
         buffer.resize(buffer.len() + packet_crypto.tag_len(), 0);
-        debug_assert!(buffer.len() <= self.datagram_start + conn.path.mtu as usize);
+        debug_assert!(
+            buffer.len() <= self.datagram_start + conn.path.max_udp_payload_size as usize
+        );
         let encode_start = self.partial_encode.start;
         let packet_buf = &mut buffer[encode_start..];
         self.partial_encode.finish(

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -31,8 +31,8 @@ use crate::{
         EndpointEventInner, IssuedCid,
     },
     transport_parameters::TransportParameters,
-    ResetToken, RetryToken, Side, Transmit, TransportError, MAX_CID_SIZE, MIN_INITIAL_SIZE,
-    MIN_MTU, RESET_TOKEN_SIZE,
+    ResetToken, RetryToken, Side, Transmit, TransportError, INITIAL_MAX_UDP_PAYLOAD_SIZE,
+    MAX_CID_SIZE, MIN_INITIAL_SIZE, RESET_TOKEN_SIZE,
 };
 
 /// The main entry point to the library
@@ -694,7 +694,9 @@ where
 
         let mut buf = Vec::<u8>::new();
         let partial_encode = header.encode(&mut buf);
-        let max_len = MIN_MTU as usize - partial_encode.header_len - crypto.packet.local.tag_len();
+        let max_len = INITIAL_MAX_UDP_PAYLOAD_SIZE as usize
+            - partial_encode.header_len
+            - crypto.packet.local.tag_len();
         frame::Close::from(reason).encode(&mut buf, max_len);
         buf.resize(buf.len() + crypto.packet.local.tag_len(), 0);
         partial_encode.finish(

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -310,7 +310,7 @@ const LOC_CID_COUNT: u64 = 8;
 const RESET_TOKEN_SIZE: usize = 16;
 const MAX_CID_SIZE: usize = 20;
 const MIN_INITIAL_SIZE: u16 = 1200;
-const INITIAL_MAX_UDP_PAYLOAD_SIZE: u16 = 1232;
+const INITIAL_MAX_UDP_PAYLOAD_SIZE: u16 = 1200;
 const TIMER_GRANULARITY: Duration = Duration::from_millis(1);
 /// Maximum number of streams that can be uniquely identified by a stream ID
 const MAX_STREAM_COUNT: u64 = 1 << 60;

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -310,7 +310,7 @@ const LOC_CID_COUNT: u64 = 8;
 const RESET_TOKEN_SIZE: usize = 16;
 const MAX_CID_SIZE: usize = 20;
 const MIN_INITIAL_SIZE: u16 = 1200;
-const MIN_MTU: u16 = 1232;
+const INITIAL_MAX_UDP_PAYLOAD_SIZE: u16 = 1232;
 const TIMER_GRANULARITY: Duration = Duration::from_millis(1);
 /// Maximum number of streams that can be uniquely identified by a stream ID
 const MAX_STREAM_COUNT: u64 = 1 << 60;


### PR DESCRIPTION
As mentioned in #1154, it seems quinn sends UDP datagrams with a payload 1232 bytes by default.

This is easily reproducible with the client.rs/server.rs quinn example, making a GET request and serve a reasonable big file.
```
cargo run --example client https:/server:1234/README.md
```
```
[...]
Jul 06 02:59:45.746 TRACE drive{id=0}: quinn_proto::connection: sending 1232 bytes in 1 datagrams
[...]
```

---

Looking at the QUIC spec, ([quic-draft-32 #14](https://datatracker.ietf.org/doc/html/draft-ietf-quic-transport-34#section-14)) , it seems the protocol should supports networks where the maximum UDP payload is 1200 bytes.
Any larger value should be discovered using PMTUD.

This PR contains two changes:
* Renaming the [`const MIN_MTU: u16 = 1232;`](https://github.com/quinn-rs/quinn/blob/3f908a2c8c1ec4585212d776fafe536ea17bf2b4/quinn-proto/src/lib.rs#L313) into `MAX_INITIAL_UDP_PAYLOAD_SIZE`. This change has no impact from the semantic point of view. The rationale behind this change is because that value seems to be used across the code to compute what in QUIC is defined as "the maximum datagram size" (i.e., the UDP datagram payload).
* Changing this value from `1232` to `1200` and avoid quinn assembles packets (UDP datagrams) with a payload greater than this value.

