### PR TITLE
Fix example in "Self Signed Certificates" section of book

### DIFF
--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -77,7 +77,7 @@ pub fn generate_self_signed_cert(cert_path: &str, key_path: &str) -> anyhow::Res
     fs::write(&cert_path, &serialized_certificate).context("failed to write certificate")?;
     fs::write(&key_path, &serialized_key).context("failed to write private key")?;
 
-    let cert = quinn::Certificate::from_der(&cert)?;
+    let cert = quinn::Certificate::from_der(&serialized_certificate)?;
     let key = quinn::PrivateKey::from_der(&serialized_key)?;
     Ok((cert, key))
 }


### PR DESCRIPTION
Was trying out some example code from the book and found a typo, nothing big though.