### PR TITLE
Output json throughput statistics from perf client

### DIFF
--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -13,6 +13,8 @@ hdrhistogram = { version = "7.2", default-features = false }
 quinn = { path = "../quinn" }
 rcgen = "0.8"
 rustls = { version = "0.19", features = ["dangerous_configuration"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 socket2 = "0.4"
 webpki = "0.21"
 structopt = "0.3"

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -6,6 +6,11 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 publish = false
 
+[features]
+default = ["json-output"]
+# Allow for json output from the perf client
+json-output = ["serde", "serde_json"]
+
 [dependencies]
 anyhow = "1.0.22"
 futures-util = "0.3.11"
@@ -13,8 +18,8 @@ hdrhistogram = { version = "7.2", default-features = false }
 quinn = { path = "../quinn" }
 rcgen = "0.8"
 rustls = { version = "0.19", features = ["dangerous_configuration"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"], optional = true  }
+serde_json = { version = "1.0", optional = true }
 socket2 = "0.4"
 webpki = "0.21"
 structopt = "0.3"

--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -13,6 +13,7 @@ use tracing::{debug, error, info};
 
 use perf::bind_socket;
 use perf::stats::{OpenStreamStats, Stats};
+#[cfg(feature = "json-output")]
 use std::path::PathBuf;
 
 /// Connects to a QUIC perf server and maintains a specified pattern of requests until interrupted
@@ -59,6 +60,7 @@ struct Opt {
     #[structopt(long)]
     conn_stats: bool,
     /// File path to output JSON statistics to. If the file is '-', stdout will be used
+    #[cfg(feature = "json-output")]
     #[structopt(long)]
     json: Option<PathBuf>,
 }
@@ -201,6 +203,7 @@ async fn run(opt: Opt) -> Result<()> {
 
     endpoint.wait_idle().await;
 
+    #[cfg(feature = "json-output")]
     if let Some(path) = opt.json {
         stats.print_json(path.as_path())?;
     }

--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -7,12 +7,12 @@ use std::{
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use futures_util::StreamExt;
-use hdrhistogram::Histogram;
 use structopt::StructOpt;
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info};
 
 use perf::bind_socket;
+use perf::stats::{RequestStats, Stats};
 
 /// Connects to a QUIC perf server and maintains a specified pattern of requests until interrupted
 #[derive(StructOpt)]
@@ -367,143 +367,4 @@ impl rustls::ServerCertVerifier for SkipServerVerification {
     ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
         Ok(rustls::ServerCertVerified::assertion())
     }
-}
-
-struct RequestStats {
-    start: Instant,
-    upload_start: Option<Instant>,
-    download_start: Option<Instant>,
-    first_byte: Option<Instant>,
-    download_end: Option<Instant>,
-    upload_size: u64,
-    download_size: u64,
-    success: bool,
-}
-
-impl RequestStats {
-    pub fn new(upload_size: u64, download_size: u64) -> Self {
-        Self {
-            start: Instant::now(),
-            upload_start: None,
-            download_start: None,
-            first_byte: None,
-            upload_size,
-            download_size,
-            download_end: None,
-            success: false,
-        }
-    }
-}
-
-struct Stats {
-    /// Test start time
-    start: Instant,
-    /// Durations of complete requests
-    duration: Histogram<u64>,
-    /// Time from finishing the upload until receiving the first byte of the response
-    fbl: Histogram<u64>,
-    /// Throughput for uploads
-    upload_throughput: Histogram<u64>,
-    /// Throughput for downloads
-    download_throughput: Histogram<u64>,
-    /// The total amount of requests executed
-    requests: usize,
-    /// The amount of successful requests
-    success: usize,
-}
-
-impl Default for Stats {
-    fn default() -> Self {
-        Self {
-            start: Instant::now(),
-            duration: Histogram::new(3).unwrap(),
-            fbl: Histogram::new(3).unwrap(),
-            upload_throughput: Histogram::new(3).unwrap(),
-            download_throughput: Histogram::new(3).unwrap(),
-            requests: 0,
-            success: 0,
-        }
-    }
-}
-
-impl Stats {
-    pub fn record(&mut self, request: RequestStats) {
-        self.requests += 1;
-        self.success += if request.success { 1 } else { 0 };
-
-        // Record the remaining metrics only if the request is successful
-        // In this case all timings are available
-        if !request.success {
-            return;
-        }
-
-        let duration = request.download_end.unwrap().duration_since(request.start);
-        self.duration.record(duration.as_millis() as u64).unwrap();
-
-        let fbl = request
-            .first_byte
-            .unwrap()
-            .duration_since(request.download_start.unwrap());
-        self.fbl.record(fbl.as_millis() as u64).unwrap();
-
-        let download_duration = request
-            .download_end
-            .unwrap()
-            .duration_since(request.download_start.unwrap());
-        let download_bps = throughput_bps(download_duration, request.download_size);
-        self.download_throughput
-            .record(download_bps as u64)
-            .unwrap();
-
-        let upload_duration = request
-            .download_start
-            .unwrap()
-            .duration_since(request.upload_start.unwrap());
-        let upload_bps = throughput_bps(upload_duration, request.upload_size);
-        self.upload_throughput.record(upload_bps as u64).unwrap();
-    }
-
-    pub fn print(&self) {
-        let dt = self.start.elapsed();
-        let rps = self.requests as f64 / dt.as_secs_f64();
-
-        println!("Overall stats:");
-        println!(
-            "RPS: {:.2} ({} requests in {:4.2?})",
-            rps, self.requests, dt,
-        );
-        println!(
-            "Success rate: {:4.2}%",
-            100.0 * self.success as f64 / self.requests as f64,
-        );
-        println!();
-
-        println!("Stream metrics:\n");
-
-        println!("      │ Duration  │ FBL       | Upload Throughput | Download Throughput");
-        println!("──────┼───────────┼───────────┼───────────────────┼────────────────────");
-
-        let print_metric = |label: &'static str, get_metric: fn(&Histogram<u64>) -> u64| {
-            println!(
-                " {} │ {:>9} │ {:>9} │ {:11.2} MiB/s │ {:13.2} MiB/s",
-                label,
-                format!("{:.2?}", Duration::from_millis(get_metric(&self.duration))),
-                format!("{:.2?}", Duration::from_millis(get_metric(&self.fbl))),
-                get_metric(&self.upload_throughput) as f64 / 1024.0 / 1024.0,
-                get_metric(&self.download_throughput) as f64 / 1024.0 / 1024.0,
-            );
-        };
-
-        print_metric("AVG ", |hist| hist.mean() as u64);
-        print_metric("P0  ", |hist| hist.value_at_quantile(0.00));
-        print_metric("P10 ", |hist| hist.value_at_quantile(0.10));
-        print_metric("P50 ", |hist| hist.value_at_quantile(0.50));
-        print_metric("P90 ", |hist| hist.value_at_quantile(0.90));
-        print_metric("P100", |hist| hist.value_at_quantile(1.00));
-        println!();
-    }
-}
-
-fn throughput_bps(duration: Duration, size: u64) -> f64 {
-    (size as f64) / (duration.as_secs_f64())
 }

--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -13,6 +13,7 @@ use tracing::{debug, error, info};
 
 use perf::bind_socket;
 use perf::stats::{OpenStreamStats, Stats};
+use std::path::PathBuf;
 
 /// Connects to a QUIC perf server and maintains a specified pattern of requests until interrupted
 #[derive(StructOpt)]
@@ -57,6 +58,9 @@ struct Opt {
     /// Whether to print connection statistics
     #[structopt(long)]
     conn_stats: bool,
+    /// File path to output JSON statistics to. If the file is '-', stdout will be used
+    #[structopt(long)]
+    json: Option<PathBuf>,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -197,7 +201,9 @@ async fn run(opt: Opt) -> Result<()> {
 
     endpoint.wait_idle().await;
 
-    // TODO: Print stats
+    if let Some(path) = opt.json {
+        stats.print_json(path.as_path())?;
+    }
 
     Ok(())
 }

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -4,6 +4,8 @@ use anyhow::{Context, Result};
 use socket2::{Domain, Protocol, Socket, Type};
 use tracing::warn;
 
+pub mod stats;
+
 pub fn bind_socket(
     addr: SocketAddr,
     send_buffer_size: usize,

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use socket2::{Domain, Protocol, Socket, Type};
 use tracing::warn;
 
+#[cfg_attr(not(feature = "json-output"), allow(dead_code))]
 pub mod stats;
 
 pub fn bind_socket(

--- a/perf/src/stats.rs
+++ b/perf/src/stats.rs
@@ -1,11 +1,10 @@
 use hdrhistogram::Histogram;
 use quinn::StreamId;
-use std::fs::File;
-use std::io;
-use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime};
+#[cfg(feature = "json-output")]
+use {std::fs::File, std::io, std::path::Path};
 
 pub struct Stats {
     /// Test start time
@@ -121,6 +120,7 @@ impl Stats {
         println!();
     }
 
+    #[cfg(feature = "json-output")]
     pub fn print_json(&self, path: &Path) -> io::Result<()> {
         match path {
             path if path == Path::new("-") => json::print(self, std::io::stdout()),
@@ -245,6 +245,7 @@ fn throughput_bytes_per_second(duration_in_micros: u64, size: u64) -> f64 {
     (size as f64) / (duration_in_micros as f64 / 1000000.0)
 }
 
+#[cfg(feature = "json-output")]
 mod json {
     use crate::stats;
     use crate::stats::{Stats, StreamIntervalStats};

--- a/perf/src/stats.rs
+++ b/perf/src/stats.rs
@@ -1,0 +1,141 @@
+use hdrhistogram::Histogram;
+use std::time::{Duration, Instant};
+
+pub struct RequestStats {
+    start: Instant,
+    pub upload_start: Option<Instant>,
+    pub download_start: Option<Instant>,
+    pub first_byte: Option<Instant>,
+    pub download_end: Option<Instant>,
+    upload_size: u64,
+    download_size: u64,
+    pub success: bool,
+}
+
+impl RequestStats {
+    pub fn new(upload_size: u64, download_size: u64) -> Self {
+        Self {
+            start: Instant::now(),
+            upload_start: None,
+            download_start: None,
+            first_byte: None,
+            upload_size,
+            download_size,
+            download_end: None,
+            success: false,
+        }
+    }
+}
+
+pub struct Stats {
+    /// Test start time
+    start: Instant,
+    /// Durations of complete requests
+    duration: Histogram<u64>,
+    /// Time from finishing the upload until receiving the first byte of the response
+    fbl: Histogram<u64>,
+    /// Throughput for uploads
+    upload_throughput: Histogram<u64>,
+    /// Throughput for downloads
+    download_throughput: Histogram<u64>,
+    /// The total amount of requests executed
+    requests: usize,
+    /// The amount of successful requests
+    success: usize,
+}
+
+impl Default for Stats {
+    fn default() -> Self {
+        Self {
+            start: Instant::now(),
+            duration: Histogram::new(3).unwrap(),
+            fbl: Histogram::new(3).unwrap(),
+            upload_throughput: Histogram::new(3).unwrap(),
+            download_throughput: Histogram::new(3).unwrap(),
+            requests: 0,
+            success: 0,
+        }
+    }
+}
+
+impl Stats {
+    pub fn record(&mut self, request: RequestStats) {
+        self.requests += 1;
+        self.success += if request.success { 1 } else { 0 };
+
+        // Record the remaining metrics only if the request is successful
+        // In this case all timings are available
+        if !request.success {
+            return;
+        }
+
+        let duration = request.download_end.unwrap().duration_since(request.start);
+        self.duration.record(duration.as_millis() as u64).unwrap();
+
+        let fbl = request
+            .first_byte
+            .unwrap()
+            .duration_since(request.download_start.unwrap());
+        self.fbl.record(fbl.as_millis() as u64).unwrap();
+
+        let download_duration = request
+            .download_end
+            .unwrap()
+            .duration_since(request.download_start.unwrap());
+        let download_bps = throughput_bps(download_duration, request.download_size);
+        self.download_throughput
+            .record(download_bps as u64)
+            .unwrap();
+
+        let upload_duration = request
+            .download_start
+            .unwrap()
+            .duration_since(request.upload_start.unwrap());
+        let upload_bps = throughput_bps(upload_duration, request.upload_size);
+        self.upload_throughput.record(upload_bps as u64).unwrap();
+    }
+
+    pub fn print(&self) {
+        let dt = self.start.elapsed();
+        let rps = self.requests as f64 / dt.as_secs_f64();
+
+        println!("Overall stats:");
+        println!(
+            "RPS: {:.2} ({} requests in {:4.2?})",
+            rps, self.requests, dt,
+        );
+        println!(
+            "Success rate: {:4.2}%",
+            100.0 * self.success as f64 / self.requests as f64,
+        );
+        println!();
+
+        println!("Stream metrics:\n");
+
+        println!("      │ Duration  │ FBL       | Upload Throughput | Download Throughput");
+        println!("──────┼───────────┼───────────┼───────────────────┼────────────────────");
+
+        let print_metric = |label: &'static str, get_metric: fn(&Histogram<u64>) -> u64| {
+            println!(
+                " {} │ {:>9} │ {:>9} │ {:11.2} MiB/s │ {:13.2} MiB/s",
+                label,
+                format!("{:.2?}", Duration::from_millis(get_metric(&self.duration))),
+                format!("{:.2?}", Duration::from_millis(get_metric(&self.fbl))),
+                get_metric(&self.upload_throughput) as f64 / 1024.0 / 1024.0,
+                get_metric(&self.download_throughput) as f64 / 1024.0 / 1024.0,
+            );
+        };
+
+        print_metric("AVG ", |hist| hist.mean() as u64);
+        print_metric("P0  ", |hist| hist.value_at_quantile(0.00));
+        print_metric("P10 ", |hist| hist.value_at_quantile(0.10));
+        print_metric("P50 ", |hist| hist.value_at_quantile(0.50));
+        print_metric("P90 ", |hist| hist.value_at_quantile(0.90));
+        print_metric("P100", |hist| hist.value_at_quantile(1.00));
+        println!();
+    }
+}
+
+fn throughput_bps(duration: Duration, size: u64) -> f64 {
+    (size as f64) / (duration.as_secs_f64())
+}

--- a/perf/src/stats.rs
+++ b/perf/src/stats.rs
@@ -1,37 +1,18 @@
 use hdrhistogram::Histogram;
-use std::time::{Duration, Instant};
-
-pub struct RequestStats {
-    start: Instant,
-    pub upload_start: Option<Instant>,
-    pub download_start: Option<Instant>,
-    pub first_byte: Option<Instant>,
-    pub download_end: Option<Instant>,
-    upload_size: u64,
-    download_size: u64,
-    pub success: bool,
-}
-
-impl RequestStats {
-    pub fn new(upload_size: u64, download_size: u64) -> Self {
-        Self {
-            start: Instant::now(),
-            upload_start: None,
-            download_start: None,
-            first_byte: None,
-            upload_size,
-            download_size,
-            download_end: None,
-            success: false,
-        }
-    }
-}
+use quinn::StreamId;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime};
 
 pub struct Stats {
     /// Test start time
-    start: Instant,
-    /// Durations of complete requests
-    duration: Histogram<u64>,
+    start_instant: Instant,
+    /// Test start system time
+    start: SystemTime,
+    /// Durations of uploads
+    upload_duration: Histogram<u64>,
+    /// Durations of downloads
+    download_duration: Histogram<u64>,
     /// Time from finishing the upload until receiving the first byte of the response
     fbl: Histogram<u64>,
     /// Throughput for uploads
@@ -40,63 +21,62 @@ pub struct Stats {
     download_throughput: Histogram<u64>,
     /// The total amount of requests executed
     requests: usize,
-    /// The amount of successful requests
-    success: usize,
+    /// Stats accumulated over each interval
+    intervals: Vec<Interval>,
 }
 
 impl Default for Stats {
     fn default() -> Self {
         Self {
-            start: Instant::now(),
-            duration: Histogram::new(3).unwrap(),
+            start_instant: Instant::now(),
+            start: SystemTime::now(),
+            upload_duration: Histogram::new(3).unwrap(),
+            download_duration: Histogram::new(3).unwrap(),
             fbl: Histogram::new(3).unwrap(),
             upload_throughput: Histogram::new(3).unwrap(),
             download_throughput: Histogram::new(3).unwrap(),
             requests: 0,
-            success: 0,
+            intervals: vec![],
         }
     }
 }
 
 impl Stats {
-    pub fn record(&mut self, request: RequestStats) {
-        self.requests += 1;
-        self.success += if request.success { 1 } else { 0 };
+    pub fn on_interval(&mut self, start: Instant, stream_stats: &OpenStreamStats) {
+        let mut interval = Interval::new(start - self.start_instant, self.start_instant.elapsed());
+        let mut guard = stream_stats.0.lock().unwrap();
 
-        // Record the remaining metrics only if the request is successful
-        // In this case all timings are available
-        if !request.success {
-            return;
+        guard.retain(|stream_stats| {
+            self.record(stream_stats.clone());
+            interval.record_stream_stats(stream_stats.clone());
+            // Retain if not finished yet
+            !stream_stats.finished.load(Ordering::SeqCst)
+        });
+
+        self.intervals.push(interval);
+    }
+
+    fn record(&mut self, stream_stats: Arc<StreamStats>) {
+        if stream_stats.finished.load(Ordering::SeqCst) {
+            let duration = stream_stats.duration.load(Ordering::SeqCst) as u64;
+            let bps = throughput_bytes_per_second(duration, stream_stats.request_size);
+
+            if stream_stats.sender {
+                self.upload_throughput.record(bps as u64).unwrap();
+                self.upload_duration.record(duration).unwrap();
+            } else {
+                self.download_throughput.record(bps as u64).unwrap();
+                self.download_duration.record(duration).unwrap();
+                self.fbl
+                    .record(stream_stats.first_byte_latency.load(Ordering::SeqCst) as u64)
+                    .unwrap();
+                self.requests += 1;
+            }
         }
-
-        let duration = request.download_end.unwrap().duration_since(request.start);
-        self.duration.record(duration.as_millis() as u64).unwrap();
-
-        let fbl = request
-            .first_byte
-            .unwrap()
-            .duration_since(request.download_start.unwrap());
-        self.fbl.record(fbl.as_millis() as u64).unwrap();
-
-        let download_duration = request
-            .download_end
-            .unwrap()
-            .duration_since(request.download_start.unwrap());
-        let download_bps = throughput_bps(download_duration, request.download_size);
-        self.download_throughput
-            .record(download_bps as u64)
-            .unwrap();
-
-        let upload_duration = request
-            .download_start
-            .unwrap()
-            .duration_since(request.upload_start.unwrap());
-        let upload_bps = throughput_bps(upload_duration, request.upload_size);
-        self.upload_throughput.record(upload_bps as u64).unwrap();
     }
 
     pub fn print(&self) {
-        let dt = self.start.elapsed();
+        let dt = self.start_instant.elapsed();
         let rps = self.requests as f64 / dt.as_secs_f64();
 
         println!("Overall stats:");
@@ -104,23 +84,26 @@ impl Stats {
             "RPS: {:.2} ({} requests in {:4.2?})",
             rps, self.requests, dt,
         );
-        println!(
-            "Success rate: {:4.2}%",
-            100.0 * self.success as f64 / self.requests as f64,
-        );
         println!();
 
         println!("Stream metrics:\n");
 
-        println!("      │ Duration  │ FBL       | Upload Throughput | Download Throughput");
-        println!("──────┼───────────┼───────────┼───────────────────┼────────────────────");
+        println!("      │ Upload Duration │ Download Duration | FBL        | Upload Throughput | Download Throughput");
+        println!("──────┼─────────────────┼───────────────────┼────────────┼───────────────────┼────────────────────");
 
         let print_metric = |label: &'static str, get_metric: fn(&Histogram<u64>) -> u64| {
             println!(
-                " {} │ {:>9} │ {:>9} │ {:11.2} MiB/s │ {:13.2} MiB/s",
+                " {} │ {:>15} │ {:>17} │  {:>9} │ {:11.2} MiB/s │ {:13.2} MiB/s",
                 label,
-                format!("{:.2?}", Duration::from_millis(get_metric(&self.duration))),
-                format!("{:.2?}", Duration::from_millis(get_metric(&self.fbl))),
+                format!(
+                    "{:.2?}",
+                    Duration::from_micros(get_metric(&self.upload_duration))
+                ),
+                format!(
+                    "{:.2?}",
+                    Duration::from_micros(get_metric(&self.download_duration))
+                ),
+                format!("{:.2?}", Duration::from_micros(get_metric(&self.fbl))),
                 get_metric(&self.upload_throughput) as f64 / 1024.0 / 1024.0,
                 get_metric(&self.download_throughput) as f64 / 1024.0 / 1024.0,
             );
@@ -136,6 +119,114 @@ impl Stats {
     }
 }
 
-fn throughput_bps(duration: Duration, size: u64) -> f64 {
-    (size as f64) / (duration.as_secs_f64())
+/// Statistics for the currently open streams
+#[derive(Clone, Default)]
+pub struct OpenStreamStats(Arc<Mutex<Vec<Arc<StreamStats>>>>);
+
+impl OpenStreamStats {
+    pub fn new_sender(&self, stream: &quinn::SendStream, upload_size: u64) -> Arc<StreamStats> {
+        let send_stream_stats = StreamStats {
+            id: stream.id(),
+            request_size: upload_size,
+            bytes: Default::default(),
+            sender: true,
+            finished: Default::default(),
+            duration: Default::default(),
+            first_byte_latency: Default::default(),
+        };
+        let send_stream_stats = Arc::new(send_stream_stats);
+        self.push(send_stream_stats.clone());
+        send_stream_stats
+    }
+
+    pub fn new_receiver(&self, stream: &quinn::RecvStream, download_size: u64) -> Arc<StreamStats> {
+        let recv_stream_stats = StreamStats {
+            id: stream.id(),
+            request_size: download_size,
+            bytes: Default::default(),
+            sender: false,
+            finished: Default::default(),
+            duration: Default::default(),
+            first_byte_latency: Default::default(),
+        };
+        let recv_stream_stats = Arc::new(recv_stream_stats);
+        self.push(recv_stream_stats.clone());
+        recv_stream_stats
+    }
+
+    fn push(&self, stream_stats: Arc<StreamStats>) {
+        self.0.lock().unwrap().push(stream_stats);
+    }
+}
+
+pub struct StreamStats {
+    id: StreamId,
+    request_size: u64,
+    bytes: AtomicUsize,
+    sender: bool,
+    finished: AtomicBool,
+    duration: AtomicU64,
+    first_byte_latency: AtomicU64,
+}
+
+impl StreamStats {
+    pub fn on_first_byte(&self, latency: Duration) {
+        self.first_byte_latency
+            .store(latency.as_micros() as u64, Ordering::SeqCst);
+    }
+
+    pub fn on_bytes(&self, bytes: usize) {
+        self.bytes.fetch_add(bytes, Ordering::SeqCst);
+    }
+
+    pub fn finish(&self, duration: Duration) {
+        self.duration
+            .store(duration.as_micros() as u64, Ordering::SeqCst);
+        self.finished.store(true, Ordering::SeqCst);
+    }
+}
+
+struct Interval {
+    streams: Vec<StreamIntervalStats>,
+    period: IntervalPeriod,
+}
+
+impl Interval {
+    fn new(start: Duration, end: Duration) -> Self {
+        let period = IntervalPeriod {
+            start: start.as_secs_f64(),
+            end: end.as_secs_f64(),
+            seconds: (end - start).as_secs_f64(),
+        };
+
+        Self {
+            streams: vec![],
+            period,
+        }
+    }
+
+    fn record_stream_stats(&mut self, stream_stats: Arc<StreamStats>) {
+        let bytes = stream_stats.bytes.swap(0, Ordering::SeqCst);
+        self.streams.push(StreamIntervalStats {
+            id: stream_stats.id,
+            bytes,
+            sender: stream_stats.sender,
+        })
+    }
+}
+
+struct IntervalPeriod {
+    start: f64,
+    end: f64,
+    seconds: f64,
+}
+
+struct StreamIntervalStats {
+    id: StreamId,
+    bytes: usize,
+    sender: bool,
+}
+
+fn throughput_bytes_per_second(duration_in_micros: u64, size: u64) -> f64 {
+    (size as f64) / (duration_in_micros as f64 / 1000000.0)
 }


### PR DESCRIPTION
This change adds a `--json` option to the  perf_client, allowing for throughput statistics to be output in a style partially matching that of iperf3. An `--interval` option is also added, to allow specifying the interval (in seconds) at which the statistics are gathered. This will allow the data gathered by the perf client to be used in a variety of ways, including through tools built for iperf3, such as https://github.com/rkost/iperf3Vis.

Example output (truncated):

```
{
  "start": {
    "timestamp": {
      "timesecs": 1627418034
    }
  },
  "intervals": [
    {
      "streams": [
        {
          "id": 0,
          "start": 0.010186108,
          "end": 1.010887858,
          "seconds": 1.00070175,
          "bytes": 10000000,
          "bits_per_second": 79943899.36861807,
          "sender": false
        },
        {
          "id": 4,
          "start": 0.010186108,
          "end": 1.010887858,
          "seconds": 1.00070175,
          "bytes": 10000000,
          "bits_per_second": 79943899.36861807,
          "sender": false
        },
       ...
      ],
      "sum": {
        "bytes": 153470294,
        "start": 0.010186108,
        "end": 1.010887858,
        "seconds": 1.00070175,
        "bits_per_second": 1226901373.960823,
        "sender": false
      }
    },
    {
      "streams": [
        {
          "id": 60,
          "start": 1.01089626,
          "end": 2.012940925,
          "seconds": 1.002044665,
          "bytes": 6529706,
          "bits_per_second": 52131057.451416105,
          "sender": false
        },
        {
          "id": 64,
          "start": 1.01089626,
          "end": 2.012940925,
          "seconds": 1.002044665,
          "bytes": 10000000,
          "bits_per_second": 79836760.56994925,
          "sender": false
        },
        ...
      ],
      "sum": {
        "bytes": 145551156,
        "start": 1.01089626,
        "end": 2.012940925,
        "seconds": 1.002044665,
        "bits_per_second": 1162033279.2251332,
        "sender": false
      }
    }
  ]
}
```

Example visualization with iperf3Vis:
![image](https://user-images.githubusercontent.com/55108558/127415314-c59b6e9a-1689-4e8d-9a13-89db1f3a5136.png)
