### PR TITLE
Log and ignore transmit errors

### DIFF
--- a/quinn/src/platform/mod.rs
+++ b/quinn/src/platform/mod.rs
@@ -1,7 +1,11 @@
 //! Uniform interface to send/recv UDP packets with ECN information.
-use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::{
+    net::{IpAddr, Ipv6Addr, SocketAddr},
+    time::{Duration, Instant},
+};
 
-use proto::EcnCodepoint;
+use proto::{EcnCodepoint, Transmit};
+use tracing::warn;
 
 #[cfg(unix)]
 mod cmsg;
@@ -51,5 +55,26 @@ impl Default for RecvMeta {
             ecn: None,
             dst_ip: None,
         }
+    }
+}
+
+/// Log at most 1 IO error per minute
+const IO_ERROR_LOG_INTERVAL: Duration = std::time::Duration::from_secs(60);
+
+/// Logs a warning message when sendmsg fails
+///
+/// Logging will only be performed if at least [`IO_ERROR_LOG_INTERVAL`]
+/// has elapsed since the last error was logged.
+fn log_sendmsg_error(
+    last_send_error: &mut Instant,
+    err: impl core::fmt::Debug,
+    transmit: &Transmit,
+) {
+    let now = Instant::now();
+    if now.saturating_duration_since(*last_send_error) > IO_ERROR_LOG_INTERVAL {
+        *last_send_error = now;
+        warn!(
+        "sendmsg error: {:?}, Transmit: {{ destination: {:?}, src_ip: {:?}, enc: {:?}, len: {:?}, segment_size: {:?} }}",
+            err, transmit.destination, transmit.src_ip, transmit.ecn, transmit.contents.len(), transmit.segment_size);
     }
 }


### PR DESCRIPTION
Some more transient transmit errors have been observed. E.g. for some
peers transmission failed with
```
error: Os { code: 101, kind: Other, message: "Network is unreachable" }
```

That lead the endpoint to shut down and not process any messages for any
other clients.

To prevent this, this changes the behavior to ignore errors inside the endpoint.
In order to not lose all visibility, the change however adds low frequency
logging for the errors.