### PR TITLE
rather than importing futures only import the crates we really need. …

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.22"
 bytes = "1"
-futures = "0.3.8"
+futures-util = "0.3.11"
 hdrhistogram = { version = "7.2", default-features = false }
 quinn = { path = "../quinn" }
 rcgen = "0.8"

--- a/bench/src/bulk.rs
+++ b/bench/src/bulk.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
-use futures::StreamExt;
+use futures_util::StreamExt;
 use hdrhistogram::Histogram;
 use structopt::StructOpt;
 use tokio::runtime::{Builder, Runtime};
@@ -141,7 +141,7 @@ async fn client(server_addr: SocketAddr, server_cert: quinn::Certificate, opt: O
 
     let connection = Arc::new(connection);
 
-    let mut ops = futures::stream::iter((0..opt.streams).map(|_| {
+    let mut ops = futures_util::stream::iter((0..opt.streams).map(|_| {
         let connection = connection.clone();
         async move { send_data_on_stream(connection, opt.stream_size_mb).await }
     }))

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.22"
 bytes = "1"
-futures = "0.3.8"
+futures-util = "0.3.11"
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14.1", features = ["client", "server", "http2"] }

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use anyhow::{anyhow, bail, Context, Result};
-use futures::{future, StreamExt};
+use futures_util::{future, StreamExt};
 use http_body::Body;
 use lazy_static::lazy_static;
 use structopt::StructOpt;

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -13,7 +13,7 @@ use std::{
 
 use anyhow::{anyhow, bail, Context as _, Result};
 use bytes::Bytes;
-use futures::{ready, Future, StreamExt, TryFutureExt};
+use futures_util::{ready, Future, StreamExt, TryFutureExt};
 use http::{Response, StatusCode};
 use hyper::service::{make_service_fn, service_fn};
 use structopt::{self, StructOpt};

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.22"
-futures = "0.3.8"
+futures-util = "0.3.11"
 hdrhistogram = { version = "7.2", default-features = false }
 quinn = { path = "../quinn" }
 rcgen = "0.8"

--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
-use futures::StreamExt;
+use futures_util::StreamExt;
 use hdrhistogram::Histogram;
 use structopt::StructOpt;
 use tokio::sync::Semaphore;

--- a/perf/src/bin/perf_server.rs
+++ b/perf/src/bin/perf_server.rs
@@ -2,7 +2,7 @@ use std::{fs, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
-use futures::StreamExt;
+use futures_util::StreamExt;
 use structopt::StructOpt;
 use tracing::{debug, error, info};
 

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -30,7 +30,9 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 bytes = "1"
-futures = "0.3.8"
+futures-channel = "0.3.11"
+futures-core = "0.3.11"
+futures-util = "0.3.11"
 fxhash = "0.2.1"
 libc = "0.2.69"
 mio = { version = "0.7.7", features = ["net"] }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -30,9 +30,8 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 bytes = "1"
+futures-util = { version = "0.3.11", features = ["io"] }
 futures-channel = "0.3.11"
-futures-core = "0.3.11"
-futures-util = "0.3.11"
 fxhash = "0.2.1"
 libc = "0.2.69"
 mio = { version = "0.7.7", features = ["net"] }

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use bencher::{benchmark_group, benchmark_main, Bencher};
-use futures::StreamExt;
+use futures_util::StreamExt;
 use tokio::runtime::{Builder, Runtime};
 use tracing::error_span;
 use tracing_futures::Instrument as _;

--- a/quinn/examples/connection.rs
+++ b/quinn/examples/connection.rs
@@ -3,7 +3,7 @@
 //! Checkout the `README.md` for guidance.
 
 // Provides the async `next()` method on `incoming` below
-use futures::StreamExt;
+use futures_util::StreamExt;
 
 mod common;
 use common::{make_client_endpoint, make_server_endpoint};

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -2,7 +2,7 @@
 //!
 //! Checkout the `README.md` for guidance.
 
-use futures::StreamExt;
+use futures_util::StreamExt;
 use std::{error::Error, net::SocketAddr, sync::Arc};
 
 use quinn::{ClientConfig, ClientConfigBuilder, Endpoint};

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use anyhow::{anyhow, bail, Context, Result};
-use futures::{StreamExt, TryFutureExt};
+use futures_util::{StreamExt, TryFutureExt};
 use structopt::{self, StructOpt};
 use tracing::{error, info, info_span};
 use tracing_futures::Instrument as _;

--- a/quinn/examples/single_socket.rs
+++ b/quinn/examples/single_socket.rs
@@ -2,7 +2,7 @@
 //!
 //! Checkout the `README.md` for guidance.
 
-use futures::StreamExt;
+use futures_util::StreamExt;
 use std::{error::Error, net::SocketAddr};
 
 use quinn::Endpoint;
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     )?;
 
     // connect to multiple endpoints using the same socket/endpoint
-    futures::future::join_all(vec![
+    futures_util::future::join_all(vec![
         run_client(&client, addr1),
         run_client(&client, addr2),
         run_client(&client, addr3),

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -10,10 +10,8 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures::{
-    channel::{mpsc, oneshot},
-    FutureExt, StreamExt,
-};
+use futures_channel::{mpsc, oneshot};
+use futures_util::{FutureExt, StreamExt};
 use fxhash::FxHashMap;
 use proto::{ConnectionError, ConnectionHandle, ConnectionStats, Dir, StreamEvent, StreamId};
 use thiserror::Error;
@@ -539,7 +537,7 @@ where
 #[derive(Debug)]
 pub struct IncomingUniStreams<S: proto::crypto::Session>(ConnectionRef<S>);
 
-impl<S> futures::Stream for IncomingUniStreams<S>
+impl<S> futures_core::stream::Stream for IncomingUniStreams<S>
 where
     S: proto::crypto::Session,
 {
@@ -568,7 +566,7 @@ where
 #[derive(Debug)]
 pub struct IncomingBiStreams<S: proto::crypto::Session>(ConnectionRef<S>);
 
-impl<S> futures::Stream for IncomingBiStreams<S>
+impl<S> futures_core::stream::Stream for IncomingBiStreams<S>
 where
     S: proto::crypto::Session,
 {
@@ -599,7 +597,7 @@ where
 #[derive(Debug)]
 pub struct Datagrams<S: proto::crypto::Session>(ConnectionRef<S>);
 
-impl<S> futures::Stream for Datagrams<S>
+impl<S> futures_core::stream::Stream for Datagrams<S>
 where
     S: proto::crypto::Session,
 {

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -537,7 +537,7 @@ where
 #[derive(Debug)]
 pub struct IncomingUniStreams<S: proto::crypto::Session>(ConnectionRef<S>);
 
-impl<S> futures_core::stream::Stream for IncomingUniStreams<S>
+impl<S> futures_util::stream::Stream for IncomingUniStreams<S>
 where
     S: proto::crypto::Session,
 {
@@ -566,7 +566,7 @@ where
 #[derive(Debug)]
 pub struct IncomingBiStreams<S: proto::crypto::Session>(ConnectionRef<S>);
 
-impl<S> futures_core::stream::Stream for IncomingBiStreams<S>
+impl<S> futures_util::stream::Stream for IncomingBiStreams<S>
 where
     S: proto::crypto::Session,
 {
@@ -597,7 +597,7 @@ where
 #[derive(Debug)]
 pub struct Datagrams<S: proto::crypto::Session>(ConnectionRef<S>);
 
-impl<S> futures_core::stream::Stream for Datagrams<S>
+impl<S> futures_util::stream::Stream for Datagrams<S>
 where
     S: proto::crypto::Session,
 {

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -13,7 +13,8 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures::{channel::mpsc, StreamExt};
+use futures_channel::mpsc;
+use futures_util::StreamExt;
 use fxhash::FxHashMap;
 use once_cell::sync::OnceCell;
 use proto::{self as proto, generic::ClientConfig, ConnectError, ConnectionHandle, DatagramEvent};
@@ -155,7 +156,7 @@ where
     /// [`Incoming`]: crate::generic::Incoming
     pub async fn wait_idle(&self) {
         let mut state = broadcast::State::default();
-        futures::future::poll_fn(|cx| {
+        futures_util::future::poll_fn(|cx| {
             let endpoint = &mut *self.inner.lock().unwrap();
             if endpoint.connections.is_empty() {
                 return Poll::Ready(());
@@ -459,7 +460,7 @@ where
     }
 }
 
-impl<S> futures::Stream for Incoming<S>
+impl<S> futures_core::stream::Stream for Incoming<S>
 where
     S: proto::crypto::Session,
 {

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -460,7 +460,7 @@ where
     }
 }
 
-impl<S> futures_core::stream::Stream for Incoming<S>
+impl<S> futures_util::stream::Stream for Incoming<S>
 where
     S: proto::crypto::Session,
 {

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -11,7 +11,7 @@
 #![cfg_attr(
     feature = "rustls",
     doc = "```no_run
-# use futures::TryFutureExt;
+# use futures_util::TryFutureExt;
 let mut builder = quinn::Endpoint::builder();
 // ... configure builder ...
 // Ensure you're inside a tokio runtime context

--- a/quinn/src/platform/fallback.rs
+++ b/quinn/src/platform/fallback.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::ready;
+use futures_util::ready;
 use proto::Transmit;
 use tokio::io::ReadBuf;
 

--- a/quinn/src/platform/unix.rs
+++ b/quinn/src/platform/unix.rs
@@ -8,7 +8,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures_core::ready;
+use futures_util::ready;
 use lazy_static::lazy_static;
 use proto::{EcnCodepoint, Transmit};
 use tokio::io::unix::AsyncFd;

--- a/quinn/src/platform/unix.rs
+++ b/quinn/src/platform/unix.rs
@@ -8,7 +8,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::ready;
+use futures_core::ready;
 use lazy_static::lazy_static;
 use proto::{EcnCodepoint, Transmit};
 use tokio::io::unix::AsyncFd;

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -6,8 +6,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures_core::ready;
-use futures_util::AsyncRead;
+use futures_util::{io::AsyncRead, ready};
 use proto::{Chunk, Chunks, ConnectionError, ReadableError, StreamId};
 use thiserror::Error;
 use tokio::io::ReadBuf;

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -6,7 +6,8 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures::{io::AsyncRead, ready};
+use futures_core::ready;
+use futures_util::AsyncRead;
 use proto::{Chunk, Chunks, ConnectionError, ReadableError, StreamId};
 use thiserror::Error;
 use tokio::io::ReadBuf;

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -1,14 +1,14 @@
-use bytes::Bytes;
-use futures_channel::oneshot;
-use futures_core::ready;
-use futures_util::{io::AsyncWrite, FutureExt};
-use proto::{ConnectionError, FinishError, StreamId, Written};
 use std::{
     future::Future,
     io,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use bytes::Bytes;
+use futures_channel::oneshot;
+use futures_util::{io::AsyncWrite, ready, FutureExt};
+use proto::{ConnectionError, FinishError, StreamId, Written};
 use thiserror::Error;
 
 use crate::{connection::ConnectionRef, recv_stream::UnknownStream, VarInt};

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -1,13 +1,14 @@
+use bytes::Bytes;
+use futures_channel::oneshot;
+use futures_core::ready;
+use futures_util::{io::AsyncWrite, FutureExt};
+use proto::{ConnectionError, FinishError, StreamId, Written};
 use std::{
     future::Future,
     io,
     pin::Pin,
     task::{Context, Poll},
 };
-
-use bytes::Bytes;
-use futures::{channel::oneshot, io::AsyncWrite, ready, FutureExt};
-use proto::{ConnectionError, FinishError, StreamId, Written};
 use thiserror::Error;
 
 use crate::{connection::ConnectionRef, recv_stream::UnknownStream, VarInt};

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -8,7 +8,8 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures::{future, StreamExt};
+use futures_util::future;
+use futures_util::StreamExt;
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use tokio::{
     runtime::{Builder, Runtime},
@@ -514,7 +515,7 @@ fn run_echo(args: EchoArgs) {
                 };
                 let recv_task = async { recv.read_to_end(usize::max_value()).await.expect("read") };
 
-                let (_, data) = futures::join!(send_task, recv_task);
+                let (_, data) = futures_util::join!(send_task, recv_task);
 
                 assert_eq!(data[..], msg[..], "Data mismatch");
             }

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crc::crc32;
-use futures::{future, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
+use futures_util::{future, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use quinn::{ConnectionError, ReadError, WriteError};
 use rand::{self, RngCore};
 use tokio::runtime::Builder;


### PR DESCRIPTION
…This way we can streamline our dependencies, e.g. futures-executor is not used at all

Additionally i updated the dependencies to futures 0.3.11, as 0.3.8 is yanked (same for 0.3.9 and 0.3.10)