### PR TITLE
Infallible `TransportConfig` setters

### DIFF
--- a/bench/src/bulk.rs
+++ b/bench/src/bulk.rs
@@ -1,4 +1,5 @@
 use std::{
+    convert::TryInto,
     net::{IpAddr, Ipv6Addr, SocketAddr},
     str::FromStr,
     sync::Arc,
@@ -271,9 +272,7 @@ fn transport_config(opt: &Opt) -> quinn::TransportConfig {
     // High stream windows are chosen because the amount of concurrent streams
     // is configurable as a parameter.
     let mut config = quinn::TransportConfig::default();
-    config
-        .max_concurrent_uni_streams(opt.max_streams as u64)
-        .unwrap();
+    config.max_concurrent_uni_streams(opt.max_streams.try_into().unwrap());
     config
 }
 

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -2,6 +2,7 @@
 #![type_length_limit = "2121396"]
 
 use std::{
+    convert::TryInto,
     env,
     net::{SocketAddr, ToSocketAddrs},
     sync::{Arc, Mutex},
@@ -276,10 +277,8 @@ impl State {
         }
         let mut transport = quinn::TransportConfig::default();
         transport.send_window(1024 * 1024 * 2);
-        transport.receive_window(1024 * 1024 * 2).unwrap();
-        transport
-            .max_idle_timeout(Some(Duration::from_secs(1)))
-            .unwrap();
+        transport.receive_window((1024_u32 * 1024 * 2).into());
+        transport.max_idle_timeout(Some(Duration::from_secs(1).try_into().unwrap()));
         let client_config = quinn::ClientConfig {
             crypto: Arc::new(tls_config),
             transport: Arc::new(transport),

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<()> {
 async fn server(server_config: quinn::ServerConfigBuilder, addr: SocketAddr) -> Result<()> {
     let mut transport = quinn::TransportConfig::default();
     transport.send_window(1024 * 1024 * 3);
-    transport.receive_window(1024 * 1024).unwrap();
+    transport.receive_window((1024_u32 * 1024).into());
     let mut server_config = server_config.build();
     server_config.transport = Arc::new(transport);
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -46,7 +46,7 @@ pub use crate::connection::{
 };
 
 mod config;
-pub use config::{ConfigError, TransportConfig};
+pub use config::{ConfigError, IdleTimeout, TransportConfig};
 
 pub mod crypto;
 #[cfg(feature = "rustls")]

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -7,7 +7,7 @@
 //! implementations of the `crypto::Session` trait.
 
 use std::{
-    convert::{TryFrom, TryInto},
+    convert::TryFrom,
     net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6},
 };
 
@@ -134,11 +134,7 @@ impl TransportParameters {
             initial_max_stream_data_bidi_remote: config.stream_receive_window,
             initial_max_stream_data_uni: config.stream_receive_window,
             max_udp_payload_size: endpoint_config.max_udp_payload_size,
-            max_idle_timeout: config.max_idle_timeout.map_or(0u32.into(), |x| {
-                x.as_millis()
-                    .try_into()
-                    .expect("setter guarantees this is in-bounds")
-            }),
+            max_idle_timeout: config.max_idle_timeout.unwrap_or(VarInt(0)),
             disable_active_migration: server_config.map_or(false, |c| !c.migration),
             active_connection_id_limit: if cid_gen.cid_len() == 0 {
                 2 // i.e. default, i.e. unsent

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -83,7 +83,7 @@ impl Context {
         let cert_chain = quinn::CertificateChain::from_certs(vec![cert.clone()]);
 
         let mut transport = quinn::TransportConfig::default();
-        transport.max_concurrent_uni_streams(1024).unwrap();
+        transport.max_concurrent_uni_streams(1024_u16.into());
         let mut server_config = quinn::ServerConfig::default();
         server_config.transport = Arc::new(transport);
         let mut server_config = ServerConfigBuilder::new(server_config);

--- a/quinn/examples/common/mod.rs
+++ b/quinn/examples/common/mod.rs
@@ -62,7 +62,7 @@ fn configure_server() -> Result<(ServerConfig, Vec<u8>), Box<dyn Error>> {
     let priv_key = PrivateKey::from_der(&priv_key)?;
 
     let mut transport_config = TransportConfig::default();
-    transport_config.max_concurrent_uni_streams(0).unwrap();
+    transport_config.max_concurrent_uni_streams(0_u8.into());
     let mut server_config = ServerConfig::default();
     server_config.transport = Arc::new(transport_config);
     let mut cfg_builder = ServerConfigBuilder::new(server_config);

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -64,7 +64,7 @@ fn main() {
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527
 async fn run(options: Opt) -> Result<()> {
     let mut transport_config = quinn::TransportConfig::default();
-    transport_config.max_concurrent_uni_streams(0).unwrap();
+    transport_config.max_concurrent_uni_streams(0_u8.into());
     let mut server_config = quinn::ServerConfig::default();
     server_config.transport = Arc::new(transport_config);
     let mut server_config = quinn::ServerConfigBuilder::new(server_config);

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -64,8 +64,8 @@ mod work_limiter;
 
 pub use proto::{
     crypto, ApplicationClose, Certificate, CertificateChain, Chunk, ConfigError, ConnectError,
-    ConnectionClose, ConnectionError, ParseError, PrivateKey, StreamId, Transmit, TransportConfig,
-    VarInt,
+    ConnectionClose, ConnectionError, IdleTimeout, ParseError, PrivateKey, StreamId, Transmit,
+    TransportConfig, VarInt,
 };
 
 pub use crate::builders::EndpointError;

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "rustls")]
 
 use std::{
+    convert::TryInto,
     io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
     str,
@@ -39,8 +40,7 @@ fn handshake_timeout() {
     const IDLE_TIMEOUT: Duration = Duration::from_millis(500);
     let mut transport_config = crate::TransportConfig::default();
     transport_config
-        .max_idle_timeout(Some(IDLE_TIMEOUT))
-        .unwrap()
+        .max_idle_timeout(Some(IDLE_TIMEOUT.try_into().unwrap()))
         .initial_rtt(Duration::from_millis(10));
     client_config.transport = Arc::new(transport_config);
 
@@ -420,15 +420,13 @@ fn run_echo(args: EchoArgs) {
         // Use small receive windows
         let mut transport_config = TransportConfig::default();
         if let Some(receive_window) = args.receive_window {
-            transport_config.receive_window(receive_window).unwrap();
+            transport_config.receive_window(receive_window.try_into().unwrap());
         }
         if let Some(stream_receive_window) = args.stream_receive_window {
-            transport_config
-                .stream_receive_window(stream_receive_window)
-                .unwrap();
+            transport_config.stream_receive_window(stream_receive_window.try_into().unwrap());
         }
-        transport_config.max_concurrent_bidi_streams(1).unwrap();
-        transport_config.max_concurrent_uni_streams(1).unwrap();
+        transport_config.max_concurrent_bidi_streams(1_u8.into());
+        transport_config.max_concurrent_uni_streams(1_u8.into());
         let transport_config = Arc::new(transport_config);
 
         // We don't use the `endpoint` helper here because we want two different endpoints with

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "rustls")]
 use std::{
+    convert::TryInto,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -134,9 +135,7 @@ fn configure_connector(node_cert: &[u8]) -> quinn::ClientConfig {
     unwrap!(peer_cfg_builder.add_certificate_authority(their_cert));
     let mut peer_cfg = peer_cfg_builder.build();
     let transport_config = unwrap!(Arc::get_mut(&mut peer_cfg.transport));
-    transport_config
-        .max_idle_timeout(Some(Duration::from_secs(20)))
-        .unwrap();
+    transport_config.max_idle_timeout(Some(Duration::from_secs(20).try_into().unwrap()));
 
     peer_cfg
 }
@@ -154,9 +153,7 @@ fn configure_listener() -> (quinn::ServerConfig, Vec<u8>) {
     ));
     let mut our_cfg = our_cfg_builder.build();
     let transport_config = unwrap!(Arc::get_mut(&mut our_cfg.transport));
-    transport_config
-        .max_idle_timeout(Some(Duration::from_secs(20)))
-        .unwrap();
+    transport_config.max_idle_timeout(Some(Duration::from_secs(20).try_into().unwrap()));
 
     (our_cfg, our_cert_der)
 }


### PR DESCRIPTION
Based on the discussion in #1176, I've updated the relevant `TransportConfig` setters to take `VarInt`, so they become infallible. In most cases, this is just a case of applying `.into()`/`.try_into()` to the argument (particularly with the addition of `TryFrom<Duration> for VarInt`).

In that issue one thing suggested was using `impl Into<VarInt>`, in the end I left that out since it doesn't do much for literal arguments, which still need to be ascribed with a relevant type (e.g. `1u8`).

---

- 0f840f01 **Use `VarInt` in `TransportConfig`'s `VarInt` field setters**

  Rather than taking a `u64` and returning a `ConfigError::OutOfBounds`,
  these methods are now infallible by taking a `VarInt` directly.
  
  In many cases, call-sites can be updated simply by adding a `.into()` or
  `.try_into()` to the argument.
  
  BREAKING CHANGE: The `max_concurrent_bidi_streams`,
  `max_concurrent_uni_streams`, `stream_receive_window`, and
  `receive_window` methods on `TransportConfig` now take `VarInt`
  arguments and return `&mut Self`.

- 5713ddaf **Use `VarInt` in `TransportConfig` `max_idle_timeout` field**

  Rather than using `Duration` internally, max idle timoout is now stored
  as a `VarInt`. This avoids some conversions and an internal `unwrap`.

- edf1e786 **Implement `TryFrom<Duration>` for `VarInt`**

  This tries to encode a `Duration`, as milliseconds, into a `VarInt`.

- d707827b **Use `VarInt` in `TransportConfig` `max_idle_timeout` setter**

  This allows the setter to be infallible. The impl of `TryFrom<Duration>`
  for `VarInt` means call-sites can just use `.try_into()`.
  
  BREAKING CHANGE: The `max_idle_timeout` method on `TransportConfig` now
  takes a `VarInt` argument and returns `&mut Self`.
