### PR TITLE
Fix cubic minimum congestion window handling

### DIFF
--- a/quinn-proto/src/congestion/cubic.rs
+++ b/quinn-proto/src/congestion/cubic.rs
@@ -191,10 +191,7 @@ impl Controller for Cubic {
 
         self.cubic_state.w_max = self.window as f64;
         self.ssthresh = (self.cubic_state.w_max * BETA_CUBIC) as u64;
-        self.ssthresh = cmp::max(
-            self.ssthresh,
-            self.config.max_datagram_size * self.config.minimum_window,
-        );
+        self.ssthresh = cmp::max(self.ssthresh, self.config.minimum_window);
         self.window = self.ssthresh;
         self.cubic_state.k = self.cubic_state.cubic_k(self.config.max_datagram_size);
 


### PR DESCRIPTION
`config.minimum_window` is already in bytes - it doesn't have to be multiplied by them..