### PR TITLE
Return owned memory via BytesMut to reduce downstream copying

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -15,7 +15,7 @@ quinn = { path = "../quinn" }
 rcgen = "0.8"
 rustls = "0.19"
 structopt = "0.3"
-tokio = { version = "1.0.1", features = ["rt"] }
+tokio = { version = "1.0.1", features = ["rt", "sync"] }
 tracing = "0.1.10"
 tracing-subscriber = { version = "0.2.5", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}
 

--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -342,8 +342,8 @@ pub struct IllegalOrderedRead;
 mod test {
     use super::*;
     use assert_matches::assert_matches;
-    use std::iter::FromIterator;
     use bytes::Bytes;
+    use std::iter::FromIterator;
 
     #[test]
     fn assemble_ordered() {

--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -4,7 +4,7 @@ use std::{
     mem,
 };
 
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::{Buf, BytesMut};
 
 use crate::range_set::RangeSet;
 

--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -128,7 +128,7 @@ impl Assembler {
             if chunk.offset != offset + (buffer.len() as u64) {
                 if !buffer.is_empty() {
                     self.data
-                        .push(Buffer::new_defragmented(offset, buffer.split().freeze()));
+                        .push(Buffer::new_defragmented(offset, buffer.split()));
                 }
                 offset = chunk.offset;
             }
@@ -136,13 +136,13 @@ impl Assembler {
         }
         if !buffer.is_empty() {
             self.data
-                .push(Buffer::new_defragmented(offset, buffer.split().freeze()));
+                .push(Buffer::new_defragmented(offset, buffer.split()));
         }
     }
 
     // Note: If a packet contains many frames from the same stream, the estimated over-allocation
     // will be much higher because we are counting the same allocation multiple times.
-    pub(crate) fn insert(&mut self, mut offset: u64, mut bytes: Bytes, allocation_size: usize) {
+    pub(crate) fn insert(&mut self, mut offset: u64, mut bytes: BytesMut, allocation_size: usize) {
         debug_assert!(
             bytes.len() <= allocation_size,
             "allocation_size less than bytes.len(): {:?} < {:?}",
@@ -226,11 +226,11 @@ pub struct Chunk {
     /// The offset in the stream
     pub offset: u64,
     /// The contents of the chunk
-    pub bytes: Bytes,
+    pub bytes: BytesMut,
 }
 
 impl Chunk {
-    fn new(offset: u64, bytes: Bytes) -> Self {
+    fn new(offset: u64, bytes: BytesMut) -> Self {
         Chunk { offset, bytes }
     }
 }
@@ -238,7 +238,7 @@ impl Chunk {
 #[derive(Debug, Eq)]
 struct Buffer {
     offset: u64,
-    bytes: Bytes,
+    bytes: BytesMut,
     /// Size of the allocation behind `bytes`, if `defragmented == false`.
     /// Otherwise this will be set to `bytes.len()` by `try_mark_defragment`.
     /// Will never be less than `bytes.len()`.
@@ -248,7 +248,7 @@ struct Buffer {
 
 impl Buffer {
     /// Constructs a new fragmented Buffer
-    fn new(offset: u64, bytes: Bytes, allocation_size: usize) -> Self {
+    fn new(offset: u64, bytes: BytesMut, allocation_size: usize) -> Self {
         Self {
             offset,
             bytes,
@@ -258,7 +258,7 @@ impl Buffer {
     }
 
     /// Constructs a new defragmented Buffer
-    fn new_defragmented(offset: u64, bytes: Bytes) -> Self {
+    fn new_defragmented(offset: u64, bytes: BytesMut) -> Self {
         let allocation_size = bytes.len();
         Self {
             offset,
@@ -273,7 +273,7 @@ impl Buffer {
         let duplicate = offset.saturating_sub(self.offset) as usize;
         self.offset = self.offset.max(offset);
         if duplicate >= self.bytes.len() {
-            self.bytes = Bytes::new();
+            self.bytes = BytesMut::new();
             self.defragmented = true;
             self.allocation_size = 0;
             return;
@@ -342,18 +342,19 @@ pub struct IllegalOrderedRead;
 mod test {
     use super::*;
     use assert_matches::assert_matches;
+    use std::iter::FromIterator;
 
     #[test]
     fn assemble_ordered() {
         let mut x = Assembler::new();
         assert_matches!(next(&mut x, 32), None);
-        x.insert(0, Bytes::from_static(b"123"), 3);
+        x.insert(0, BytesMut::from_iter(b"123"), 3);
         assert_matches!(next(&mut x, 1), Some(ref y) if &y[..] == b"1");
         assert_matches!(next(&mut x, 3), Some(ref y) if &y[..] == b"23");
-        x.insert(3, Bytes::from_static(b"456"), 3);
+        x.insert(3, BytesMut::from_iter(b"456"), 3);
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"456");
-        x.insert(6, Bytes::from_static(b"789"), 3);
-        x.insert(9, Bytes::from_static(b"10"), 2);
+        x.insert(6, BytesMut::from_iter(b"789"), 3);
+        x.insert(9, BytesMut::from_iter(b"10"), 2);
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"789");
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"10");
         assert_matches!(next(&mut x, 32), None);
@@ -363,9 +364,9 @@ mod test {
     fn assemble_unordered() {
         let mut x = Assembler::new();
         x.ensure_ordering(false).unwrap();
-        x.insert(3, Bytes::from_static(b"456"), 3);
+        x.insert(3, BytesMut::from_iter(b"456"), 3);
         assert_matches!(next(&mut x, 32), None);
-        x.insert(0, Bytes::from_static(b"123"), 3);
+        x.insert(0, BytesMut::from_iter(b"123"), 3);
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"123");
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"456");
         assert_matches!(next(&mut x, 32), None);
@@ -374,8 +375,8 @@ mod test {
     #[test]
     fn assemble_duplicate() {
         let mut x = Assembler::new();
-        x.insert(0, Bytes::from_static(b"123"), 3);
-        x.insert(0, Bytes::from_static(b"123"), 3);
+        x.insert(0, BytesMut::from_iter(b"123"), 3);
+        x.insert(0, BytesMut::from_iter(b"123"), 3);
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"123");
         assert_matches!(next(&mut x, 32), None);
     }
@@ -383,8 +384,8 @@ mod test {
     #[test]
     fn assemble_duplicate_compact() {
         let mut x = Assembler::new();
-        x.insert(0, Bytes::from_static(b"123"), 3);
-        x.insert(0, Bytes::from_static(b"123"), 3);
+        x.insert(0, BytesMut::from_iter(b"123"), 3);
+        x.insert(0, BytesMut::from_iter(b"123"), 3);
         x.defragment();
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"123");
         assert_matches!(next(&mut x, 32), None);
@@ -393,8 +394,8 @@ mod test {
     #[test]
     fn assemble_contained() {
         let mut x = Assembler::new();
-        x.insert(0, Bytes::from_static(b"12345"), 5);
-        x.insert(1, Bytes::from_static(b"234"), 3);
+        x.insert(0, BytesMut::from_iter(b"12345"), 5);
+        x.insert(1, BytesMut::from_iter(b"234"), 3);
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"12345");
         assert_matches!(next(&mut x, 32), None);
     }
@@ -402,8 +403,8 @@ mod test {
     #[test]
     fn assemble_contained_compact() {
         let mut x = Assembler::new();
-        x.insert(0, Bytes::from_static(b"12345"), 5);
-        x.insert(1, Bytes::from_static(b"234"), 3);
+        x.insert(0, BytesMut::from_iter(b"12345"), 5);
+        x.insert(1, BytesMut::from_iter(b"234"), 3);
         x.defragment();
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"12345");
         assert_matches!(next(&mut x, 32), None);
@@ -412,8 +413,8 @@ mod test {
     #[test]
     fn assemble_contains() {
         let mut x = Assembler::new();
-        x.insert(1, Bytes::from_static(b"234"), 3);
-        x.insert(0, Bytes::from_static(b"12345"), 5);
+        x.insert(1, BytesMut::from_iter(b"234"), 3);
+        x.insert(0, BytesMut::from_iter(b"12345"), 5);
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"12345");
         assert_matches!(next(&mut x, 32), None);
     }
@@ -421,8 +422,8 @@ mod test {
     #[test]
     fn assemble_contains_compact() {
         let mut x = Assembler::new();
-        x.insert(1, Bytes::from_static(b"234"), 3);
-        x.insert(0, Bytes::from_static(b"12345"), 5);
+        x.insert(1, BytesMut::from_iter(b"234"), 3);
+        x.insert(0, BytesMut::from_iter(b"12345"), 5);
         x.defragment();
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"12345");
         assert_matches!(next(&mut x, 32), None);
@@ -431,8 +432,8 @@ mod test {
     #[test]
     fn assemble_overlapping() {
         let mut x = Assembler::new();
-        x.insert(0, Bytes::from_static(b"123"), 3);
-        x.insert(1, Bytes::from_static(b"234"), 3);
+        x.insert(0, BytesMut::from_iter(b"123"), 3);
+        x.insert(1, BytesMut::from_iter(b"234"), 3);
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"123");
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"4");
         assert_matches!(next(&mut x, 32), None);
@@ -441,8 +442,8 @@ mod test {
     #[test]
     fn assemble_overlapping_compact() {
         let mut x = Assembler::new();
-        x.insert(0, Bytes::from_static(b"123"), 4);
-        x.insert(1, Bytes::from_static(b"234"), 4);
+        x.insert(0, BytesMut::from_iter(b"123"), 4);
+        x.insert(1, BytesMut::from_iter(b"234"), 4);
         x.defragment();
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"1234");
         assert_matches!(next(&mut x, 32), None);
@@ -451,10 +452,10 @@ mod test {
     #[test]
     fn assemble_complex() {
         let mut x = Assembler::new();
-        x.insert(0, Bytes::from_static(b"1"), 1);
-        x.insert(2, Bytes::from_static(b"3"), 1);
-        x.insert(4, Bytes::from_static(b"5"), 1);
-        x.insert(0, Bytes::from_static(b"123456"), 6);
+        x.insert(0, BytesMut::from_iter(b"1"), 1);
+        x.insert(2, BytesMut::from_iter(b"3"), 1);
+        x.insert(4, BytesMut::from_iter(b"5"), 1);
+        x.insert(0, BytesMut::from_iter(b"123456"), 6);
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"123456");
         assert_matches!(next(&mut x, 32), None);
     }
@@ -462,10 +463,10 @@ mod test {
     #[test]
     fn assemble_complex_compact() {
         let mut x = Assembler::new();
-        x.insert(0, Bytes::from_static(b"1"), 1);
-        x.insert(2, Bytes::from_static(b"3"), 1);
-        x.insert(4, Bytes::from_static(b"5"), 1);
-        x.insert(0, Bytes::from_static(b"123456"), 6);
+        x.insert(0, BytesMut::from_iter(b"1"), 1);
+        x.insert(2, BytesMut::from_iter(b"3"), 1);
+        x.insert(4, BytesMut::from_iter(b"5"), 1);
+        x.insert(0, BytesMut::from_iter(b"123456"), 6);
         x.defragment();
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"123456");
         assert_matches!(next(&mut x, 32), None);
@@ -474,55 +475,55 @@ mod test {
     #[test]
     fn assemble_old() {
         let mut x = Assembler::new();
-        x.insert(0, Bytes::from_static(b"1234"), 4);
+        x.insert(0, BytesMut::from_iter(b"1234"), 4);
         assert_matches!(next(&mut x, 32), Some(ref y) if &y[..] == b"1234");
-        x.insert(0, Bytes::from_static(b"1234"), 4);
+        x.insert(0, BytesMut::from_iter(b"1234"), 4);
         assert_matches!(next(&mut x, 32), None);
     }
 
     #[test]
     fn compact() {
         let mut x = Assembler::new();
-        x.insert(0, Bytes::from_static(b"abc"), 4);
-        x.insert(3, Bytes::from_static(b"def"), 4);
-        x.insert(9, Bytes::from_static(b"jkl"), 4);
-        x.insert(12, Bytes::from_static(b"mno"), 4);
+        x.insert(0, BytesMut::from_iter(b"abc"), 4);
+        x.insert(3, BytesMut::from_iter(b"def"), 4);
+        x.insert(9, BytesMut::from_iter(b"jkl"), 4);
+        x.insert(12, BytesMut::from_iter(b"mno"), 4);
         x.defragment();
         assert_eq!(
             next_unordered(&mut x),
-            Chunk::new(0, Bytes::from_static(b"abcdef"))
+            Chunk::new(0, BytesMut::from_iter(b"abcdef"))
         );
         assert_eq!(
             next_unordered(&mut x),
-            Chunk::new(9, Bytes::from_static(b"jklmno"))
+            Chunk::new(9, BytesMut::from_iter(b"jklmno"))
         );
     }
 
     #[test]
     fn defrag_with_missing_prefix() {
         let mut x = Assembler::new();
-        x.insert(3, Bytes::from_static(b"def"), 3);
+        x.insert(3, BytesMut::from_iter(b"def"), 3);
         x.defragment();
         assert_eq!(
             next_unordered(&mut x),
-            Chunk::new(3, Bytes::from_static(b"def"))
+            Chunk::new(3, BytesMut::from_iter(b"def"))
         );
     }
 
     #[test]
     fn defrag_read_chunk() {
         let mut x = Assembler::new();
-        x.insert(3, Bytes::from_static(b"def"), 4);
-        x.insert(0, Bytes::from_static(b"abc"), 4);
-        x.insert(7, Bytes::from_static(b"hij"), 4);
-        x.insert(11, Bytes::from_static(b"lmn"), 4);
+        x.insert(3, BytesMut::from_iter(b"def"), 4);
+        x.insert(0, BytesMut::from_iter(b"abc"), 4);
+        x.insert(7, BytesMut::from_iter(b"hij"), 4);
+        x.insert(11, BytesMut::from_iter(b"lmn"), 4);
         x.defragment();
         assert_matches!(x.read(usize::MAX, true), Some(ref y) if &y.bytes[..] == b"abcdef");
-        x.insert(5, Bytes::from_static(b"fghijklmn"), 9);
+        x.insert(5, BytesMut::from_iter(b"fghijklmn"), 9);
         assert_matches!(x.read(usize::MAX, true), Some(ref y) if &y.bytes[..] == b"ghijklmn");
-        x.insert(13, Bytes::from_static(b"nopq"), 4);
+        x.insert(13, BytesMut::from_iter(b"nopq"), 4);
         assert_matches!(x.read(usize::MAX, true), Some(ref y) if &y.bytes[..] == b"opq");
-        x.insert(15, Bytes::from_static(b"pqrs"), 4);
+        x.insert(15, BytesMut::from_iter(b"pqrs"), 4);
         assert_matches!(x.read(usize::MAX, true), Some(ref y) if &y.bytes[..] == b"rs");
         assert_matches!(x.read(usize::MAX, true), None);
     }
@@ -531,16 +532,16 @@ mod test {
     fn unordered_happy_path() {
         let mut x = Assembler::new();
         x.ensure_ordering(false).unwrap();
-        x.insert(0, Bytes::from_static(b"abc"), 3);
+        x.insert(0, BytesMut::from_iter(b"abc"), 3);
         assert_eq!(
             next_unordered(&mut x),
-            Chunk::new(0, Bytes::from_static(b"abc"))
+            Chunk::new(0, BytesMut::from_iter(b"abc"))
         );
         assert_eq!(x.read(usize::MAX, false), None);
-        x.insert(3, Bytes::from_static(b"def"), 3);
+        x.insert(3, BytesMut::from_iter(b"def"), 3);
         assert_eq!(
             next_unordered(&mut x),
-            Chunk::new(3, Bytes::from_static(b"def"))
+            Chunk::new(3, BytesMut::from_iter(b"def"))
         );
         assert_eq!(x.read(usize::MAX, false), None);
     }
@@ -549,104 +550,104 @@ mod test {
     fn unordered_dedup() {
         let mut x = Assembler::new();
         x.ensure_ordering(false).unwrap();
-        x.insert(3, Bytes::from_static(b"def"), 3);
+        x.insert(3, BytesMut::from_iter(b"def"), 3);
         assert_eq!(
             next_unordered(&mut x),
-            Chunk::new(3, Bytes::from_static(b"def"))
+            Chunk::new(3, BytesMut::from_iter(b"def"))
         );
         assert_eq!(x.read(usize::MAX, false), None);
-        x.insert(0, Bytes::from_static(b"a"), 1);
-        x.insert(0, Bytes::from_static(b"abcdefghi"), 9);
-        x.insert(0, Bytes::from_static(b"abcd"), 4);
+        x.insert(0, BytesMut::from_iter(b"a"), 1);
+        x.insert(0, BytesMut::from_iter(b"abcdefghi"), 9);
+        x.insert(0, BytesMut::from_iter(b"abcd"), 4);
         assert_eq!(
             next_unordered(&mut x),
-            Chunk::new(0, Bytes::from_static(b"a"))
+            Chunk::new(0, BytesMut::from_iter(b"a"))
         );
         assert_eq!(
             next_unordered(&mut x),
-            Chunk::new(1, Bytes::from_static(b"bc"))
+            Chunk::new(1, BytesMut::from_iter(b"bc"))
         );
         assert_eq!(
             next_unordered(&mut x),
-            Chunk::new(6, Bytes::from_static(b"ghi"))
-        );
-        assert_eq!(x.read(usize::MAX, false), None);
-        x.insert(8, Bytes::from_static(b"ijkl"), 4);
-        assert_eq!(
-            next_unordered(&mut x),
-            Chunk::new(9, Bytes::from_static(b"jkl"))
+            Chunk::new(6, BytesMut::from_iter(b"ghi"))
         );
         assert_eq!(x.read(usize::MAX, false), None);
-        x.insert(12, Bytes::from_static(b"mno"), 3);
+        x.insert(8, BytesMut::from_iter(b"ijkl"), 4);
         assert_eq!(
             next_unordered(&mut x),
-            Chunk::new(12, Bytes::from_static(b"mno"))
+            Chunk::new(9, BytesMut::from_iter(b"jkl"))
         );
         assert_eq!(x.read(usize::MAX, false), None);
-        x.insert(2, Bytes::from_static(b"cde"), 3);
+        x.insert(12, BytesMut::from_iter(b"mno"), 3);
+        assert_eq!(
+            next_unordered(&mut x),
+            Chunk::new(12, BytesMut::from_iter(b"mno"))
+        );
+        assert_eq!(x.read(usize::MAX, false), None);
+        x.insert(2, BytesMut::from_iter(b"cde"), 3);
         assert_eq!(x.read(usize::MAX, false), None);
     }
 
     #[test]
     fn chunks_dedup() {
         let mut x = Assembler::new();
-        x.insert(3, Bytes::from_static(b"def"), 3);
+        x.insert(3, BytesMut::from_iter(b"def"), 3);
         assert_eq!(x.read(usize::MAX, true), None);
-        x.insert(0, Bytes::from_static(b"a"), 1);
-        x.insert(1, Bytes::from_static(b"bcdefghi"), 9);
-        x.insert(0, Bytes::from_static(b"abcd"), 4);
+        x.insert(0, BytesMut::from_iter(b"a"), 1);
+        x.insert(1, BytesMut::from_iter(b"bcdefghi"), 9);
+        x.insert(0, BytesMut::from_iter(b"abcd"), 4);
         assert_eq!(
             x.read(usize::MAX, true),
-            Some(Chunk::new(0, Bytes::from_static(b"abcd")))
+            Some(Chunk::new(0, BytesMut::from_iter(b"abcd")))
         );
         assert_eq!(
             x.read(usize::MAX, true),
-            Some(Chunk::new(4, Bytes::from_static(b"efghi")))
+            Some(Chunk::new(4, BytesMut::from_iter(b"efghi")))
         );
         assert_eq!(x.read(usize::MAX, true), None);
-        x.insert(8, Bytes::from_static(b"ijkl"), 4);
+        x.insert(8, BytesMut::from_iter(b"ijkl"), 4);
         assert_eq!(
             x.read(usize::MAX, true),
-            Some(Chunk::new(9, Bytes::from_static(b"jkl")))
+            Some(Chunk::new(9, BytesMut::from_iter(b"jkl")))
         );
         assert_eq!(x.read(usize::MAX, true), None);
-        x.insert(12, Bytes::from_static(b"mno"), 3);
+        x.insert(12, BytesMut::from_iter(b"mno"), 3);
         assert_eq!(
             x.read(usize::MAX, true),
-            Some(Chunk::new(12, Bytes::from_static(b"mno")))
+            Some(Chunk::new(12, BytesMut::from_iter(b"mno")))
         );
         assert_eq!(x.read(usize::MAX, true), None);
-        x.insert(2, Bytes::from_static(b"cde"), 3);
+        x.insert(2, BytesMut::from_iter(b"cde"), 3);
         assert_eq!(x.read(usize::MAX, true), None);
     }
 
     #[test]
     fn ordered_eager_discard() {
         let mut x = Assembler::new();
-        x.insert(0, Bytes::from_static(b"abc"), 3);
+        x.insert(0, BytesMut::from_iter(b"abc"), 3);
         assert_eq!(x.data.len(), 1);
         assert_eq!(
             x.read(usize::MAX, true),
-            Some(Chunk::new(0, Bytes::from_static(b"abc")))
+            Some(Chunk::new(0, BytesMut::from_iter(b"abc")))
         );
-        x.insert(0, Bytes::from_static(b"ab"), 2);
+        x.insert(0, BytesMut::from_iter(b"ab"), 2);
         assert_eq!(x.data.len(), 0);
-        x.insert(2, Bytes::from_static(b"cd"), 2);
+        x.insert(2, BytesMut::from_iter(b"cd"), 2);
         assert_eq!(
             x.data.peek(),
-            Some(&Buffer::new(3, Bytes::from_static(b"d"), 2))
+            Some(&Buffer::new(3, BytesMut::from_iter(b"d"), 2))
         );
     }
 
     #[test]
     fn ordered_insert_unordered_read() {
         let mut x = Assembler::new();
-        x.insert(0, Bytes::from_static(b"abc"), 3);
-        x.insert(0, Bytes::from_static(b"abc"), 3);
+        x.insert(0, BytesMut::from_iter(b"abc"), 3);
+        x.insert(0, BytesMut::from_iter(b"abc"), 3);
         x.ensure_ordering(false).unwrap();
         assert_eq!(
             x.read(3, false),
-            Some(Chunk::new(0, Bytes::from_static(b"abc")))
+            Some(Chunk::new(0, BytesMut::from_iter(b"abc")))
         );
         assert_eq!(x.read(3, false), None);
     }
@@ -656,6 +657,6 @@ mod test {
     }
 
     fn next(x: &mut Assembler, size: usize) -> Option<Bytes> {
-        x.read(size, true).map(|chunk| chunk.bytes)
+        x.read(size, true).map(|chunk| chunk.bytes.freeze())
     }
 }

--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -343,6 +343,7 @@ mod test {
     use super::*;
     use assert_matches::assert_matches;
     use std::iter::FromIterator;
+    use bytes::Bytes;
 
     #[test]
     fn assemble_ordered() {

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -135,7 +135,8 @@ impl DatagramState {
     }
 
     pub fn recv(&mut self) -> Option<BytesMut> {
-        let x = self.incoming.pop_front()?.assert_incoming();
+        // We can unwrap without panicking below since we are popping from the incoming field
+        let x = self.incoming.pop_front()?.assert_incoming().unwrap();
         self.recv_buffered -= x.len();
         Some(x)
     }

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use bytes::Bytes;
+use bytes::BytesMut;
 use thiserror::Error;
 use tracing::{debug, trace};
 
@@ -21,7 +21,7 @@ impl<'a, S: Session> Datagrams<'a, S> {
     /// Queue an unreliable, unordered datagram for immediate transmission
     ///
     /// Returns `Err` iff a `len`-byte datagram cannot currently be sent
-    pub fn send(&mut self, data: Bytes) -> Result<(), SendDatagramError> {
+    pub fn send(&mut self, data: BytesMut) -> Result<(), SendDatagramError> {
         if self.conn.config.datagram_receive_buffer_size.is_none() {
             return Err(SendDatagramError::Disabled);
         }
@@ -68,7 +68,7 @@ impl<'a, S: Session> Datagrams<'a, S> {
     }
 
     /// Receive an unreliable, unordered datagram
-    pub fn recv(&mut self) -> Option<Bytes> {
+    pub fn recv(&mut self) -> Option<BytesMut> {
         self.conn.datagrams.recv()
     }
 }
@@ -131,7 +131,7 @@ impl DatagramState {
         true
     }
 
-    pub fn recv(&mut self) -> Option<Bytes> {
+    pub fn recv(&mut self) -> Option<BytesMut> {
         let x = self.incoming.pop_front()?.data;
         self.recv_buffered -= x.len();
         Some(x)

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -42,7 +42,10 @@ impl<'a, S: Session> Datagrams<'a, S> {
             return Err(SendDatagramError::TooLarge);
         }
         self.conn.datagrams.outgoing_total += data.len();
-        self.conn.datagrams.outgoing.push_back(Datagram::Outgoing(data));
+        self.conn
+            .datagrams
+            .outgoing
+            .push_back(Datagram::Outgoing(data));
         Ok(())
     }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1651,10 +1651,10 @@ where
                 }
             }
             let offset = self.spaces[space].crypto_offset;
-            let outgoing = Bytes::from(outgoing);
+            let outgoing = BytesMut::from(&outgoing[..]);
             if let State::Handshake(ref mut state) = self.state {
                 if space == SpaceId::Initial && offset == 0 && self.side.is_client() {
-                    state.client_hello = Some(outgoing.clone());
+                    state.client_hello = Some(outgoing.clone().freeze());
                 }
             }
             self.spaces[space].crypto_offset += outgoing.len() as u64;
@@ -1971,7 +1971,7 @@ where
                 }
 
                 trace!("retrying with CID {}", rem_cid);
-                let client_hello = state.client_hello.take().unwrap();
+                let client_hello = BytesMut::from(&state.client_hello.take().unwrap() as &[u8]);
                 self.retry_src_cid = Some(rem_cid);
                 self.rem_cids.update_cid(rem_cid);
                 self.rem_handshake_cid = rem_cid;

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1651,10 +1651,10 @@ where
                 }
             }
             let offset = self.spaces[space].crypto_offset;
-            let outgoing = BytesMut::from(&outgoing[..]);
+            let outgoing = Bytes::from(outgoing);
             if let State::Handshake(ref mut state) = self.state {
                 if space == SpaceId::Initial && offset == 0 && self.side.is_client() {
-                    state.client_hello = Some(outgoing.clone().freeze());
+                    state.client_hello = Some(outgoing.clone());
                 }
             }
             self.spaces[space].crypto_offset += outgoing.len() as u64;
@@ -1971,7 +1971,7 @@ where
                 }
 
                 trace!("retrying with CID {}", rem_cid);
-                let client_hello = BytesMut::from(&state.client_hello.take().unwrap() as &[u8]);
+                let client_hello = state.client_hello.take().unwrap();
                 self.retry_src_cid = Some(rem_cid);
                 self.rem_cids.update_cid(rem_cid);
                 self.rem_handshake_cid = rem_cid;

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -64,7 +64,8 @@ impl Recv {
 
         self.end = self.end.max(end);
         if !self.stopped {
-            self.assembler.insert(frame.offset, frame.data, payload_len);
+            self.assembler
+                .insert(frame.offset, frame.data.freeze(), payload_len);
         } else {
             self.assembler.set_bytes_read(end);
         }

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -785,7 +785,8 @@ mod tests {
         connection::State as ConnState, connection::Streams, ReadableError, RecvStream, SendStream,
         TransportErrorCode, WriteError,
     };
-    use bytes::Bytes;
+    use bytes::BytesMut;
+    use std::iter::FromIterator;
 
     fn make(side: Side) -> StreamsState {
         StreamsState::new(
@@ -811,7 +812,7 @@ mod tests {
                         id,
                         offset: 0,
                         fin: true,
-                        data: Bytes::from_static(&[0; MESSAGE_SIZE]),
+                        data: BytesMut::from_iter(&[0; MESSAGE_SIZE]),
                     },
                     2048
                 )
@@ -852,7 +853,7 @@ mod tests {
                         id,
                         offset: 0,
                         fin: false,
-                        data: Bytes::from_static(&[0; 2048]),
+                        data: BytesMut::from_iter(&[0; 2048]),
                     },
                     2048
                 )
@@ -915,7 +916,7 @@ mod tests {
                         id,
                         offset: 4096,
                         fin: false,
-                        data: Bytes::from_static(&[0; 0]),
+                        data: BytesMut::from_iter(&[0; 0]),
                     },
                     0
                 )
@@ -978,7 +979,7 @@ mod tests {
                         id,
                         offset: 0,
                         fin: false,
-                        data: Bytes::from_static(&[0; 32]),
+                        data: BytesMut::from_iter(&[0; 32]),
                     },
                     32
                 )
@@ -1010,7 +1011,7 @@ mod tests {
                         id,
                         offset: 32,
                         fin: true,
-                        data: Bytes::from_static(&[0; 16]),
+                        data: BytesMut::from_iter(&[0; 16]),
                     },
                     16
                 )
@@ -1033,7 +1034,7 @@ mod tests {
                         id,
                         offset: 0,
                         fin: false,
-                        data: Bytes::from_static(&[0; 32])
+                        data: BytesMut::from_iter(&[0; 32])
                     },
                     32
                 )
@@ -1259,7 +1260,7 @@ mod tests {
                     id,
                     offset: 0,
                     fin: true,
-                    data: Bytes::from_static(&[0; 32]),
+                    data: BytesMut::from_iter(&[0; 32]),
                 },
                 32,
             )

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -517,7 +517,8 @@ impl Crypto {
 }
 
 pub struct Iter {
-    bytes: Cursor<BytesMut>,
+    // TODO: ditch io::Cursor after bytes 0.5
+    bytes: io::Cursor<BytesMut>,
     last_ty: Option<Type>,
 }
 
@@ -850,10 +851,10 @@ pub enum Datagram {
 }
 
 impl Datagram {
-    pub(crate) fn assert_incoming(self) -> BytesMut {
+    pub(crate) fn assert_incoming(self) -> Option<BytesMut> {
         match self {
-            Self::Incoming(ret) => ret,
-            _ => panic!("Asserted datagram was incoming type, but was actually outgoing type"),
+            Self::Incoming(ret) => Some(ret),
+            _ => None,
         }
     }
 }

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -502,7 +502,7 @@ pub type StreamMetaVec = TinyVec<[StreamMeta; 1]>;
 #[derive(Debug, Clone)]
 pub struct Crypto {
     pub offset: u64,
-    pub data: BytesMut,
+    pub data: Bytes,
 }
 
 impl Crypto {
@@ -680,7 +680,7 @@ impl Iter {
             }
             Type::CRYPTO => Frame::Crypto(Crypto {
                 offset: self.bytes.get_var()?,
-                data: self.take_len()?,
+                data: self.take_len()?.freeze(),
             }),
             Type::NEW_TOKEN => Frame::NewToken {
                 token: self.take_len()?.freeze(),

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -17,8 +17,8 @@ use crate::{
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-use std::ops::Deref;
 use std::io::Cursor;
+use std::ops::Deref;
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Type(u64);
@@ -559,7 +559,9 @@ impl Iter {
         }
         let start = self.bytes.position() as usize;
         self.bytes.advance(len as usize);
-        Ok(BytesMut::from(&self.bytes.get_ref()[start..(start + len as usize)]))
+        Ok(BytesMut::from(
+            &self.bytes.get_ref()[start..(start + len as usize)],
+        ))
     }
 
     fn try_next(&mut self) -> Result<Frame, IterErr> {
@@ -844,14 +846,14 @@ pub enum Datagram {
     /// Used to designate an outgoing immutable buffer
     Outgoing(Bytes),
     /// Used to designate an incoming mutable buffer
-    Incoming(BytesMut)
+    Incoming(BytesMut),
 }
 
 impl Datagram {
     pub(crate) fn assert_incoming(self) -> BytesMut {
         match self {
             Self::Incoming(ret) => ret,
-            _ => panic!("Asserted datagram was incoming type, but was actually outgoing type")
+            _ => panic!("Asserted datagram was incoming type, but was actually outgoing type"),
         }
     }
 }
@@ -862,7 +864,7 @@ impl Deref for Datagram {
     fn deref(&self) -> &Self::Target {
         match self {
             Self::Outgoing(bytes) => &bytes[..],
-            Self::Incoming(bytes) => &bytes[..]
+            Self::Incoming(bytes) => &bytes[..],
         }
     }
 }

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use assert_matches::assert_matches;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use hex_literal::hex;
 use rand::RngCore;
 use ring::hmac;
@@ -1562,7 +1562,7 @@ fn datagram_unsupported() {
     assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
     assert_matches!(pair.client_datagrams(client_ch).max_size(), None);
 
-    match pair.client_datagrams(client_ch).send(Bytes::new()) {
+    match pair.client_datagrams(client_ch).send(BytesMut::new()) {
         Err(SendDatagramError::UnsupportedByPeer) => {}
         Err(e) => panic!("unexpected error: {}", e),
         Ok(_) => panic!("unexpected success"),

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use assert_matches::assert_matches;
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use hex_literal::hex;
 use rand::RngCore;
 use ring::hmac;
@@ -1562,7 +1562,7 @@ fn datagram_unsupported() {
     assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
     assert_matches!(pair.client_datagrams(client_ch).max_size(), None);
 
-    match pair.client_datagrams(client_ch).send(BytesMut::new()) {
+    match pair.client_datagrams(client_ch).send(Bytes::new()) {
         Err(SendDatagramError::UnsupportedByPeer) => {}
         Err(e) => panic!("unexpected error: {}", e),
         Ok(_) => panic!("unexpected success"),

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -9,7 +9,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use futures_channel::{mpsc, oneshot};
 use futures_util::{FutureExt, StreamExt};
 use fxhash::FxHashMap;
@@ -382,7 +382,7 @@ where
     /// Application datagrams are a low-level primitive. They may be lost or delivered out of order,
     /// and `data` must both fit inside a single QUIC packet and be smaller than the maximum
     /// dictated by the peer.
-    pub fn send_datagram(&self, data: Bytes) -> Result<(), SendDatagramError> {
+    pub fn send_datagram(&self, data: BytesMut) -> Result<(), SendDatagramError> {
         let conn = &mut *self.0.lock("send_datagram");
         if let Some(ref x) = conn.error {
             return Err(SendDatagramError::ConnectionClosed(x.clone()));
@@ -601,7 +601,7 @@ impl<S> futures_util::stream::Stream for Datagrams<S>
 where
     S: proto::crypto::Session,
 {
-    type Item = Result<Bytes, ConnectionError>;
+    type Item = Result<BytesMut, ConnectionError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         let mut conn = self.0.lock("Datagrams::poll_next");

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -382,7 +382,7 @@ where
     /// Application datagrams are a low-level primitive. They may be lost or delivered out of order,
     /// and `data` must both fit inside a single QUIC packet and be smaller than the maximum
     /// dictated by the peer.
-    pub fn send_datagram(&self, data: BytesMut) -> Result<(), SendDatagramError> {
+    pub fn send_datagram(&self, data: Bytes) -> Result<(), SendDatagramError> {
         let conn = &mut *self.0.lock("send_datagram");
         if let Some(ref x) = conn.error {
             return Err(SendDatagramError::ConnectionClosed(x.clone()));

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -162,7 +162,7 @@ where
 
                 match chunks.next(usize::MAX) {
                     Ok(Some(chunk)) => {
-                        bufs[read] = chunk.bytes;
+                        bufs[read] = chunk.bytes.freeze();
                         read += 1;
                     }
                     res => return (if read == 0 { None } else { Some(read) }, res.err()).into(),
@@ -334,7 +334,7 @@ where
                         return Poll::Ready(Err(ReadToEndError::TooLong));
                     }
                     self.end = self.end.max(end);
-                    self.read.push((chunk.bytes, chunk.offset));
+                    self.read.push((chunk.bytes.freeze(), chunk.offset));
                 }
                 None => {
                     if self.end == 0 {

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -162,7 +162,7 @@ where
 
                 match chunks.next(usize::MAX) {
                     Ok(Some(chunk)) => {
-                        bufs[read] = chunk.bytes.freeze();
+                        bufs[read] = chunk.bytes;
                         read += 1;
                     }
                     res => return (if read == 0 { None } else { Some(read) }, res.err()).into(),
@@ -334,7 +334,7 @@ where
                         return Poll::Ready(Err(ReadToEndError::TooLong));
                     }
                     self.end = self.end.max(end);
-                    self.read.push((chunk.bytes.freeze(), chunk.offset));
+                    self.read.push((chunk.bytes, chunk.offset));
                 }
                 None => {
                     if self.end == 0 {


### PR DESCRIPTION
Compiles and runs. Tests return Ok(())