### PR TITLE
Disable default features in proto dependency

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -36,7 +36,7 @@ fxhash = "0.2.1"
 libc = "0.2.69"
 mio = { version = "0.7.7", features = ["net"] }
 once_cell = "1.7.2"
-proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.7" }
+proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.7", default-features = false }
 rustls = { version = "0.19", features = ["quic"], optional = true }
 socket2 = "0.4"
 thiserror = "1.0.21"


### PR DESCRIPTION
Prevents quinn-proto's default features from infecting anything that depends directly on quinn but doesn't necessary want them.