### PR TITLE
Fix inner crate test

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -52,6 +52,7 @@ anyhow = "1.0.22"
 crc = "1.8.1"
 bencher = "0.1.5"
 directories-next = "2"
+futures-util = { version = "0.3.11", default-features = false, features = ["async-await-macro"] }
 rand = "0.8"
 rcgen = "0.8"
 structopt = "0.3.0"


### PR DESCRIPTION
There's a test in the quinn crate that uses `futures_util::join!` which is behind a feature gate the quinn itself doesn't enable.  (Other crates in the workspace do enable that feature, so it only errors if you run cargo test from within quinn before running it for the workspace).

This adds a line to dev-dependancies which enables that feature when testing quinn.