### PR TITLE
Endpoint - allowing override server configuration

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -109,6 +109,11 @@ where
         self.transmits.pop_front()
     }
 
+    /// Replace the server configuration, affecting new incoming connections only
+    pub fn set_server_config(&mut self, server_config: Option<Arc<ServerConfig<S>>>) {
+        self.server_config = server_config;
+    }
+
     /// Process `EndpointEvent`s emitted from related `Connection`s
     ///
     /// In turn, processing this event may return a `ConnectionEvent` for the same `Connection`.

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -17,7 +17,11 @@ use futures_channel::mpsc;
 use futures_util::StreamExt;
 use fxhash::FxHashMap;
 use once_cell::sync::OnceCell;
-use proto::{self as proto, generic::ClientConfig, ConnectError, ConnectionHandle, DatagramEvent};
+use proto::{
+    self as proto,
+    generic::{ClientConfig, ServerConfig},
+    ConnectError, ConnectionHandle, DatagramEvent,
+};
 
 use crate::{
     broadcast::{self, Broadcast},
@@ -114,6 +118,17 @@ where
         inner.socket = socket;
         inner.ipv6 = addr.is_ipv6();
         Ok(())
+    }
+
+    /// Replace the server configuration, affecting new incoming connections only
+    ///
+    /// Useful for e.g. refreshing TLS certificates without disrupting existing connections.
+    pub fn set_server_config(&self, server_config: Option<ServerConfig<S>>) {
+        self.inner
+            .lock()
+            .unwrap()
+            .inner
+            .set_server_config(server_config.map(Arc::new))
     }
 
     /// Get the local `SocketAddr` the underlying socket is bound to


### PR DESCRIPTION
The idea here is to reload the server configuration allowing a new setup for incoming connections without dropping the endpoint and closing existing ones.

The main rationale is the fact that, in some circumstances, on long server sessions, it is needed to reload its TLS configuration. In particular, to have the possibility to renew an expiring TLS certificate keeping the server/service operative.

---

<details>
  <summary>Pseudo Code Usage Idea</summary>

```
let (endpoint, mut incoming) = endpoint.bind(&listen_addr).unwrap();

loop {
  select! {
      Some(incoming) = incoming.next() => {
          // Handle new incoming connection
       }
       new_config = config_reload.next() => {
           let new_server_config = build_new_server_config(&config);
           endpoint.override_server_config(new_server_config);
        }
    }
}

```  
</details>
