### PR TITLE
Explicit TLS configuration setup

### DIFF
--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -30,12 +30,8 @@ pub fn server_endpoint(
     key: quinn::PrivateKey,
     opt: &Opt,
 ) -> (SocketAddr, quinn::Incoming) {
-    let mut server_config = quinn::ServerConfigBuilder::default();
-    server_config
-        .certificate(quinn::CertificateChain::from_certs(vec![cert]), key)
-        .unwrap();
-
-    let mut server_config = server_config.build();
+    let cert_chain = quinn::CertificateChain::from_certs(vec![cert]);
+    let mut server_config = quinn::ServerConfig::with_single_cert(cert_chain, key).unwrap();
     server_config.transport = Arc::new(transport_config(opt));
 
     let mut endpoint = quinn::EndpointBuilder::default();

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -75,9 +75,10 @@ async fn main() -> Result<()> {
         _ => quinn::CertificateChain::from_pem(&cert_chain)?,
     };
 
-    let mut server_config = quinn::ServerConfigBuilder::default();
-    server_config.certificate(cert_chain, key)?;
-    server_config.protocols(&[b"hq-29", b"siduck-00"]);
+    let mut server_config = quinn::ServerConfig::with_single_cert(cert_chain, key)?;
+    Arc::get_mut(&mut server_config.crypto)
+        .unwrap()
+        .alpn_protocols = vec![b"hq-29".to_vec(), b"siduck-00".to_vec()];
 
     let main = server(server_config.clone(), SocketAddr::new(opt.listen, 4433));
     let default = server(server_config.clone(), SocketAddr::new(opt.listen, 443));
@@ -89,11 +90,10 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn server(server_config: quinn::ServerConfigBuilder, addr: SocketAddr) -> Result<()> {
+async fn server(mut server_config: quinn::ServerConfig, addr: SocketAddr) -> Result<()> {
     let mut transport = quinn::TransportConfig::default();
     transport.send_window(1024 * 1024 * 3);
     transport.receive_window((1024_u32 * 1024).into());
-    let mut server_config = server_config.build();
     server_config.transport = Arc::new(transport);
 
     let mut endpoint_builder = quinn::Endpoint::builder();
@@ -280,8 +280,8 @@ async fn h2_handle(request: hyper::Request<hyper::Body>) -> Result<hyper::Respon
     })
 }
 
-async fn h2_server(server_config: quinn::ServerConfigBuilder) -> Result<()> {
-    let mut tls_cfg = (*server_config.build().crypto).clone();
+async fn h2_server(server_config: quinn::ServerConfig) -> Result<()> {
+    let mut tls_cfg = (*server_config.crypto).clone();
     tls_cfg.set_protocols(&[b"h2".to_vec(), b"http/1.1".to_vec()]);
     let tls_acceptor = TlsAcceptor::from(sync::Arc::new(tls_cfg));
 

--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -111,9 +111,9 @@ async fn run(opt: Opt) -> Result<()> {
 
     let (endpoint, _) = endpoint.with_socket(socket).context("binding endpoint")?;
 
-    let mut cfg = quinn::ClientConfigBuilder::default();
-    cfg.protocols(&[b"perf"]);
-    let mut cfg = cfg.build();
+    let mut cfg = quinn::ClientConfig::with_root_certificates(vec![]).unwrap();
+    let tls_config = Arc::get_mut(&mut cfg.crypto).unwrap();
+    tls_config.alpn_protocols = vec![b"perf".to_vec()];
 
     let tls_config: &mut rustls::ClientConfig = Arc::get_mut(&mut cfg.crypto).unwrap();
     if opt.insecure {

--- a/perf/src/bin/perf_server.rs
+++ b/perf/src/bin/perf_server.rs
@@ -64,14 +64,10 @@ async fn run(opt: Opt) -> Result<()> {
         }
     };
 
-    let mut server_config = quinn::ServerConfigBuilder::default();
-    server_config.certificate(cert, key).unwrap();
-    server_config.protocols(&[b"perf"]);
-
-    let mut server_config = server_config.build();
-
     // Configure cipher suites for efficiency
+    let mut server_config = quinn::ServerConfig::with_single_cert(cert, key).unwrap();
     let tls_config = Arc::get_mut(&mut server_config.crypto).unwrap();
+    tls_config.alpn_protocols = vec![b"perf".to_vec()];
     tls_config.ciphersuites.clear();
     tls_config
         .ciphersuites

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -18,8 +18,6 @@ maintenance = { status = "experimental" }
 
 [features]
 default = ["tls-rustls"]
-# Use Google's list of CT logs to enable certificate transparency checks
-certificate-transparency = ["ct-logs"]
 tls-rustls = ["rustls", "webpki", "ring"]
 # Trust the contents of the OS certificate store by default
 native-certs = ["rustls-native-certs"]
@@ -28,7 +26,6 @@ native-certs = ["rustls-native-certs"]
 arbitrary = { version = "0.4.5", features = ["derive"], optional = true }
 bytes = "1"
 fxhash = "0.2.1"
-ct-logs = { version = "0.8", optional = true }
 rand = "0.8"
 ring = { version = "0.16.7", optional = true }
 # If rustls gets updated to a new version which contains

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -153,11 +153,6 @@ pub trait ServerConfig<S>: Clone + Send + Sync
 where
     S: Session,
 {
-    /// Construct the default configuration
-    fn new() -> Self
-    where
-        Self: Sized;
-
     /// Start a server session with this configuration
     fn start_session(&self, params: &TransportParameters) -> S;
 }

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -140,11 +140,6 @@ pub trait ClientConfig<S>: Clone
 where
     S: Session,
 {
-    /// Construct the default configuration
-    fn new() -> Self
-    where
-        Self: Sized;
-
     /// Start a client session with this configuration
     fn start_session(
         &self,

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -295,16 +295,6 @@ impl crypto::ClientConfig<TlsSession> for Arc<rustls::ClientConfig> {
 }
 
 impl crypto::ServerConfig<TlsSession> for Arc<rustls::ServerConfig> {
-    fn new() -> Self {
-        let mut cfg = rustls::ServerConfig::with_ciphersuites(
-            rustls::NoClientAuth::new(),
-            &QUIC_CIPHER_SUITES,
-        );
-        cfg.versions = vec![rustls::ProtocolVersion::TLSv1_3];
-        cfg.max_early_data_size = u32::max_value();
-        Arc::new(cfg)
-    }
-
     fn start_session(&self, params: &TransportParameters) -> TlsSession {
         TlsSession {
             using_alpn: !self.alpn_protocols.is_empty(),

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -275,30 +275,6 @@ pub struct HandshakeData {
 }
 
 impl crypto::ClientConfig<TlsSession> for Arc<rustls::ClientConfig> {
-    fn new() -> Self {
-        let mut cfg = rustls::ClientConfig::with_ciphersuites(&QUIC_CIPHER_SUITES);
-        cfg.versions = vec![rustls::ProtocolVersion::TLSv1_3];
-        cfg.enable_early_data = true;
-        #[cfg(feature = "native-certs")]
-        match rustls_native_certs::load_native_certs() {
-            Ok(x) => {
-                cfg.root_store = x;
-            }
-            Err((Some(x), e)) => {
-                cfg.root_store = x;
-                tracing::warn!("couldn't load some default trust roots: {}", e);
-            }
-            Err((None, e)) => {
-                tracing::warn!("couldn't load any default trust roots: {}", e);
-            }
-        }
-        #[cfg(feature = "certificate-transparency")]
-        {
-            cfg.ct_logs = Some(&ct_logs::LOGS);
-        }
-        Arc::new(cfg)
-    }
-
     fn start_session(
         &self,
         server_name: &str,
@@ -411,7 +387,7 @@ impl crypto::PacketKey for PacketKey {
 /// This list prefers AES ciphers, which are hardware accelerated on most platforms.
 /// This list can be removed if the rustls dependency is updated to a new version
 /// which contains the linked change.
-static QUIC_CIPHER_SUITES: [&rustls::SupportedCipherSuite; 3] = [
+pub(crate) static QUIC_CIPHER_SUITES: [&rustls::SupportedCipherSuite; 3] = [
     &rustls::ciphersuite::TLS13_AES_256_GCM_SHA384,
     &rustls::ciphersuite::TLS13_AES_128_GCM_SHA256,
     &rustls::ciphersuite::TLS13_CHACHA20_POLY1305_SHA256,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -857,6 +857,11 @@ pub enum ConnectError {
     /// Examples include attempting to connect to port 0, or using an inappropriate address family.
     #[error("invalid remote address: {0}")]
     InvalidRemoteAddress(SocketAddr),
+    /// No default client configuration was set up
+    ///
+    /// Use [`Endpoint::connect_with`] to specify a client configuration.
+    #[error("no default client config")]
+    NoDefaultClientConfig,
 }
 
 /// Reset Tokens which are associated with peer socket addresses

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -319,7 +319,7 @@ fn reject_self_signed_server_cert() {
     let _guard = subscribe();
     let mut pair = Pair::default();
     info!("connecting");
-    let client_ch = pair.begin_connect(ClientConfig::default());
+    let client_ch = pair.begin_connect(client_config_with_certs(vec![]));
     pair.drive();
     assert_matches!(pair.client_conn_mut(client_ch).poll(),
                     Some(Event::ConnectionLost { reason: ConnectionError::TransportError(ref error)})
@@ -1769,8 +1769,7 @@ fn handshake_anti_deadlock_probe() {
     server
         .certificate(CertificateChain::from_certs(Some(cert.clone())), key)
         .unwrap();
-    let mut client = client_config();
-    client.add_certificate_authority(cert).unwrap();
+    let client = client_config_with_certs(vec![cert]);
     let mut pair = Pair::new(Default::default(), server);
 
     let client_ch = pair.begin_connect(client);
@@ -1806,8 +1805,7 @@ fn server_can_send_3_inital_packets() {
     server
         .certificate(CertificateChain::from_certs(Some(cert.clone())), key)
         .unwrap();
-    let mut client = client_config();
-    client.add_certificate_authority(cert).unwrap();
+    let client = client_config_with_certs(vec![cert]);
     let mut pair = Pair::new(Default::default(), server);
 
     let client_ch = pair.begin_connect(client);

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -16,7 +16,7 @@ use tracing::info;
 use super::*;
 use crate::cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator};
 use crate::crypto::Session as _;
-use crate::{Certificate, CertificateChain, PrivateKey};
+use crate::{Certificate, PrivateKey};
 mod util;
 use util::*;
 
@@ -1764,11 +1764,7 @@ fn handshake_anti_deadlock_probe() {
     let _guard = subscribe();
 
     let (cert, key) = big_cert_and_key();
-
-    let mut server = server_config();
-    server
-        .certificate(CertificateChain::from_certs(Some(cert.clone())), key)
-        .unwrap();
+    let server = server_config_with_cert(cert.clone(), key);
     let client = client_config_with_certs(vec![cert]);
     let mut pair = Pair::new(Default::default(), server);
 
@@ -1800,11 +1796,7 @@ fn server_can_send_3_inital_packets() {
     let _guard = subscribe();
 
     let (cert, key) = big_cert_and_key();
-
-    let mut server = server_config();
-    server
-        .certificate(CertificateChain::from_certs(Some(cert.clone())), key)
-        .unwrap();
+    let server = server_config_with_cert(cert.clone(), key);
     let client = client_config_with_certs(vec![cert]);
     let mut pair = Pair::new(Default::default(), server);
 

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -376,20 +376,13 @@ impl Write for TestWriter {
 }
 
 pub fn server_config() -> ServerConfig {
-    let key = CERTIFICATE.serialize_private_key_der();
-    let cert = CERTIFICATE.serialize_pem().unwrap();
+    let cert = Certificate::from_der(&CERTIFICATE.serialize_der().unwrap()).unwrap();
+    let key = PrivateKey::from_der(&CERTIFICATE.serialize_private_key_der()).unwrap();
+    server_config_with_cert(cert, key)
+}
 
-    let mut crypto = crypto::ServerConfig::new();
-    Arc::make_mut(&mut crypto)
-        .set_single_cert(
-            rustls::internal::pemfile::certs(&mut cert.as_bytes()).unwrap(),
-            rustls::PrivateKey(key.to_vec()),
-        )
-        .unwrap();
-    ServerConfig {
-        crypto,
-        ..Default::default()
-    }
+pub fn server_config_with_cert(cert: Certificate, key: PrivateKey) -> ServerConfig {
+    ServerConfig::with_single_cert(CertificateChain::from_certs(vec![cert]), key).unwrap()
 }
 
 pub fn client_config() -> ClientConfig {

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -33,7 +33,6 @@ bytes = "1"
 futures-util = { version = "0.3.11", default-features = false, features = ["io"] }
 futures-channel = "0.3.11"
 fxhash = "0.2.1"
-once_cell = "1.7.2"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.7", default-features = false }
 rustls = { version = "0.19", features = ["quic"], optional = true }
 thiserror = "1.0.21"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -15,9 +15,7 @@ edition = "2018"
 all-features = true
 
 [features]
-default = ["native-certs", "certificate-transparency", "tls-rustls"]
-# Use Google's list of CT logs to enable certificate transparency checks
-certificate-transparency = ["proto/certificate-transparency"]
+default = ["native-certs", "tls-rustls"]
 # Records how long locks are held, and warns if they are held >= 1ms
 lock_tracking = []
 # Trust the contents of the OS certificate store by default

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -10,7 +10,7 @@ use tokio::runtime::{Builder, Runtime};
 use tracing::error_span;
 use tracing_futures::Instrument as _;
 
-use quinn::{Endpoint, ServerConfigBuilder};
+use quinn::Endpoint;
 
 benchmark_group!(
     benches,
@@ -82,15 +82,13 @@ impl Context {
         let cert = quinn::Certificate::from_der(&cert.serialize_der().unwrap()).unwrap();
         let cert_chain = quinn::CertificateChain::from_certs(vec![cert.clone()]);
 
-        let mut transport = quinn::TransportConfig::default();
-        transport.max_concurrent_uni_streams(1024_u16.into());
-        let mut server_config = quinn::ServerConfig::default();
-        server_config.transport = Arc::new(transport);
-        let mut server_config = ServerConfigBuilder::new(server_config);
-        server_config.certificate(cert_chain, key).unwrap();
+        let mut server_config = quinn::ServerConfig::with_single_cert(cert_chain, key).unwrap();
+        Arc::get_mut(&mut server_config.transport)
+            .unwrap()
+            .max_concurrent_uni_streams(1024_u16.into());
 
         Self {
-            server_config: server_config.build(),
+            server_config,
             client_config: quinn::ClientConfig::with_root_certificates(vec![cert]).unwrap(),
         }
     }

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -10,7 +10,7 @@ use tokio::runtime::{Builder, Runtime};
 use tracing::error_span;
 use tracing_futures::Instrument as _;
 
-use quinn::{ClientConfigBuilder, Endpoint, ServerConfigBuilder};
+use quinn::{Endpoint, ServerConfigBuilder};
 
 benchmark_group!(
     benches,
@@ -89,12 +89,9 @@ impl Context {
         let mut server_config = ServerConfigBuilder::new(server_config);
         server_config.certificate(cert_chain, key).unwrap();
 
-        let mut client_config = ClientConfigBuilder::default();
-        client_config.add_certificate_authority(cert).unwrap();
-
         Self {
             server_config: server_config.build(),
-            client_config: client_config.build(),
+            client_config: quinn::ClientConfig::with_root_certificates(vec![cert]).unwrap(),
         }
     }
 

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -67,20 +67,14 @@ async fn run(options: Opt) -> Result<()> {
         .next()
         .ok_or_else(|| anyhow!("couldn't resolve to an address"))?;
 
-    let mut endpoint = quinn::Endpoint::builder();
-    let mut client_config = quinn::ClientConfigBuilder::default();
-    client_config.protocols(common::ALPN_QUIC_HTTP);
-    if options.keylog {
-        client_config.enable_keylog();
-    }
+    let mut certs = Vec::new();
     if let Some(ca_path) = options.ca {
-        client_config
-            .add_certificate_authority(quinn::Certificate::from_der(&fs::read(&ca_path)?)?)?;
+        certs.push(quinn::Certificate::from_der(&fs::read(&ca_path)?)?);
     } else {
         let dirs = directories_next::ProjectDirs::from("org", "quinn", "quinn-examples").unwrap();
         match fs::read(dirs.data_local_dir().join("cert.der")) {
             Ok(cert) => {
-                client_config.add_certificate_authority(quinn::Certificate::from_der(&cert)?)?;
+                certs.push(quinn::Certificate::from_der(&cert)?);
             }
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
                 info!("local server certificate not found");
@@ -91,7 +85,14 @@ async fn run(options: Opt) -> Result<()> {
         }
     }
 
-    endpoint.default_client_config(client_config.build());
+    let mut endpoint = quinn::Endpoint::builder();
+    let client_config = quinn::ClientConfig::with_root_certificates(certs)?;
+    let mut client_config_builder = quinn::ClientConfigBuilder::new(client_config);
+    client_config_builder.protocols(common::ALPN_QUIC_HTTP);
+    if options.keylog {
+        client_config_builder.enable_keylog();
+    }
+    endpoint.default_client_config(client_config_builder.build());
 
     let (endpoint, _) = endpoint.bind(&"[::]:0".parse().unwrap())?;
 

--- a/quinn/examples/common/mod.rs
+++ b/quinn/examples/common/mod.rs
@@ -2,8 +2,8 @@
 //! Commonly used code in most examples.
 
 use quinn::{
-    Certificate, CertificateChain, ClientConfig, ClientConfigBuilder, Endpoint, Incoming,
-    PrivateKey, ServerConfig, ServerConfigBuilder, TransportConfig,
+    Certificate, CertificateChain, ClientConfig, Endpoint, Incoming, PrivateKey, ServerConfig,
+    ServerConfigBuilder, TransportConfig,
 };
 use std::{error::Error, net::SocketAddr, sync::Arc};
 
@@ -46,11 +46,11 @@ pub fn make_server_endpoint(bind_addr: SocketAddr) -> Result<(Incoming, Vec<u8>)
 ///
 /// - server_certs: a list of trusted certificates in DER format.
 fn configure_client(server_certs: &[&[u8]]) -> Result<ClientConfig, Box<dyn Error>> {
-    let mut cfg_builder = ClientConfigBuilder::default();
-    for cert in server_certs {
-        cfg_builder.add_certificate_authority(Certificate::from_der(cert)?)?;
-    }
-    Ok(cfg_builder.build())
+    let certs = server_certs
+        .iter()
+        .map(|der| Certificate::from_der(der))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(ClientConfig::with_root_certificates(certs)?)
 }
 
 /// Returns default server configuration along with its certificate.

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -5,7 +5,7 @@
 use futures_util::StreamExt;
 use std::{error::Error, net::SocketAddr, sync::Arc};
 
-use quinn::{ClientConfig, ClientConfigBuilder, Endpoint};
+use quinn::{ClientConfig, Endpoint};
 
 mod common;
 use common::make_server_endpoint;
@@ -76,7 +76,7 @@ impl rustls::ServerCertVerifier for SkipServerVerification {
 }
 
 fn configure_client() -> ClientConfig {
-    let mut cfg = ClientConfigBuilder::default().build();
+    let mut cfg = ClientConfig::with_root_certificates(vec![]).unwrap();
     let tls_cfg: &mut rustls::ClientConfig = Arc::get_mut(&mut cfg.crypto).unwrap();
     // this is only available when compiled with "dangerous_configuration" feature
     tls_cfg

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -63,22 +63,7 @@ fn main() {
 #[tokio::main]
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527
 async fn run(options: Opt) -> Result<()> {
-    let mut transport_config = quinn::TransportConfig::default();
-    transport_config.max_concurrent_uni_streams(0_u8.into());
-    let mut server_config = quinn::ServerConfig::default();
-    server_config.transport = Arc::new(transport_config);
-    let mut server_config = quinn::ServerConfigBuilder::new(server_config);
-    server_config.protocols(common::ALPN_QUIC_HTTP);
-
-    if options.keylog {
-        server_config.enable_keylog();
-    }
-
-    if options.stateless_retry {
-        server_config.use_stateless_retry(true);
-    }
-
-    if let (Some(key_path), Some(cert_path)) = (&options.key, &options.cert) {
+    let (certs, key) = if let (Some(key_path), Some(cert_path)) = (&options.key, &options.cert) {
         let key = fs::read(key_path).context("failed to read private key")?;
         let key = if key_path.extension().map_or(false, |x| x == "der") {
             quinn::PrivateKey::from_der(&key)?
@@ -87,13 +72,12 @@ async fn run(options: Opt) -> Result<()> {
         };
         let cert_chain = fs::read(cert_path).context("failed to read certificate chain")?;
         let cert_chain = if cert_path.extension().map_or(false, |x| x == "der") {
-            quinn::CertificateChain::from_certs(Some(
-                quinn::Certificate::from_der(&cert_chain).unwrap(),
-            ))
+            quinn::CertificateChain::from_certs(Some(quinn::Certificate::from_der(&cert_chain)?))
         } else {
             quinn::CertificateChain::from_pem(&cert_chain)?
         };
-        server_config.certificate(cert_chain, key)?;
+
+        (cert_chain, key)
     } else {
         let dirs = directories_next::ProjectDirs::from("org", "quinn", "quinn-examples").unwrap();
         let path = dirs.data_local_dir();
@@ -115,13 +99,30 @@ async fn run(options: Opt) -> Result<()> {
                 bail!("failed to read certificate: {}", e);
             }
         };
+
         let key = quinn::PrivateKey::from_der(&key)?;
         let cert = quinn::Certificate::from_der(&cert)?;
-        server_config.certificate(quinn::CertificateChain::from_certs(vec![cert]), key)?;
+        (quinn::CertificateChain::from_certs(vec![cert]), key)
+    };
+
+    let mut server_config = quinn::ServerConfig::with_single_cert(certs, key)?;
+    Arc::get_mut(&mut server_config.transport)
+        .unwrap()
+        .max_concurrent_uni_streams(0_u8.into());
+
+    let mut server_config_builder = quinn::ServerConfigBuilder::new(server_config);
+    server_config_builder.protocols(common::ALPN_QUIC_HTTP);
+
+    if options.keylog {
+        server_config_builder.enable_keylog();
+    }
+
+    if options.stateless_retry {
+        server_config_builder.use_stateless_retry(true);
     }
 
     let mut endpoint = quinn::Endpoint::builder();
-    endpoint.listen(server_config.build());
+    endpoint.listen(server_config_builder.build());
 
     let root = Arc::<Path>::from(options.root.clone());
     if !root.exists() {

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -1,6 +1,5 @@
 use std::{io, net::SocketAddr, sync::Arc};
 
-use once_cell::sync::OnceCell;
 use proto::{
     generic::{ClientConfig, EndpointConfig, ServerConfig},
     ConnectionIdGenerator,
@@ -81,12 +80,7 @@ where
         Ok((
             Endpoint {
                 inner: rc.clone(),
-                // If a default client config hasn't been specified explicitly, leave the OnceCell
-                // empty so `Endpoint` can initialize it iff needed.
-                default_client_config: self
-                    .default_client_config
-                    .map(OnceCell::from)
-                    .unwrap_or_default(),
+                default_client_config: self.default_client_config,
             },
             Incoming::new(rc),
         ))

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -10,7 +10,7 @@ use udp::UdpSocket;
 
 use crate::endpoint::{Endpoint, EndpointDriver, EndpointRef, Incoming};
 #[cfg(feature = "rustls")]
-use crate::{Certificate, CertificateChain, PrivateKey};
+use crate::{CertificateChain, PrivateKey};
 
 /// A helper for constructing an [`Endpoint`].
 ///
@@ -33,12 +33,12 @@ impl<S> EndpointBuilder<S>
 where
     S: proto::crypto::Session + Send + 'static,
 {
-    /// Start a builder with a specific initial low-level configuration.
-    pub fn new(config: EndpointConfig<S>, default_client_config: ClientConfig<S>) -> Self {
+    /// Start a builder with a specific initial low-level configuration
+    pub fn new(config: EndpointConfig<S>, default_client_config: Option<ClientConfig<S>>) -> Self {
         Self {
             server_config: None,
             config,
-            default_client_config: Some(default_client_config),
+            default_client_config,
         }
     }
 
@@ -273,21 +273,6 @@ where
 
 #[cfg(feature = "rustls")]
 impl ClientConfigBuilder<proto::crypto::rustls::TlsSession> {
-    /// Add a trusted certificate authority.
-    ///
-    /// For more advanced/less secure certificate verification, construct a [`ClientConfig`]
-    /// manually and use rustls's `dangerous_configuration` feature to override the certificate
-    /// verifier.
-    ///
-    /// [`ClientConfig`]: crate::generic::ClientConfig
-    pub fn add_certificate_authority(
-        &mut self,
-        cert: Certificate,
-    ) -> Result<&mut Self, webpki::Error> {
-        self.config.add_certificate_authority(cert)?;
-        Ok(self)
-    }
-
     /// Enable NSS-compatible cryptographic key logging to the `SSLKEYLOGFILE` environment variable.
     ///
     /// Useful for debugging encrypted communications with protocol analyzers such as Wireshark.
@@ -324,14 +309,5 @@ where
         Self {
             config: self.config.clone(),
         }
-    }
-}
-
-impl<S> Default for ClientConfigBuilder<S>
-where
-    S: proto::crypto::Session,
-{
-    fn default() -> Self {
-        Self::new(ClientConfig::default())
     }
 }

--- a/quinn/src/builders.rs
+++ b/quinn/src/builders.rs
@@ -9,8 +9,6 @@ use tracing::error;
 use udp::UdpSocket;
 
 use crate::endpoint::{Endpoint, EndpointDriver, EndpointRef, Incoming};
-#[cfg(feature = "rustls")]
-use crate::{CertificateChain, PrivateKey};
 
 /// A helper for constructing an [`Endpoint`].
 ///
@@ -178,16 +176,6 @@ impl ServerConfigBuilder<proto::crypto::rustls::TlsSession> {
         self
     }
 
-    /// Set the certificate chain that will be presented to clients.
-    pub fn certificate(
-        &mut self,
-        cert_chain: CertificateChain,
-        key: PrivateKey,
-    ) -> Result<&mut Self, rustls::TLSError> {
-        self.config.certificate(cert_chain, key)?;
-        Ok(self)
-    }
-
     /// Set the application-layer protocols to accept, in order of descending preference.
     ///
     /// When set, clients which don't declare support for at least one of the supplied protocols will be rejected.
@@ -209,17 +197,6 @@ where
     fn clone(&self) -> Self {
         Self {
             config: self.config.clone(),
-        }
-    }
-}
-
-impl<S> Default for ServerConfigBuilder<S>
-where
-    S: proto::crypto::Session,
-{
-    fn default() -> Self {
-        Self {
-            config: ServerConfig::default(),
         }
     }
 }

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -67,7 +67,8 @@ fn handshake_timeout() {
 #[tokio::test]
 async fn close_endpoint() {
     let _guard = subscribe();
-    let endpoint = Endpoint::builder();
+    let mut endpoint = Endpoint::builder();
+    endpoint.default_client_config(ClientConfigBuilder::default().build());
     let (endpoint, incoming) = endpoint
         .bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
         .unwrap();

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -130,10 +130,10 @@ async fn write_to_peer(conn: quinn::Connection, data: Vec<u8>) -> Result<(), Wri
 
 /// Builds client configuration. Trusts given node certificate.
 fn configure_connector(node_cert: &[u8]) -> quinn::ClientConfig {
-    let mut peer_cfg_builder = quinn::ClientConfigBuilder::default();
     let their_cert = unwrap!(quinn::Certificate::from_der(node_cert));
-    unwrap!(peer_cfg_builder.add_certificate_authority(their_cert));
-    let mut peer_cfg = peer_cfg_builder.build();
+    let mut peer_cfg = unwrap!(quinn::ClientConfig::with_root_certificates(vec![
+        their_cert
+    ],));
     let transport_config = unwrap!(Arc::get_mut(&mut peer_cfg.transport));
     transport_config.max_idle_timeout(Some(Duration::from_secs(20).try_into().unwrap()));
 

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -144,14 +144,9 @@ fn configure_connector(node_cert: &[u8]) -> quinn::ClientConfig {
 fn configure_listener() -> (quinn::ServerConfig, Vec<u8>) {
     let (our_cert_der, our_priv_key) = gen_cert();
     let our_cert = unwrap!(quinn::Certificate::from_der(&our_cert_der));
+    let our_cert_chain = quinn::CertificateChain::from_certs(vec![our_cert]);
+    let mut our_cfg = quinn::ServerConfig::with_single_cert(our_cert_chain, our_priv_key).unwrap();
 
-    let our_cfg = Default::default();
-    let mut our_cfg_builder = quinn::ServerConfigBuilder::new(our_cfg);
-    unwrap!(our_cfg_builder.certificate(
-        quinn::CertificateChain::from_certs(vec![our_cert]),
-        our_priv_key
-    ));
-    let mut our_cfg = our_cfg_builder.build();
     let transport_config = unwrap!(Arc::get_mut(&mut our_cfg.transport));
     transport_config.max_idle_timeout(Some(Duration::from_secs(20).try_into().unwrap()));
 


### PR DESCRIPTION
Extracts the parts of #1150 that don't rely on rustls 0.20 (now released) and the rustls-native-certs update (not yet done). Arguably should have done this sooner to avoid the rebase, but let's get it done now?