### PR TITLE
make example code truly async

### DIFF
--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -133,11 +133,11 @@ async fn run(options: Opt) -> Result<()> {
 
     while let Some(conn) = incoming.next().await {
         info!("connection incoming");
-        tokio::spawn(
+        tokio::spawn(async move {
             handle_connection(root.clone(), conn).unwrap_or_else(move |e| {
                 error!("connection failed: {reason}", reason = e.to_string())
-            }),
-        );
+            })
+        });
     }
 
     Ok(())
@@ -173,11 +173,11 @@ async fn handle_connection(root: Arc<Path>, conn: quinn::Connecting) -> Result<(
                 }
                 Ok(s) => s,
             };
-            tokio::spawn(
+            tokio::spawn(async move {
                 handle_request(root.clone(), stream)
                     .unwrap_or_else(move |e| error!("failed: {reason}", reason = e.to_string()))
-                    .instrument(info_span!("request")),
-            );
+                    .instrument(info_span!("request"))
+            });
         }
         Ok(())
     }

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -135,9 +135,11 @@ async fn run(options: Opt) -> Result<()> {
         info!("connection incoming");
         let root_clone = root.clone();
         tokio::spawn(async move {
-            handle_connection(root_clone, conn).unwrap_or_else(move |e| {
-                error!("connection failed: {reason}", reason = e.to_string())
-            })
+            handle_connection(root_clone, conn)
+                .unwrap_or_else(move |e| {
+                    error!("connection failed: {reason}", reason = e.to_string())
+                })
+                .await
         });
     }
 
@@ -179,6 +181,7 @@ async fn handle_connection(root: Arc<Path>, conn: quinn::Connecting) -> Result<(
                 handle_request(root_clone, stream)
                     .unwrap_or_else(move |e| error!("failed: {reason}", reason = e.to_string()))
                     .instrument(info_span!("request"))
+                    .await
             });
         }
         Ok(())

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -133,8 +133,9 @@ async fn run(options: Opt) -> Result<()> {
 
     while let Some(conn) = incoming.next().await {
         info!("connection incoming");
+        let root_clone = root.clone();
         tokio::spawn(async move {
-            handle_connection(root.clone(), conn).unwrap_or_else(move |e| {
+            handle_connection(root_clone, conn).unwrap_or_else(move |e| {
                 error!("connection failed: {reason}", reason = e.to_string())
             })
         });
@@ -173,8 +174,9 @@ async fn handle_connection(root: Arc<Path>, conn: quinn::Connecting) -> Result<(
                 }
                 Ok(s) => s,
             };
+            let root_clone = root.clone();
             tokio::spawn(async move {
-                handle_request(root.clone(), stream)
+                handle_request(root_clone, stream)
                     .unwrap_or_else(move |e| error!("failed: {reason}", reason = e.to_string()))
                     .instrument(info_span!("request"))
             });


### PR DESCRIPTION
In the original case, the code was actually running synchronously. So, fix it.