### PR TITLE
Upgrade to tracing-subscriber 0.3

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -16,4 +16,4 @@ rustls = "0.19"
 structopt = "0.3"
 tokio = { version = "1.0.1", features = ["rt"] }
 tracing = "0.1.10"
-tracing-subscriber = { version = "0.2.5", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}
+tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -24,5 +24,5 @@ webpki = "0.21"
 structopt = "0.3"
 tokio = { version = "1.0.1", features = ["rt", "macros", "signal", "net", "sync"] }
 tracing = "0.1.10"
-tracing-subscriber = { version = "0.2.5", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}
+tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
 bytes = "1"

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -42,5 +42,5 @@ webpki = { version = "0.21", default-features = false, optional = true }
 assert_matches = "1.1"
 hex-literal = "0.3.0"
 rcgen = "0.8"
-tracing-subscriber = { version = "0.2.5", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}
+tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
 lazy_static = "1"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -48,7 +48,7 @@ rand = "0.8"
 rcgen = "0.8"
 structopt = "0.3.0"
 tokio = { version = "1.0.1", features = ["rt", "rt-multi-thread", "time", "macros"] }
-tracing-subscriber = { version = "0.2.5", default-features = false, features = ["env-filter", "fmt", "ansi", "chrono"]}
+tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }
 unwrap = "1.2.1"
 url = "2"


### PR DESCRIPTION
I don't think we actually need `local-time`, but I ran into https://github.com/tokio-rs/tracing/issues/1683.

This also eliminates part of the [chrono issues](https://rustsec.org/advisories/RUSTSEC-2020-0159), filed https://github.com/est31/rcgen/issues/65 to deal with the dependency via rcgen.