### PR TITLE
Send ping on rebind to ensure peers notice migration

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -48,7 +48,7 @@ rand = "0.8"
 rcgen = "0.8"
 rustls-pemfile = "0.2.1"
 structopt = "0.3.0"
-tokio = { version = "1.0.1", features = ["rt", "rt-multi-thread", "time", "macros"] }
+tokio = { version = "1.0.1", features = ["rt", "rt-multi-thread", "time", "macros", "sync"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }
 unwrap = "1.2.1"

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -793,6 +793,9 @@ impl ConnectionInner {
     fn process_conn_events(&mut self, cx: &mut Context) -> Result<(), ConnectionError> {
         loop {
             match self.conn_events.poll_next_unpin(cx) {
+                Poll::Ready(Some(ConnectionEvent::Ping)) => {
+                    self.inner.ping();
+                }
                 Poll::Ready(Some(ConnectionEvent::Proto(event))) => {
                     self.inner.handle_event(event);
                 }

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -163,6 +163,13 @@ impl Endpoint {
         let mut inner = self.inner.lock().unwrap();
         inner.socket = socket;
         inner.ipv6 = addr.is_ipv6();
+
+        // Generate some activity so peers notice the rebind
+        for sender in inner.connections.senders.values() {
+            // Ignoring errors from dropped connections
+            let _ = sender.unbounded_send(ConnectionEvent::Ping);
+        }
+
         Ok(())
     }
 

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -76,6 +76,7 @@ enum ConnectionEvent {
         reason: bytes::Bytes,
     },
     Proto(proto::ConnectionEvent),
+    Ping,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Otherwise, a client that is only receiving will lose its connection on rebind.