### PR TITLE
Fix cases of spurious transmit readiness

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3028,7 +3028,7 @@ impl Connection {
     ///
     /// See also `self.space(SpaceId::Data).can_send()`
     fn can_send_1rtt(&self) -> bool {
-        self.streams.can_send()
+        self.streams.can_send_stream_data()
             || self.path.challenge_pending
             || self
                 .prev_path

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -305,6 +305,12 @@ impl StreamsState {
                 .any(|id| self.send.get(id).map_or(false, |s| !s.is_reset()))
         })
     }
+
+    /// Whether MAX_STREAM_DATA frames could be sent for stream `id`
+    pub fn can_send_flow_control(&self, id: StreamId) -> bool {
+        self.recv
+            .get(&id)
+            .map_or(false, |s| s.receiving_unknown_size())
     }
 
     pub fn write_control_frames(

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 default = ["native-certs", "tls-rustls"]
 # Records how long locks are held, and warns if they are held >= 1ms
 lock_tracking = []
-# Trust the contents of the OS certificate store by default
+# Provides `ClientConfig::with_native_roots()` convenience method
 native-certs = ["proto/native-certs"]
 tls-rustls = ["rustls", "webpki", "proto/tls-rustls"]
 


### PR DESCRIPTION
Fixes https://github.com/quinn-rs/quinn/issues/1196. Probably.

These fixes add extra work and don't address the complexity that led to the bug in the first place. https://github.com/quinn-rs/quinn/issues/1226 discusses possible future work to make this logic more fundamentally robust.