### PR TITLE
Apply datagram frame size to entire frame, not just payload

### DIFF
--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -62,7 +62,12 @@ impl<'a> Datagrams<'a> {
             - 4                 // worst-case packet number size
             - self.conn.spaces[SpaceId::Data].crypto.as_ref().map_or_else(|| &self.conn.zero_rtt_crypto.as_ref().unwrap().packet, |x| &x.packet.local).tag_len()
             - Datagram::SIZE_BOUND;
-        let limit = self.conn.peer_params.max_datagram_frame_size?.into_inner();
+        let limit = self
+            .conn
+            .peer_params
+            .max_datagram_frame_size?
+            .into_inner()
+            .saturating_sub(Datagram::SIZE_BOUND as u64);
         Some(limit.min(max_size as u64) as usize)
     }
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -14,7 +14,10 @@ use rustls::internal::msgs::enums::AlertDescription;
 use tracing::info;
 
 use super::*;
-use crate::cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator};
+use crate::{
+    cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator},
+    frame::FrameStruct,
+};
 mod util;
 use util::*;
 
@@ -1544,9 +1547,9 @@ fn datagram_recv_buffer_overflow() {
     let mut pair = Pair::new(Default::default(), server);
     let (client_ch, server_ch) = pair.connect();
     assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
-    assert_matches!(
+    assert_eq!(
         pair.client_conn_mut(client_ch).datagrams().max_size(),
-        Some(WINDOW)
+        Some(WINDOW - Datagram::SIZE_BOUND)
     );
 
     const DATA1: &[u8] = &[0xAB; (WINDOW / 3) + 1];


### PR DESCRIPTION
This is, unfortunately, the specified behavior.