### PR TITLE
Backwards-compatibility with late draft versions

### DIFF
--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -67,10 +67,8 @@ pub async fn connect_client(
         .with_root_certificates(roots)
         .with_no_client_auth();
 
-    let client_config = quinn::ClientConfig {
-        crypto: Arc::new(crypto),
-        transport: Arc::new(transport_config(&opt)),
-    };
+    let mut client_config = quinn::ClientConfig::new(Arc::new(crypto));
+    client_config.transport = Arc::new(transport_config(&opt));
 
     let quinn::NewConnection { connection, .. } = endpoint
         .connect_with(client_config, server_addr, "localhost")

--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -115,11 +115,7 @@ async fn run(opt: Opt) -> Result<()> {
         .with_no_client_auth();
     crypto.alpn_protocols = vec![b"perf".to_vec()];
 
-    let transport = Arc::new(quinn::TransportConfig::default());
-    let cfg = quinn::ClientConfig {
-        crypto: Arc::new(crypto),
-        transport,
-    };
+    let cfg = quinn::ClientConfig::new(Arc::new(crypto));
 
     let stream_stats = OpenStreamStats::default();
 

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -551,12 +551,23 @@ impl fmt::Debug for ServerConfig {
 ///
 /// Default values should be suitable for most internet applications.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct ClientConfig {
     /// Transport configuration to use
     pub transport: Arc<TransportConfig>,
 
     /// Cryptographic configuration to use
     pub crypto: Arc<dyn crypto::ClientConfig>,
+}
+
+impl ClientConfig {
+    /// Create a default config with a particular cryptographic config
+    pub fn new(crypto: Arc<dyn crypto::ClientConfig>) -> Self {
+        Self {
+            transport: Default::default(),
+            crypto,
+        }
+    }
 }
 
 #[cfg(feature = "rustls")]
@@ -583,10 +594,7 @@ impl ClientConfig {
 
     /// Create a client configuration that trusts specified trust anchors
     pub fn with_root_certificates(roots: rustls::RootCertStore) -> Self {
-        Self {
-            transport: Arc::new(TransportConfig::default()),
-            crypto: Arc::new(crypto::rustls::client_config(roots)),
-        }
+        Self::new(Arc::new(crypto::rustls::client_config(roots)))
     }
 }
 

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -121,15 +121,6 @@ pub trait ClientConfig: Send + Sync {
 
 /// Server-side configuration for the crypto protocol
 pub trait ServerConfig: Send + Sync {
-    /// Start a server session with this configuration
-    ///
-    /// Never called if `initial_keys` rejected `version`.
-    fn start_session(
-        self: Arc<Self>,
-        version: u32,
-        params: &TransportParameters,
-    ) -> Box<dyn Session>;
-
     /// Create the initial set of keys given the client's initial destination ConnectionId
     fn initial_keys(
         &self,
@@ -142,6 +133,15 @@ pub trait ServerConfig: Send + Sync {
     ///
     /// Never called if `initial_keys` rejected `version`.
     fn retry_tag(&self, version: u32, orig_dst_cid: &ConnectionId, packet: &[u8]) -> [u8; 16];
+
+    /// Start a server session with this configuration
+    ///
+    /// Never called if `initial_keys` rejected `version`.
+    fn start_session(
+        self: Arc<Self>,
+        version: u32,
+        params: &TransportParameters,
+    ) -> Box<dyn Session>;
 }
 
 /// Keys used to protect packet payloads

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -20,7 +20,7 @@ use crate::{
     coding::BufMutExt,
     config::{ClientConfig, EndpointConfig, ServerConfig},
     connection::{Connection, ConnectionError},
-    crypto::Keys,
+    crypto::{Keys, UnsupportedVersion},
     frame,
     packet::{Header, Packet, PacketDecodeError, PacketNumber, PartialDecode},
     shared::{
@@ -278,12 +278,22 @@ impl Endpoint {
                 return None;
             }
 
-            let crypto = self
-                .server_config
-                .as_ref()
-                .unwrap()
-                .crypto
-                .initial_keys(&dst_cid, Side::Server);
+            let crypto = match self.server_config.as_ref().unwrap().crypto.initial_keys(
+                first_decode.version().unwrap(),
+                &dst_cid,
+                Side::Server,
+            ) {
+                Ok(keys) => keys,
+                Err(UnsupportedVersion) => {
+                    // This probably indicates that the user set supported_versions incorrectly in
+                    // `EndpointConfig`.
+                    debug!(
+                        "ignoring initial packet version {:#x} unsupported by cryptographic layer",
+                        first_decode.version().unwrap()
+                    );
+                    return None;
+                }
+            };
             return match first_decode.finish(Some(&*crypto.header.remote)) {
                 Ok(packet) => self
                     .handle_first_packet(now, remote, local_ip, ecn, packet, remaining, &crypto)
@@ -370,6 +380,7 @@ impl Endpoint {
         let remote_id = RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid();
         trace!(initial_dcid = %remote_id);
         let (ch, conn) = self.add_connection(
+            self.config.initial_version,
             remote_id,
             remote_id,
             remote,
@@ -418,6 +429,7 @@ impl Endpoint {
 
     fn add_connection(
         &mut self,
+        version: u32,
         init_cid: ConnectionId,
         rem_cid: ConnectionId,
         remote: SocketAddr,
@@ -440,7 +452,9 @@ impl Endpoint {
                 );
                 (
                     None,
-                    config.crypto.start_session(&server_name, &params)?,
+                    config
+                        .crypto
+                        .start_session(version, &server_name, &params)?,
                     config.transport,
                 )
             }
@@ -464,7 +478,7 @@ impl Endpoint {
                 };
                 (
                     Some(config.clone()),
-                    config.crypto.clone().start_session(&server_params),
+                    config.crypto.clone().start_session(version, &server_params),
                     config.transport.clone(),
                 )
             }
@@ -481,7 +495,7 @@ impl Endpoint {
             tls,
             self.local_cid_generator.as_ref(),
             now,
-            self.config.initial_version,
+            version,
         );
         let id = self.connections.insert(ConnectionMeta {
             init_cid,
@@ -510,14 +524,15 @@ impl Endpoint {
         rest: Option<BytesMut>,
         crypto: &Keys,
     ) -> Option<(ConnectionHandle, Connection)> {
-        let (src_cid, dst_cid, token, packet_number) = match packet.header {
+        let (src_cid, dst_cid, token, packet_number, version) = match packet.header {
             Header::Initial {
                 src_cid,
                 dst_cid,
                 ref token,
                 number,
+                version,
                 ..
-            } => (src_cid, dst_cid, token.clone(), number),
+            } => (src_cid, dst_cid, token.clone(), number, version),
             _ => panic!("non-initial packet in handle_first_packet()"),
         };
         let packet_number = packet_number.expand(0);
@@ -551,6 +566,7 @@ impl Endpoint {
         {
             debug!("refusing connection");
             self.initial_close(
+                version,
                 remote,
                 local_ip,
                 crypto,
@@ -570,6 +586,7 @@ impl Endpoint {
                 dst_cid.len()
             );
             self.initial_close(
+                version,
                 remote,
                 local_ip,
                 crypto,
@@ -596,13 +613,13 @@ impl Endpoint {
                 let header = Header::Retry {
                     src_cid: temp_loc_cid,
                     dst_cid: src_cid,
-                    version: self.config.initial_version,
+                    version,
                 };
 
                 let mut buf = Vec::new();
                 let encode = header.encode(&mut buf);
                 buf.put_slice(&token);
-                buf.extend_from_slice(&server_config.crypto.retry_tag(&dst_cid, &buf));
+                buf.extend_from_slice(&server_config.crypto.retry_tag(version, &dst_cid, &buf));
                 encode.finish(&mut buf, &*crypto.header.local, None);
 
                 self.transmits.push_back(Transmit {
@@ -624,6 +641,7 @@ impl Endpoint {
                 _ => {
                     debug!("rejecting invalid stateless retry token");
                     self.initial_close(
+                        version,
                         remote,
                         local_ip,
                         crypto,
@@ -640,6 +658,7 @@ impl Endpoint {
 
         let (ch, mut conn) = self
             .add_connection(
+                version,
                 dst_cid,
                 src_cid,
                 remote,
@@ -663,7 +682,15 @@ impl Endpoint {
                 debug!("handshake failed: {}", e);
                 self.handle_event(ch, EndpointEvent(EndpointEventInner::Drained));
                 if let ConnectionError::TransportError(e) = e {
-                    self.initial_close(remote, local_ip, crypto, &src_cid, &temp_loc_cid, e);
+                    self.initial_close(
+                        version,
+                        remote,
+                        local_ip,
+                        crypto,
+                        &src_cid,
+                        &temp_loc_cid,
+                        e,
+                    );
                 }
                 None
             }
@@ -672,6 +699,7 @@ impl Endpoint {
 
     fn initial_close(
         &mut self,
+        version: u32,
         destination: SocketAddr,
         local_ip: Option<IpAddr>,
         crypto: &Keys,
@@ -685,7 +713,7 @@ impl Endpoint {
             src_cid: *local_id,
             number,
             token: Bytes::new(),
-            version: self.config.initial_version,
+            version,
         };
 
         let mut buf = Vec::<u8>::new();
@@ -852,6 +880,9 @@ pub enum ConnectError {
     /// Use `Endpoint::connect_with` to specify a client configuration.
     #[error("no default client config")]
     NoDefaultClientConfig,
+    /// The cryptographic layer does not support the specified QUIC version
+    #[error("unsupported QUIC version")]
+    UnsupportedVersion,
 }
 
 /// Reset Tokens which are associated with peer socket addresses

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -189,7 +189,9 @@ impl Endpoint {
                 } else {
                     buf.write::<u32>(0x0a1a_2a4a);
                 }
-                buf.write(self.config.initial_version); // supported version
+                for &version in &self.config.supported_versions {
+                    buf.write(version);
+                }
                 self.transmits.push_back(Transmit {
                     destination: remote,
                     ecn: None,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -380,7 +380,7 @@ impl Endpoint {
         let remote_id = RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid();
         trace!(initial_dcid = %remote_id);
         let (ch, conn) = self.add_connection(
-            self.config.initial_version,
+            config.version,
             remote_id,
             remote_id,
             remote,

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -124,7 +124,15 @@ pub mod fuzzing {
 }
 
 /// The QUIC protocol version implemented.
-pub const DEFAULT_SUPPORTED_VERSIONS: &[u32] = &[0x00000001];
+pub const DEFAULT_SUPPORTED_VERSIONS: &[u32] = &[
+    0x00000001,
+    0xff00_001d,
+    0xff00_001e,
+    0xff00_001f,
+    0xff00_0020,
+    0xff00_0021,
+    0xff00_0022,
+];
 
 /// Whether an endpoint was the initiator of a connection
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -468,10 +468,7 @@ fn zero_rtt_rejection() {
     let mut pair = Pair::new(Arc::new(EndpointConfig::default()), server_config);
     let mut client_crypto = client_crypto();
     client_crypto.alpn_protocols = vec!["foo".into()];
-    let client_config = ClientConfig {
-        transport: Default::default(),
-        crypto: Arc::new(client_crypto.clone()),
-    };
+    let client_config = ClientConfig::new(Arc::new(client_crypto.clone()));
 
     // Establish normal connection
     let client_ch = pair.begin_connect(client_config);
@@ -502,10 +499,7 @@ fn zero_rtt_rejection() {
 
     // Changing protocols invalidates 0-RTT
     client_crypto.alpn_protocols = vec!["bar".into()];
-    let client_config = ClientConfig {
-        transport: Default::default(),
-        crypto: Arc::new(client_crypto),
-    };
+    let client_config = ClientConfig::new(Arc::new(client_crypto));
     info!("resuming session");
     let client_ch = pair.begin_connect(client_config);
     assert!(pair.client_conn_mut(client_ch).has_0rtt());
@@ -543,10 +537,7 @@ fn alpn_success() {
     let mut pair = Pair::new(Arc::new(EndpointConfig::default()), server_config);
     let mut client_crypto = client_crypto();
     client_crypto.alpn_protocols = vec!["bar".into(), "quux".into(), "corge".into()];
-    let client_config = ClientConfig {
-        transport: Default::default(),
-        crypto: Arc::new(client_crypto),
-    };
+    let client_config = ClientConfig::new(Arc::new(client_crypto));
 
     // Establish normal connection
     let client_ch = pair.begin_connect(client_config);
@@ -578,10 +569,7 @@ fn server_alpn_unset() {
 
     let mut client_crypto = client_crypto();
     client_crypto.alpn_protocols = vec!["foo".into()];
-    let client_config = ClientConfig {
-        transport: Default::default(),
-        crypto: Arc::new(client_crypto),
-    };
+    let client_config = ClientConfig::new(Arc::new(client_crypto));
 
     let client_ch = pair.begin_connect(client_config);
     pair.drive();
@@ -616,10 +604,7 @@ fn alpn_mismatch() {
 
     let mut client_crypto = client_crypto();
     client_crypto.alpn_protocols = vec!["quux".into(), "corge".into()];
-    let client_config = ClientConfig {
-        transport: Default::default(),
-        crypto: Arc::new(client_crypto),
-    };
+    let client_config = ClientConfig::new(Arc::new(client_crypto));
 
     let client_ch = pair.begin_connect(client_config);
     pair.drive();
@@ -1608,10 +1593,7 @@ fn large_initial() {
         .map(|x| x.to_be_bytes().to_vec())
         .collect::<Vec<_>>();
     client_crypto.alpn_protocols = protocols;
-    let cfg = ClientConfig {
-        transport: Default::default(),
-        crypto: Arc::new(client_crypto),
-    };
+    let cfg = ClientConfig::new(Arc::new(client_crypto));
     let client_ch = pair.begin_connect(cfg);
     pair.drive();
     let server_ch = pair.server.assert_accept();

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -394,17 +394,11 @@ pub fn server_crypto_with_cert(cert: Certificate, key: PrivateKey) -> rustls::Se
 }
 
 pub fn client_config() -> ClientConfig {
-    ClientConfig {
-        transport: Default::default(),
-        crypto: Arc::new(client_crypto()),
-    }
+    ClientConfig::new(Arc::new(client_crypto()))
 }
 
 pub fn client_config_with_certs(certs: Vec<rustls::Certificate>) -> ClientConfig {
-    ClientConfig {
-        transport: Default::default(),
-        crypto: Arc::new(client_crypto_with_certs(certs)),
-    }
+    ClientConfig::new(Arc::new(client_crypto_with_certs(certs)))
 }
 
 pub fn client_crypto() -> rustls::ClientConfig {

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -96,10 +96,7 @@ async fn run(options: Opt) -> Result<()> {
     }
 
     let mut endpoint = quinn::Endpoint::client("[::]:0".parse().unwrap())?;
-    endpoint.set_default_client_config(quinn::ClientConfig {
-        crypto: Arc::new(client_crypto),
-        transport: Default::default(),
-    });
+    endpoint.set_default_client_config(quinn::ClientConfig::new(Arc::new(client_crypto)));
 
     let request = format!("GET {}\r\n", url.path());
     let start = Instant::now();

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -82,9 +82,5 @@ fn configure_client() -> ClientConfig {
         .with_no_client_auth();
     crypto.alpn_protocols = vec![b"perf".to_vec()];
 
-    let transport = Arc::new(quinn::TransportConfig::default());
-    ClientConfig {
-        crypto: Arc::new(crypto),
-        transport,
-    }
+    ClientConfig::new(Arc::new(crypto))
 }


### PR DESCRIPTION
Inspired by conversation with @Dessix. Allows the upcoming Quinn release to remain backwards-compatible with 0.7.x.