### PR TITLE
Rename "stateless retry" to "retry"

### DIFF
--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -431,7 +431,7 @@ pub struct ServerConfig {
     /// Whether to require clients to prove ownership of an address before committing resources.
     ///
     /// Introduces an additional round-trip to the handshake to make denial of service attacks more difficult.
-    pub(crate) use_stateless_retry: bool,
+    pub(crate) use_retry: bool,
     /// Microseconds after a stateless retry token was issued for which it's considered valid.
     pub(crate) retry_token_lifetime: Duration,
 
@@ -456,7 +456,7 @@ impl ServerConfig {
             crypto,
 
             token_key,
-            use_stateless_retry: false,
+            use_retry: false,
             retry_token_lifetime: Duration::from_secs(15),
 
             concurrent_connections: 100_000,
@@ -477,8 +477,8 @@ impl ServerConfig {
     /// Whether to require clients to prove ownership of an address before committing resources.
     ///
     /// Introduces an additional round-trip to the handshake to make denial of service attacks more difficult.
-    pub fn use_stateless_retry(&mut self, value: bool) -> &mut Self {
-        self.use_stateless_retry = value;
+    pub fn use_retry(&mut self, value: bool) -> &mut Self {
+        self.use_retry = value;
         self
     }
 

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -560,8 +560,7 @@ impl Endpoint {
         }
 
         if dst_cid.len() < 8
-            && (!server_config.use_stateless_retry
-                || dst_cid.len() != self.local_cid_generator.cid_len())
+            && (!server_config.use_retry || dst_cid.len() != self.local_cid_generator.cid_len())
         {
             debug!(
                 "rejecting connection due to invalid DCID length {}",
@@ -578,7 +577,7 @@ impl Endpoint {
             return None;
         }
 
-        let (retry_src_cid, orig_dst_cid) = if server_config.use_stateless_retry {
+        let (retry_src_cid, orig_dst_cid) = if server_config.use_retry {
             if token.is_empty() {
                 // First Initial
                 let mut random_bytes = vec![0u8; RetryToken::RANDOM_BYTES_LEN];


### PR DESCRIPTION
This better reflects the final RFC terminology. See https://www.rfc-editor.org/rfc/rfc9000.html#name-retry-packet.