### PR TITLE
Make pub visibility for RttEstimator used by pub trait quinn::Congestion

### DIFF
--- a/quinn-proto/src/congestion.rs
+++ b/quinn-proto/src/congestion.rs
@@ -1,6 +1,6 @@
 //! Logic for controlling the rate at which data is sent
 
-use crate::connection::paths::RttEstimator;
+use crate::connection::RttEstimator;
 use std::any::Any;
 use std::time::Instant;
 

--- a/quinn-proto/src/congestion/bbr/mod.rs
+++ b/quinn-proto/src/congestion/bbr/mod.rs
@@ -7,7 +7,7 @@ use rand::{Rng, SeedableRng};
 
 use crate::congestion::bbr::bw_estimation::BandwidthEstimation;
 use crate::congestion::bbr::min_max::MinMax;
-use crate::connection::paths::RttEstimator;
+use crate::connection::RttEstimator;
 
 use super::{Controller, ControllerFactory};
 

--- a/quinn-proto/src/congestion/cubic.rs
+++ b/quinn-proto/src/congestion/cubic.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use super::{Controller, ControllerFactory};
-use crate::connection::paths::RttEstimator;
+use crate::connection::RttEstimator;
 use std::cmp;
 
 /// CUBIC Constants.

--- a/quinn-proto/src/congestion/new_reno.rs
+++ b/quinn-proto/src/congestion/new_reno.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use super::{Controller, ControllerFactory};
-use crate::connection::paths::RttEstimator;
+use crate::connection::RttEstimator;
 
 /// A simple, standard congestion controller
 #[derive(Debug, Clone)]

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -48,8 +48,9 @@ mod pacing;
 mod packet_builder;
 use packet_builder::PacketBuilder;
 
-pub(crate) mod paths;
+mod paths;
 use paths::PathData;
+pub use paths::RttEstimator;
 
 mod send_buffer;
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -41,8 +41,8 @@ pub use varint::{VarInt, VarIntBoundsExceeded};
 mod connection;
 pub use crate::connection::{
     BytesSource, Chunk, Chunks, Connection, ConnectionError, ConnectionStats, Datagrams, Event,
-    FinishError, ReadError, ReadableError, RecvStream, SendDatagramError, SendStream, StreamEvent,
-    Streams, UnknownStream, WriteError, Written,
+    FinishError, ReadError, ReadableError, RecvStream, RttEstimator, SendDatagramError, SendStream,
+    StreamEvent, Streams, UnknownStream, WriteError, Written,
 };
 
 mod config;


### PR DESCRIPTION
Attempt to fix this: #1242 

---

*Feedback on documentation are more than welcome* :smile: 