### PR TITLE
Only send ACKs when they've changed

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2228,13 +2228,8 @@ impl Connection {
             self.stats.frame_rx.record(&frame);
 
             let _guard = span.as_ref().map(|x| x.enter());
-            // Check for ack-eliciting frames
-            match frame {
-                Frame::Ack(_) | Frame::Padding | Frame::Close(Close::Connection(_)) => {}
-                _ => {
-                    ack_eliciting = true;
-                }
-            }
+            ack_eliciting |= frame.is_ack_eliciting();
+
             // Process frames
             match frame {
                 Frame::Padding | Frame::Ping => {}
@@ -2317,14 +2312,8 @@ impl Connection {
                     _ => {}
                 }
             }
+            ack_eliciting |= frame.is_ack_eliciting();
 
-            // Check for ack-eliciting frames
-            match frame {
-                Frame::Ack(_) | Frame::Padding | Frame::Close(_) => {}
-                _ => {
-                    ack_eliciting = true;
-                }
-            }
             // Check whether this could be a probing packet
             match frame {
                 Frame::Padding

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -201,6 +201,10 @@ impl Frame {
             HandshakeDone => Type::HANDSHAKE_DONE,
         }
     }
+
+    pub fn is_ack_eliciting(&self) -> bool {
+        !matches!(*self, Frame::Ack(_) | Frame::Padding | Frame::Close(_))
+    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Saves a great deal of redundancy when transmitting bulk data, and gives the receiver less work to do. If an ACK is lost, we'll necessarily retransmit it, because packets are only deemed lost when an ACK is received from the peer which does not cover them.

Reduces the number of ACKs sent by the server in the bulk download benchmark from e.g. 930818 to 4228.