### PR TITLE
Add additional metrics for lost packets and bytes

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1370,7 +1370,13 @@ impl Connection {
             let old_bytes_in_flight = self.in_flight.bytes;
             let largest_lost_sent = self.spaces[pn_space].sent_packets[&largest_lost].time_sent;
             self.lost_packets += lost_packets.len() as u64;
-            trace!("packets lost: {:?}", lost_packets);
+            self.stats.path.lost_packets += lost_packets.len() as u64;
+            self.stats.path.lost_bytes += size_of_lost_packets as u64;
+            trace!(
+                "packets lost: {:?}, bytes lost: {}",
+                lost_packets,
+                size_of_lost_packets
+            );
             for packet in &lost_packets {
                 let info = self.spaces[pn_space].sent_packets.remove(packet).unwrap(); // safe: lost_packets is populated just above
                 self.remove_in_flight(pn_space, &info);

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -188,6 +188,7 @@ impl PacketBuilder {
 
         conn.in_flight.insert(&packet);
         conn.spaces[space_id].sent(exact_number, packet);
+        conn.stats.path.sent_packets += 1;
         conn.reset_keep_alive(now);
         if size != 0 {
             if ack_eliciting {

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -126,6 +126,12 @@ pub struct PathStats {
     pub cwnd: u64,
     /// Congestion events on the connection
     pub congestion_events: u64,
+    /// The amount of packets lost on this path
+    pub lost_packets: u64,
+    /// The amount of bytes lost on this path
+    pub lost_bytes: u64,
+    /// The amount of packets sent on this path
+    pub sent_packets: u64,
 }
 
 /// Connection statistics


### PR DESCRIPTION
These are a bit more explicit than just tracking congestion events, since a
congestion event can cover multiple packets.
The total amount of sent packets is now also logged, in order for applications
to calculate the relative amount of packet loss. The amount of packets can
be different from the amount of datagrams in case of coalesced packets.