### PR TITLE
Fix ALPN misconfiguration in example

### DIFF
--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -76,11 +76,10 @@ impl rustls::client::ServerCertVerifier for SkipServerVerification {
 }
 
 fn configure_client() -> ClientConfig {
-    let mut crypto = rustls::ClientConfig::builder()
+    let crypto = rustls::ClientConfig::builder()
         .with_safe_defaults()
         .with_custom_certificate_verifier(SkipServerVerification::new())
         .with_no_client_auth();
-    crypto.alpn_protocols = vec![b"perf".to_vec()];
 
     ClientConfig::new(Arc::new(crypto))
 }


### PR DESCRIPTION
Introduced by a copy-paste error in 9daaa15da231f56559d771cf8d674ccdbe98890e