### PR TITLE
Rely on rustls to check for ALPN failure

### DIFF
--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -630,6 +630,7 @@ fn client_alpn_unset() {
 
 #[test]
 fn alpn_mismatch() {
+    let _guard = subscribe();
     let mut server_crypto = server_crypto();
     server_crypto.alpn_protocols = vec!["foo".into(), "bar".into(), "baz".into()];
     let server_config = ServerConfig::with_crypto(Arc::new(server_crypto));

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -608,7 +608,7 @@ fn server_alpn_unset() {
     pair.drive();
     assert_matches!(
         pair.client_conn_mut(client_ch).poll(),
-        Some(Event::ConnectionLost { reason: ConnectionError::TransportError(ref err) }) if err.code == TransportErrorCode::crypto(0x78)
+        Some(Event::ConnectionLost { reason: ConnectionError::ConnectionClosed(err) }) if err.error_code == TransportErrorCode::crypto(0x78)
     );
 }
 


### PR DESCRIPTION
Blocked on a rustls release containing https://github.com/rustls/rustls/pull/873.