### PR TITLE
Replace futures-util with optional futures-io dep

### DIFF
--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -6,7 +6,6 @@ use std::{
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
-use futures_util::StreamExt;
 use structopt::StructOpt;
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info};

--- a/perf/src/bin/perf_server.rs
+++ b/perf/src/bin/perf_server.rs
@@ -2,7 +2,6 @@ use std::{fs, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
-use futures_util::StreamExt;
 use structopt::StructOpt;
 use tracing::{debug, error, info};
 

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -30,6 +30,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 bytes = "1"
 futures-util = { version = "0.3.11", default-features = false, features = ["io"] }
+futures-core = "0.3.19"
 futures-channel = "0.3.11"
 rustc-hash = "1.1"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.8", default-features = false }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 all-features = true
 
 [features]
-default = ["native-certs", "tls-rustls", "ring", "futures-util"]
+default = ["native-certs", "tls-rustls", "ring", "futures-io"]
 # Records how long locks are held, and warns if they are held >= 1ms
 lock_tracking = []
 # Provides `ClientConfig::with_native_roots()` convenience method
@@ -29,8 +29,8 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 bytes = "1"
-# Enables futures_util::io::{AsyncRead, AsyncWrite} support for streams
-futures-util = { version = "0.3.11", default-features = false, features = ["io"], optional = true }
+# Enables futures::io::{AsyncRead, AsyncWrite} support for streams
+futures-io = { version = "0.3.19", optional = true }
 futures-core = "0.3.19"
 futures-channel = "0.3.11"
 rustc-hash = "1.1"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 all-features = true
 
 [features]
-default = ["native-certs", "tls-rustls", "ring", "futures-io"]
+default = ["native-certs", "tls-rustls", "ring"]
 # Records how long locks are held, and warns if they are held >= 1ms
 lock_tracking = []
 # Provides `ClientConfig::with_native_roots()` convenience method

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 all-features = true
 
 [features]
-default = ["native-certs", "tls-rustls", "ring"]
+default = ["native-certs", "tls-rustls", "ring", "futures-util"]
 # Records how long locks are held, and warns if they are held >= 1ms
 lock_tracking = []
 # Provides `ClientConfig::with_native_roots()` convenience method
@@ -29,7 +29,8 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 bytes = "1"
-futures-util = { version = "0.3.11", default-features = false, features = ["io"] }
+# Enables futures_util::io::{AsyncRead, AsyncWrite} support for streams
+futures-util = { version = "0.3.11", default-features = false, features = ["io"], optional = true }
 futures-core = "0.3.19"
 futures-channel = "0.3.11"
 rustc-hash = "1.1"

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use bencher::{benchmark_group, benchmark_main, Bencher};
-use futures_util::StreamExt;
 use tokio::runtime::{Builder, Runtime};
 use tracing::error_span;
 use tracing_futures::Instrument as _;

--- a/quinn/examples/connection.rs
+++ b/quinn/examples/connection.rs
@@ -2,9 +2,6 @@
 //!
 //! Checkout the `README.md` for guidance.
 
-// Provides the async `next()` method on `incoming` below
-use futures_util::StreamExt;
-
 mod common;
 use common::{make_client_endpoint, make_server_endpoint};
 

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -2,7 +2,6 @@
 //!
 //! Checkout the `README.md` for guidance.
 
-use futures_util::StreamExt;
 use std::{error::Error, net::SocketAddr, sync::Arc};
 
 use quinn::{ClientConfig, Endpoint};

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use anyhow::{anyhow, bail, Context, Result};
-use futures_util::{StreamExt, TryFutureExt};
+use futures_util::TryFutureExt;
 use structopt::{self, StructOpt};
 use tracing::{error, info, info_span};
 use tracing_futures::Instrument as _;

--- a/quinn/examples/single_socket.rs
+++ b/quinn/examples/single_socket.rs
@@ -2,7 +2,6 @@
 //!
 //! Checkout the `README.md` for guidance.
 
-use futures_util::StreamExt;
 use std::{error::Error, net::SocketAddr};
 
 use quinn::Endpoint;

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -12,7 +12,6 @@ use std::{
 
 use bytes::Bytes;
 use futures_channel::{mpsc, oneshot};
-use futures_util::StreamExt;
 use futures_core::Stream;
 use proto::{ConnectionError, ConnectionHandle, ConnectionStats, Dir, StreamEvent, StreamId};
 use rustc_hash::FxHashMap;
@@ -803,7 +802,7 @@ impl ConnectionInner {
     /// If this returns `Err`, the endpoint is dead, so the driver should exit immediately.
     fn process_conn_events(&mut self, cx: &mut Context) -> Result<(), ConnectionError> {
         loop {
-            match self.conn_events.poll_next_unpin(cx) {
+            match Pin::new(&mut self.conn_events).poll_next(cx) {
                 Poll::Ready(Some(ConnectionEvent::Ping)) => {
                     self.inner.ping();
                 }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -13,6 +13,7 @@ use std::{
 use bytes::Bytes;
 use futures_channel::{mpsc, oneshot};
 use futures_util::StreamExt;
+use futures_core::Stream;
 use proto::{ConnectionError, ConnectionHandle, ConnectionStats, Dir, StreamEvent, StreamId};
 use rustc_hash::FxHashMap;
 use thiserror::Error;
@@ -533,7 +534,7 @@ impl Clone for Connection {
 #[derive(Debug)]
 pub struct IncomingUniStreams(ConnectionRef);
 
-impl futures_util::stream::Stream for IncomingUniStreams {
+impl Stream for IncomingUniStreams {
     type Item = Result<RecvStream, ConnectionError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
@@ -559,7 +560,7 @@ impl futures_util::stream::Stream for IncomingUniStreams {
 #[derive(Debug)]
 pub struct IncomingBiStreams(ConnectionRef);
 
-impl futures_util::stream::Stream for IncomingBiStreams {
+impl Stream for IncomingBiStreams {
     type Item = Result<(SendStream, RecvStream), ConnectionError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
@@ -587,7 +588,7 @@ impl futures_util::stream::Stream for IncomingBiStreams {
 #[derive(Debug)]
 pub struct Datagrams(ConnectionRef);
 
-impl futures_util::stream::Stream for Datagrams {
+impl Stream for Datagrams {
     type Item = Result<Bytes, ConnectionError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -24,6 +24,7 @@ use udp::{RecvMeta, UdpSocket, UdpState, BATCH_SIZE};
 use crate::{
     broadcast::{self, Broadcast},
     connection::Connecting,
+    poll_fn,
     work_limiter::WorkLimiter,
     ConnectionEvent, EndpointConfig, EndpointEvent, VarInt, IO_LOOP_BOUND, RECV_TIME_BOUND,
     SEND_TIME_BOUND,
@@ -226,7 +227,7 @@ impl Endpoint {
     /// [`Incoming`]: crate::Incoming
     pub async fn wait_idle(&self) {
         let mut state = broadcast::State::default();
-        futures_util::future::poll_fn(|cx| {
+        poll_fn(move |cx| {
             let endpoint = &mut *self.inner.lock().unwrap();
             if endpoint.connections.is_empty() {
                 return Poll::Ready(());

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -15,6 +15,7 @@ use std::{
 use bytes::Bytes;
 use futures_channel::mpsc;
 use futures_util::StreamExt;
+use futures_core::Stream;
 use proto::{
     self as proto, ClientConfig, ConnectError, ConnectionHandle, DatagramEvent, ServerConfig,
 };
@@ -518,7 +519,7 @@ impl Incoming {
     }
 }
 
-impl futures_util::stream::Stream for Incoming {
+impl Stream for Incoming {
     type Item = Connecting;
 
     #[allow(unused_mut)] // MSRV

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -14,7 +14,6 @@ use std::{
 
 use bytes::Bytes;
 use futures_channel::mpsc;
-use futures_util::StreamExt;
 use futures_core::Stream;
 use proto::{
     self as proto, ClientConfig, ConnectError, ConnectionHandle, DatagramEvent, ServerConfig,
@@ -436,7 +435,7 @@ impl EndpointInner {
         use EndpointEvent::*;
 
         for _ in 0..IO_LOOP_BOUND {
-            match self.events.poll_next_unpin(cx) {
+            match Pin::new(&mut self.events).poll_next(cx) {
                 Poll::Ready(Some((ch, event))) => match event {
                     Proto(e) => {
                         if e.is_drained() {

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -519,6 +519,13 @@ impl Incoming {
     }
 }
 
+impl Incoming {
+    /// Fetch the next incoming connection, or `None` if the endpoint has been closed
+    pub async fn next(&mut self) -> Option<Connecting> {
+        poll_fn(move |cx| Pin::new(&mut *self).poll_next(cx)).await
+    }
+}
+
 impl Stream for Incoming {
     type Item = Connecting;
 

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -41,6 +41,15 @@
 
 use std::time::Duration;
 
+macro_rules! ready {
+    ($e:expr $(,)?) => {
+        match $e {
+            std::task::Poll::Ready(t) => t,
+            std::task::Poll::Pending => return std::task::Poll::Pending,
+        }
+    };
+}
+
 mod broadcast;
 mod connection;
 mod endpoint;

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures_util::io::AsyncRead;
 use proto::{Chunk, Chunks, ConnectionError, ReadableError, StreamId};
 use thiserror::Error;
 use tokio::io::ReadBuf;
@@ -355,7 +354,8 @@ pub enum ReadToEndError {
     TooLong,
 }
 
-impl AsyncRead for RecvStream {
+#[cfg(feature = "futures-util")]
+impl futures_util::io::AsyncRead for RecvStream {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context,

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures_util::{io::AsyncRead, ready};
+use futures_util::io::AsyncRead;
 use proto::{Chunk, Chunks, ConnectionError, ReadableError, StreamId};
 use thiserror::Error;
 use tokio::io::ReadBuf;

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -354,8 +354,8 @@ pub enum ReadToEndError {
     TooLong,
 }
 
-#[cfg(feature = "futures-util")]
-impl futures_util::io::AsyncRead for RecvStream {
+#[cfg(feature = "futures-io")]
+impl futures_io::AsyncRead for RecvStream {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context,

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -219,8 +219,8 @@ impl SendStream {
     }
 }
 
-#[cfg(feature = "futures-util")]
-impl futures_util::io::AsyncWrite for SendStream {
+#[cfg(feature = "futures-io")]
+impl futures_io::AsyncWrite for SendStream {
     fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
         tokio::io::AsyncWrite::poll_write(self, cx, buf)
     }

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -7,7 +7,7 @@ use std::{
 
 use bytes::Bytes;
 use futures_channel::oneshot;
-use futures_util::{io::AsyncWrite, ready, FutureExt};
+use futures_util::{io::AsyncWrite, FutureExt};
 use proto::{ConnectionError, FinishError, StreamId, Written};
 use thiserror::Error;
 

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -7,7 +7,7 @@ use std::{
 
 use bytes::Bytes;
 use futures_channel::oneshot;
-use futures_util::{io::AsyncWrite, FutureExt};
+use futures_util::io::AsyncWrite;
 use proto::{ConnectionError, FinishError, StreamId, Written};
 use thiserror::Error;
 
@@ -136,11 +136,8 @@ impl SendStream {
             conn.finishing.insert(self.stream, send);
             conn.wake();
         }
-        match self
-            .finishing
-            .as_mut()
-            .unwrap()
-            .poll_unpin(cx)
+        match Pin::new(self.finishing.as_mut().unwrap())
+            .poll(cx)
             .map(|x| x.unwrap())
         {
             Poll::Ready(None) => Poll::Ready(Ok(())),


### PR DESCRIPTION
A trivial amount of additional code lets us save another dep and be a bit more accessible to new users (see e.g. #1262).