### PR TITLE
Remove redundant copying outgoing packets.

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -103,7 +103,7 @@ impl Endpoint {
         if self.transmits.len() >= batch {
             &self.transmits.as_slices().0[0..batch-1]
         } else {
-            &self.transmits.as_slices().0[0..self.transmits.len()]
+            &self.transmits.as_slices().0[0..self.transmits.len()-1]
         }
     }
 

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -100,7 +100,11 @@ impl Endpoint {
 
     /// Returns a batch of transmittable packets
     pub fn transmit_batch(&self, batch: usize) -> &[Transmit] {
-        &self.transmits.as_slices().0[0..batch]
+        if self.transmits.len() >= batch {
+            &self.transmits.as_slices().0[0..batch-1]
+        } else {
+            &self.transmits.as_slices().0[0..self.transmits.len()]
+        }
     }
 
     /// Whether there are transmittable packets

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -3,7 +3,7 @@ use std::{
     convert::TryFrom,
     fmt, iter,
     net::{IpAddr, SocketAddr},
-    ops::{Index, IndexMut},
+    ops::{Index, IndexMut, RangeTo},
     sync::Arc,
     time::{Instant, SystemTime},
 };
@@ -86,6 +86,26 @@ impl Endpoint {
     #[must_use]
     pub fn poll_transmit(&mut self) -> Option<Transmit> {
         self.transmits.pop_front()
+    }
+
+    /// Queues a packet for transmission
+    pub fn queue_transmit(&mut self, transmit: Transmit) {
+        self.transmits.push_back(transmit)
+    }
+
+    /// Drains a range of transmittable packets
+    pub fn drain_transmits(&mut self, range: RangeTo<usize>) {
+        self.transmits.drain(range);
+    }
+
+    /// Returns a batch of transmittable packets
+    pub fn transmit_batch(&self, batch: usize) -> &[Transmit] {
+        &self.transmits.as_slices().0[0..batch]
+    }
+
+    /// Whether there are transmittable packets
+    pub fn has_transmits(&self) -> bool {
+        self.transmits.is_empty()
     }
 
     /// Replace the server configuration, affecting new incoming connections only


### PR DESCRIPTION
Both `proto::Endpoint.transmits` and and `quinn::Endpoint.outgoing` queue transmit packets, and in `drive send` both queues are fetched and drained while this isn't required (from what I can tell). This PR removes the `outgoing` queue in `quinn::Endpoint` and simplifies it to only use `proto::Endpoint.transmits` for all outgoing packets.

This should remove redundant copying of transmits, and queue allocations. 

_left: before, right: this PR_

![image](https://user-images.githubusercontent.com/19969910/147554403-2faa8e50-faab-455c-a970-9f1da80d9c71.png)
