### PR TITLE
Remove redundant packet copying

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -84,7 +84,7 @@ impl Endpoint {
 
     /// Get the next packet to transmit
     #[must_use]
-    pub fn poll_transmit(&mut self) -> Option<Transmit> {
+    pub fn deque_transmit(&mut self) -> Option<Transmit> {
         self.transmits.pop_front()
     }
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -37,7 +37,7 @@ fn version_negotiate_server() {
     );
     assert!(event.is_none());
 
-    let io = server.poll_transmit();
+    let io = server.deque_transmit();
     assert!(io.is_some());
     if let Some(Transmit { contents, .. }) = io {
         assert_ne!(contents[0] & 0x80, 0);
@@ -46,7 +46,7 @@ fn version_negotiate_server() {
             DEFAULT_SUPPORTED_VERSIONS.contains(&u32::from_be_bytes(x.try_into().unwrap()))
         }));
     }
-    assert_matches!(server.poll_transmit(), None);
+    assert_matches!(server.deque_transmit(), None);
 }
 
 #[test]

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -288,7 +288,7 @@ impl TestEndpoint {
             }
         }
 
-        while let Some(x) = self.poll_transmit() {
+        while let Some(x) = self.deque_transmit() {
             self.outbound.extend(split_transmit(x));
         }
 


### PR DESCRIPTION
Both `proto::Endpoint.transmits` and and `quinn::Endpoint.outgoing` queue transmit packets, and in `drive send` both queues are fetched and drained while this isn't required (from what I can tell). This PR removes the `outgoing` queue in `quinn::Endpoint` and simplifies it to only use `proto::Endpoint.transmits` for all outgoing packets.

This should remove redundant copying of transmits, and queue allocations. 

_left: before, right: this PR_

![image](https://user-images.githubusercontent.com/19969910/147554403-2faa8e50-faab-455c-a970-9f1da80d9c71.png)

To make the API consistent, I renamed `poll_transmit` to `deque_transmit`. I could name `queue_transmit` to `push_transmit` to make my function more consistent although I am more satisfied with queue terminology because 1) the transmit storage is a queue 2) poll doesn't really say some dequeue operation is going to happen. 


The Linux CI error also occurs on a fresh clone: run with `cargo test echo_dualstack -- --nocapture` to validate this.