### PR TITLE
Strip down futures-* dependencies

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -8,12 +8,11 @@ publish = false
 [dependencies]
 anyhow = "1.0.22"
 bytes = "1"
-futures-util = "0.3.11"
 hdrhistogram = { version = "7.2", default-features = false }
 quinn = { path = "../quinn" }
 rcgen = "0.8"
 rustls = { version = "0.20", default-features = false, features = ["quic"] }
 structopt = "0.3"
-tokio = { version = "1.0.1", features = ["rt"] }
+tokio = { version = "1.0.1", features = ["rt", "sync"] }
 tracing = "0.1.10"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -12,7 +12,6 @@ json-output = ["serde", "serde_json"]
 
 [dependencies]
 anyhow = "1.0.22"
-futures-util = "0.3.11"
 hdrhistogram = { version = "7.2", default-features = false }
 quinn = { path = "../quinn" }
 rcgen = "0.8"

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -16,7 +16,6 @@ all-features = true
 maintenance = { status = "experimental" }
 
 [dependencies]
-futures-util = { version = "0.3.11", features = ["io"] }
 libc = "0.2.69"
 mio = { version = "0.7.7", features = ["net"] }
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.8", default-features = false }

--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -5,7 +5,6 @@ use std::{
     time::Instant,
 };
 
-use futures_util::ready;
 use proto::Transmit;
 use tokio::io::ReadBuf;
 

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -8,6 +8,15 @@ use std::{
 use proto::{EcnCodepoint, Transmit};
 use tracing::warn;
 
+macro_rules! ready {
+    ($e:expr $(,)?) => {
+        match $e {
+            std::task::Poll::Ready(t) => t,
+            std::task::Poll::Pending => return std::task::Poll::Pending,
+        }
+    };
+}
+
 #[cfg(unix)]
 mod cmsg;
 #[cfg(unix)]

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -10,7 +10,6 @@ use std::{
     time::Instant,
 };
 
-use futures_util::ready;
 use proto::{EcnCodepoint, Transmit};
 use tokio::io::unix::AsyncFd;
 

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -31,7 +31,8 @@ maintenance = { status = "experimental" }
 bytes = "1"
 # Enables futures::io::{AsyncRead, AsyncWrite} support for streams
 futures-io = { version = "0.3.19", optional = true }
-futures-core = "0.3.19"
+# Implements futures::Stream for async streams such as `Incoming`
+futures-core = { version = "0.3.19", optional = true }
 rustc-hash = "1.1"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.8", default-features = false }
 rustls = { version = "0.20", default-features = false, features = ["quic"], optional = true }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -47,7 +47,6 @@ anyhow = "1.0.22"
 crc = "2"
 bencher = "0.1.5"
 directories-next = "2"
-futures-util = { version = "0.3.11", default-features = false, features = ["async-await-macro"] }
 rand = "0.8"
 rcgen = "0.8"
 rustls-pemfile = "0.2.1"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -32,7 +32,6 @@ bytes = "1"
 # Enables futures::io::{AsyncRead, AsyncWrite} support for streams
 futures-io = { version = "0.3.19", optional = true }
 futures-core = "0.3.19"
-futures-channel = "0.3.11"
 rustc-hash = "1.1"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.8", default-features = false }
 rustls = { version = "0.20", default-features = false, features = ["quic"], optional = true }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -38,7 +38,7 @@ proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.8", def
 rustls = { version = "0.20", default-features = false, features = ["quic"], optional = true }
 thiserror = "1.0.21"
 tracing = "0.1.10"
-tokio = { version = "1.0.1", features = ["rt", "time"] }
+tokio = { version = "1.0.1", features = ["rt", "time", "sync"] }
 udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.1.0" }
 webpki = { version = "0.22", default-features = false, optional = true }
 

--- a/quinn/examples/single_socket.rs
+++ b/quinn/examples/single_socket.rs
@@ -24,12 +24,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     )?;
 
     // connect to multiple endpoints using the same socket/endpoint
-    futures_util::future::join_all(vec![
+    tokio::join!(
         run_client(&client, addr1),
         run_client(&client, addr2),
         run_client(&client, addr3),
-    ])
-    .await;
+    );
 
     // Make sure the server has a chance to clean up
     client.wait_idle().await;

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -6,9 +6,9 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures_channel::oneshot;
 use proto::{ConnectionError, FinishError, StreamId, Written};
 use thiserror::Error;
+use tokio::sync::oneshot;
 
 use crate::{
     connection::{ConnectionRef, UnknownStream},

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -522,7 +522,7 @@ fn run_echo(args: EchoArgs) {
                 };
                 let recv_task = async { recv.read_to_end(usize::max_value()).await.expect("read") };
 
-                let (_, data) = futures_util::join!(send_task, recv_task);
+                let (_, data) = tokio::join!(send_task, recv_task);
 
                 assert_eq!(data[..], msg[..], "Data mismatch");
             }

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -26,13 +26,12 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
     .unwrap();
 
     let runtime = Builder::new_current_thread().enable_all().build().unwrap();
+    let _guard = runtime.enter();
     let shared = Arc::new(Mutex::new(Shared { errors: vec![] }));
 
     let (cfg, listener_cert) = configure_listener();
-    let (endpoint, incoming_conns) = {
-        let _guard = runtime.enter();
-        quinn::Endpoint::server(cfg, "127.0.0.1:0".parse().unwrap()).unwrap()
-    };
+    let (endpoint, incoming_conns) =
+        quinn::Endpoint::server(cfg, "127.0.0.1:0".parse().unwrap()).unwrap();
     let listener_addr = endpoint.local_addr().unwrap();
 
     let expected_messages = 50;


### PR DESCRIPTION
This drops 6 packages from the workspace-scoped Cargo.lock, and should save a decent amount of buildtime, both locally and downstream.