### PR TITLE
Adjust the book with version 0.8.0

### DIFF
--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -129,14 +129,9 @@ This is the only thing you need to do for your server to be secured.
 **Configure Client**
 
 ```rust
-let mut roots = rustls::RootCertStore::empty()
-roots.add(&cert).unwrap();
 let mut crypto = rustls::ClientConfig::builder()
-    .with_safe_default_cipher_suites()
-    .with_safe_default_kx_groups()
-    .with_protocol_versions(&[&rustls::version::TLS13])
-    .unwrap()
-    .with_root_certificates(roots)
+    .with_safe_defaults()
+    .with_single_cert(vec![cert]), key)?
     .with_no_client_auth();
 let client_config = ClientConfig::new(Arc::new(crypto));
 ```

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -150,8 +150,8 @@ This is the only thing you need to do for your client to trust a server certific
 [6]: https://letsencrypt.org/getting-started/
 [7]: https://certbot.eff.org/instructions
 
-[ClientConfig]: https://docs.rs/quinn/latest/quinn/generic/struct.ClientConfig.html
+[ClientConfig]: https://docs.rs/quinn/latest/quinn/struct.ClientConfig.html
 [ServerCertVerifier]: https://docs.rs/rustls/latest/rustls/trait.ServerCertVerifier.html
-[default_client_config]: https://docs.rs/quinn/latest/quinn/generic/struct.EndpointBuilder.html#method.default_client_config
+[default_client_config]: https://docs.rs/quinn/latest/quinn/struct.EndpointBuilder.html#method.default_client_config
 [generate_simple_self_signed]: https://docs.rs/rcgen/latest/rcgen/fn.generate_simple_self_signed.html
 [Certificate]: https://docs.rs/rcgen/latest/rcgen/struct.Certificate.html

--- a/docs/book/src/quinn/certificate.md
+++ b/docs/book/src/quinn/certificate.md
@@ -151,7 +151,7 @@ This is the only thing you need to do for your client to trust a server certific
 [7]: https://certbot.eff.org/instructions
 
 [ClientConfig]: https://docs.rs/quinn/latest/quinn/struct.ClientConfig.html
-[ServerCertVerifier]: https://docs.rs/rustls/latest/rustls/trait.ServerCertVerifier.html
+[ServerCertVerifier]: https://docs.rs/rustls/latest/rustls/client/trait.ServerCertVerifier.html
 [default_client_config]: https://docs.rs/quinn/latest/quinn/struct.EndpointBuilder.html#method.default_client_config
 [generate_simple_self_signed]: https://docs.rs/rcgen/latest/rcgen/fn.generate_simple_self_signed.html
 [Certificate]: https://docs.rs/rcgen/latest/rcgen/struct.Certificate.html

--- a/docs/book/src/quinn/data-transfer.md
+++ b/docs/book/src/quinn/data-transfer.md
@@ -35,8 +35,8 @@ For example, from the connection initiator to the peer and the other way around.
 
 ```rust
 async fn open_bidirectional_stream(connection: Connection) -> anyhow::Result<()> {
-    let (mut send, recv) = connection.
-        open_bi()
+    let (mut send, recv) = connection
+        .open_bi()
         .await?;
 
     send.write_all(b"test").await?;
@@ -73,11 +73,11 @@ It is possible to get reliability without ordering (so no head-of-line blocking)
 
 ```rust
 async fn open_unidirectional_stream(connection: Connection)-> anyhow::Result<()> {
-    let mut send = connection.
-        open_uni()
+    let mut send = connection
+        .open_uni()
         .await?;
 
-    send.write_all(b"test").await.unwrap();
+    send.write_all(b"test").await?;
     send.finish().await?;
 
     Ok(())

--- a/docs/book/src/quinn/data-transfer.md
+++ b/docs/book/src/quinn/data-transfer.md
@@ -127,9 +127,9 @@ async fn receive_datagram(mut connection: NewConnection) -> anyhow::Result<()> {
 }
 ```
 
-[Endpoint]: https://docs.rs/quinn/latest/quinn/generic/struct.Endpoint.html
-[NewConnection]: https://docs.rs/quinn/latest/quinn/generic/struct.NewConnection.html
-[open_bi]: https://docs.rs/quinn/latest/quinn/generic/struct.Connection.html#method.open_bi
-[open_uni]: https://docs.rs/quinn/latest/quinn/generic/struct.Connection.html#method.open_uni
-[send_datagram]: https://docs.rs/quinn/latest/quinn/generic/struct.Connection.html#method.send_datagram
-[connection]: https://docs.rs/quinn/latest/quinn/generic/struct.NewConnection.html#structfield.connection
+[Endpoint]: https://docs.rs/quinn/latest/quinn/struct.Endpoint.html
+[NewConnection]: https://docs.rs/quinn/latest/quinn/struct.NewConnection.html
+[open_bi]: https://docs.rs/quinn/latest/quinn/struct.Connection.html#method.open_bi
+[open_uni]: https://docs.rs/quinn/latest/quinn/struct.Connection.html#method.open_uni
+[send_datagram]: https://docs.rs/quinn/latest/quinn/struct.Connection.html#method.send_datagram
+[connection]: https://docs.rs/quinn/latest/quinn/struct.NewConnection.html#structfield.connection

--- a/docs/book/src/quinn/set-up-connection.md
+++ b/docs/book/src/quinn/set-up-connection.md
@@ -76,8 +76,8 @@ async fn client() -> anyhow::Result<()> {
 [Next up](data-transfer.md), let's have a look at sending data over this connection.  
 
 
-[Endpoint]: https://docs.rs/quinn/latest/quinn/generic/struct.Endpoint.html
-[EndpointBuilder]: https://docs.rs/quinn/latest/quinn/generic/struct.EndpointBuilder.html
-[bind]: https://docs.rs/quinn/latest/quinn/generic/struct.EndpointBuilder.html#method.bind
-[connect]: https://docs.rs/quinn/latest/quinn/generic/struct.Endpoint.html#method.connect
-[with_socket]: https://docs.rs/quinn/latest/quinn/generic/struct.EndpointBuilder.html#method.with_socket
+[Endpoint]: https://docs.rs/quinn/latest/quinn/struct.Endpoint.html
+[EndpointBuilder]: https://docs.rs/quinn/latest/quinn/struct.EndpointBuilder.html
+[bind]: https://docs.rs/quinn/latest/quinn/struct.EndpointBuilder.html#method.bind
+[connect]: https://docs.rs/quinn/latest/quinn/struct.Endpoint.html#method.connect
+[with_socket]: https://docs.rs/quinn/latest/quinn/struct.EndpointBuilder.html#method.with_socket

--- a/docs/book/src/quinn/set-up-connection.md
+++ b/docs/book/src/quinn/set-up-connection.md
@@ -60,7 +60,7 @@ async fn client() -> Result<(), Box<dyn Error>> {
     let mut endpoint = Endpoint::client(client_addr());
 
     // Connect to the server passing in the server name which is supposed to be in the server certificate.
-    let connection = endpoint.connect(server_addr(), SERVER_NAME)?.await;
+    let connection = endpoint.connect(server_addr(), SERVER_NAME)?.await?;
 
     // Start transferring, receiving data, see data transfer page.
 

--- a/docs/book/src/quinn/set-up-connection.md
+++ b/docs/book/src/quinn/set-up-connection.md
@@ -60,7 +60,7 @@ async fn client() -> Result<(), Box<dyn Error>> {
     let mut endpoint = Endpoint::client(client_addr());
 
     // Connect to the server passing in the server name which is supposed to be in the server certificate.
-    let connection = endpoint.connect(server_addr(), SERVER_NAME)?;
+    let connection = endpoint.connect(server_addr(), SERVER_NAME)?.await;
 
     // Start transferring, receiving data, see data transfer page.
 


### PR DESCRIPTION
Hi!
This PR updates the book.

- adjust links that point into the no longer existent "generic" directory
- `quinn::ClientConfigBuilder`, `ServerConfigBuilder` and `EndpointBuilder` have already been removed (#1213), so adjust
- `quinn::Certificate` have already been removed (#1214), so adjust

I referred to [quinn/examples/insecure_connection.rs](https://github.com/quinn-rs/quinn/blob/0.8.0/quinn/examples/insecure_connection.rs), [quinn/examples/client.rs](https://github.com/quinn-rs/quinn/blob/0.8.0/quinn/examples/client.rs) and [quinn/examples/server.rs](https://github.com/quinn-rs/quinn/blob/0.8.0/quinn/examples/server.rs) to adjust the book.
