### PR TITLE
Rename variable of example

### DIFF
--- a/docs/book/src/quinn/set-up-connection.md
+++ b/docs/book/src/quinn/set-up-connection.md
@@ -61,7 +61,7 @@ async fn client() -> Result<(), Box<dyn Error>> {
 
     // Connect to the server passing in the server name which is supposed to be in the server certificate.
     let new_connection = endpoint.connect(server_addr(), SERVER_NAME)?.await?;
-    let connection = new_connection.connection;
+    let NewConnection { connection, .. } = new_connection;
 
     // Start transferring, receiving data, see data transfer page.
 

--- a/docs/book/src/quinn/set-up-connection.md
+++ b/docs/book/src/quinn/set-up-connection.md
@@ -60,7 +60,8 @@ async fn client() -> Result<(), Box<dyn Error>> {
     let mut endpoint = Endpoint::client(client_addr());
 
     // Connect to the server passing in the server name which is supposed to be in the server certificate.
-    let connection = endpoint.connect(server_addr(), SERVER_NAME)?.await?;
+    let new_connection = endpoint.connect(server_addr(), SERVER_NAME)?.await?;
+    let connection = new_connection.connection;
 
     // Start transferring, receiving data, see data transfer page.
 


### PR DESCRIPTION
`endpoint.connect` returns NewConnection so I think we should rename from connection to new_connection.
And `let connection = new_connection.connection;` is easy to understand but it's not good because of partial move.
Any ideas?