### PR TITLE
Minor doc fixes, document private items on ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,7 +69,7 @@ jobs:
           override: true
           components: clippy
       - name: doc
-        run: cargo doc --no-deps
+        run: cargo doc --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: -Dwarnings
       - name: lint fuzz

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Quinn is a pure-rust, async-compatible implementation of the IETF [QUIC][quic] t
   [rustls][rustls] and [*ring*][ring]
 - Application-layer datagrams for small, unreliable messages
 - Future-based async API
-- Minimum supported Rust version of 1.51.0
+- Minimum supported Rust version of 1.53.0
 
 ## Overview
 

--- a/quinn-proto/src/congestion/bbr/mod.rs
+++ b/quinn-proto/src/congestion/bbr/mod.rs
@@ -365,7 +365,7 @@ impl Bbr {
             .max(self.min_cwnd);
     }
 
-    /// https://datatracker.ietf.org/doc/html/draft-cardwell-iccrg-bbr-congestion-control#section-4.3.2.2
+    /// <https://datatracker.ietf.org/doc/html/draft-cardwell-iccrg-bbr-congestion-control#section-4.3.2.2>
     fn check_if_full_bw_reached(&mut self, app_limited: bool) {
         if app_limited {
             return;

--- a/quinn-proto/src/connection/pacing.rs
+++ b/quinn-proto/src/connection/pacing.rs
@@ -11,7 +11,7 @@ use tracing::warn;
 /// Once the bucket is empty, further transmission is blocked.
 /// The bucket refills at a rate slightly faster
 /// than one congestion window per RTT, as recommended in
-/// https://tools.ietf.org/html/draft-ietf-quic-recovery-34#section-7.7
+/// <https://tools.ietf.org/html/draft-ietf-quic-recovery-34#section-7.7>
 pub struct Pacer {
     capacity: u64,
     last_window: u64,

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -754,7 +754,7 @@ impl StreamsState {
     /// Returns whether a `MAX_DATA` frame should be enqueued as soon as possible.
     /// This will only be the case if the window update would is significant
     /// enough. As soon as a window update with a `MAX_DATA` frame has been
-    /// queued, the [`record_sent_max_data`] function should be called to
+    /// queued, the [`Recv::record_sent_max_stream_data`] function should be called to
     /// suppress sending further updates until the window increases significantly
     /// again.
     pub(super) fn add_read_credits(&mut self, credits: u64) -> ShouldTransmit {

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -120,7 +120,7 @@ impl RecvStream {
         .await
     }
 
-    /// Foundation of [`read_chunk()`]: RecvStream::read_chunk
+    /// Foundation of [`Self::read_chunk`]
     fn poll_read_chunk(
         &mut self,
         cx: &mut Context,
@@ -145,7 +145,7 @@ impl RecvStream {
         ReadChunks { stream: self, bufs }.await
     }
 
-    /// Foundation of [`read_chunks()`]: RecvStream::read_chunks
+    /// Foundation of [`Self::read_chunks`]
     fn poll_read_chunks(
         &mut self,
         cx: &mut Context,


### PR DESCRIPTION
Very minor drive-by doc fixes removing the warnings from `cargo doc --document-private-links` but also enables the `#[warn(rustdoc::broken_intra_doc_links)]` to catch these earlier. With the additional `--document-private-items` in workflow the private links are checked as well.