### PR TITLE
Allow adjustment of per-connection concurrent stream limits

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1095,6 +1095,14 @@ impl Connection {
         self.path.congestion.as_ref()
     }
 
+    /// Modify the number of remotely initiated streams that may be concurrently open
+    ///
+    /// No streams may be opened by the peer unless fewer than `count` are already open. Large
+    /// `count`s increase both minimum and worst-case memory consumption.
+    pub fn set_max_concurrent_streams(&mut self, dir: Dir, count: VarInt) {
+        self.streams.set_max_concurrent(dir, count);
+    }
+
     fn on_ack_received(
         &mut self,
         now: Instant,

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -534,6 +534,28 @@ impl Connection {
             .crypto_session()
             .export_keying_material(output, label, context)
     }
+
+    /// Modify the number of remotely initiated unidirectional streams that may be concurrently open
+    ///
+    /// No streams may be opened by the peer unless fewer than `count` are already open. Large
+    /// `count`s increase both minimum and worst-case memory consumption.
+    pub fn set_max_concurrent_uni_streams(&self, count: VarInt) {
+        let mut conn = self.0.lock("set_max_concurrent_uni_streams");
+        conn.inner.set_max_concurrent_streams(Dir::Uni, count);
+        // May need to send MAX_STREAMS to make progress
+        conn.wake();
+    }
+
+    /// Modify the number of remotely initiated bidirectional streams that may be concurrently open
+    ///
+    /// No streams may be opened by the peer unless fewer than `count` are already open. Large
+    /// `count`s increase both minimum and worst-case memory consumption.
+    pub fn set_max_concurrent_bi_streams(&self, count: VarInt) {
+        let mut conn = self.0.lock("set_max_concurrent_bi_streams");
+        conn.inner.set_max_concurrent_streams(Dir::Bi, count);
+        // May need to send MAX_STREAMS to make progress
+        conn.wake();
+    }
 }
 
 impl Clone for Connection {


### PR DESCRIPTION
Fixes #1313.

This is useful when multiple application protocols are hosted on the same endpoint, or when application logic such as authentication might want to adjust the limits of pre-existing connections.