### PR TITLE
docs: fix broken item link

### DIFF
--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -6,7 +6,7 @@
 //! builds on top of quinn-proto, which implements protocol logic independent of any particular
 //! runtime.
 //!
-//! The entry point of this crate is the [`Endpoint`](generic/struct.Endpoint.html).
+//! The entry point of this crate is the [`Endpoint`](struct.Endpoint.html).
 //!
 //! # About QUIC
 //!


### PR DESCRIPTION
There is no `generic` module in version 0.8.x, so fix the link.