### PR TITLE
Retry token fixes

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1587,6 +1587,15 @@ impl Connection {
         debug_assert!(self.side.is_server());
         let len = packet.header_data.len() + packet.payload.len();
         self.path.total_recvd = len as u64;
+        match self.state {
+            State::Handshake(ref mut state) => match packet.header {
+                Header::Initial { ref token, .. } => {
+                    state.token = Some(token.clone());
+                }
+                _ => unreachable!("first packet must be an Initial packet"),
+            },
+            _ => unreachable!("first packet must be delivered in Handshake state"),
+        }
 
         self.on_packet_authenticated(
             now,
@@ -1908,6 +1917,18 @@ impl Connection {
                     trace!("dropping short packet during handshake");
                     return;
                 } else {
+                    if let Header::Initial { ref token, .. } = packet.header {
+                        if let State::Handshake(ref hs) = self.state {
+                            if self.side.is_server() && Some(token) != hs.token.as_ref() {
+                                // Clients must send the same retry token in every Initial. Initial
+                                // packets can be spoofed, so we discard rather than killing the
+                                // connection.
+                                warn!("discarding Initial with invalid retry token");
+                                return;
+                            }
+                        }
+                    }
+
                     if !self.state.is_closed() {
                         let spin = match packet.header {
                             Header::Short { spin, .. } => spin,
@@ -3206,8 +3227,6 @@ mod state {
         /// Always set for servers
         pub rem_cid_set: bool,
         /// Stateless retry token, if the peer has provided one
-        ///
-        /// Only set for clients
         pub token: Option<Bytes>,
         /// First cryptographic message
         ///

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -245,7 +245,7 @@ impl Connection {
         };
         let state = State::Handshake(state::Handshake {
             rem_cid_set: side.is_server(),
-            token: Bytes::new(),
+            expected_token: Bytes::new(),
             client_hello: None,
         });
         let mut rng = StdRng::from_entropy();
@@ -1590,10 +1590,11 @@ impl Connection {
         debug_assert!(self.side.is_server());
         let len = packet.header_data.len() + packet.payload.len();
         self.path.total_recvd = len as u64;
+
         match self.state {
             State::Handshake(ref mut state) => match packet.header {
                 Header::Initial { ref token, .. } => {
-                    state.token = token.clone();
+                    state.expected_token = token.clone();
                 }
                 _ => unreachable!("first packet must be an Initial packet"),
             },
@@ -1922,7 +1923,7 @@ impl Connection {
                 } else {
                     if let Header::Initial { ref token, .. } = packet.header {
                         if let State::Handshake(ref hs) = self.state {
-                            if self.side.is_server() && token != &hs.token {
+                            if self.side.is_server() && token != &hs.expected_token {
                                 // Clients must send the same retry token in every Initial. Initial
                                 // packets can be spoofed, so we discard rather than killing the
                                 // connection.
@@ -2097,7 +2098,7 @@ impl Connection {
                 let token_len = packet.payload.len() - 16;
                 self.retry_token = packet.payload.freeze().split_to(token_len);
                 self.state = State::Handshake(state::Handshake {
-                    token: Bytes::new(),
+                    expected_token: Bytes::new(),
                     rem_cid_set: false,
                     client_hello: None,
                 });
@@ -2126,7 +2127,7 @@ impl Connection {
                 if self.crypto.is_handshaking() {
                     trace!("handshake ongoing");
                     self.state = State::Handshake(state::Handshake {
-                        token: Bytes::new(),
+                        expected_token: Bytes::new(),
                         ..state
                     });
                     return Ok(());
@@ -3230,8 +3231,10 @@ mod state {
         ///
         /// Always set for servers
         pub rem_cid_set: bool,
-        /// Stateless retry token received in the first Initial
-        pub token: Bytes,
+        /// Stateless retry token received in the first Initial by a server.
+        ///
+        /// Must be present in every Initial. Always empty for clients.
+        pub expected_token: Bytes,
         /// First cryptographic message
         ///
         /// Only set for clients

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2118,7 +2118,6 @@ impl Connection {
                 }
                 self.path.validated = true;
 
-                let state = state.clone();
                 self.process_early_payload(now, packet)?;
                 if self.state.is_closed() {
                     return Ok(());
@@ -2126,10 +2125,6 @@ impl Connection {
 
                 if self.crypto.is_handshaking() {
                     trace!("handshake ongoing");
-                    self.state = State::Handshake(state::Handshake {
-                        expected_token: Bytes::new(),
-                        ..state
-                    });
                     return Ok(());
                 }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -243,7 +243,7 @@ impl Connection {
         };
         let state = State::Handshake(state::Handshake {
             rem_cid_set: side.is_server(),
-            token: None,
+            token: Bytes::new(),
             client_hello: None,
         });
         let mut rng = StdRng::from_entropy();
@@ -1590,7 +1590,7 @@ impl Connection {
         match self.state {
             State::Handshake(ref mut state) => match packet.header {
                 Header::Initial { ref token, .. } => {
-                    state.token = Some(token.clone());
+                    state.token = token.clone();
                 }
                 _ => unreachable!("first packet must be an Initial packet"),
             },
@@ -1919,7 +1919,7 @@ impl Connection {
                 } else {
                     if let Header::Initial { ref token, .. } = packet.header {
                         if let State::Handshake(ref hs) = self.state {
-                            if self.side.is_server() && Some(token) != hs.token.as_ref() {
+                            if self.side.is_server() && token != &hs.token {
                                 // Clients must send the same retry token in every Initial. Initial
                                 // packets can be spoofed, so we discard rather than killing the
                                 // connection.
@@ -2093,7 +2093,7 @@ impl Connection {
 
                 let token_len = packet.payload.len() - 16;
                 self.state = State::Handshake(state::Handshake {
-                    token: Some(packet.payload.freeze().split_to(token_len)),
+                    token: packet.payload.freeze().split_to(token_len),
                     rem_cid_set: false,
                     client_hello: None,
                 });
@@ -2122,7 +2122,7 @@ impl Connection {
                 if self.crypto.is_handshaking() {
                     trace!("handshake ongoing");
                     self.state = State::Handshake(state::Handshake {
-                        token: None,
+                        token: Bytes::new(),
                         ..state
                     });
                     return Ok(());
@@ -3226,8 +3226,8 @@ mod state {
         ///
         /// Always set for servers
         pub rem_cid_set: bool,
-        /// Stateless retry token, if the peer has provided one
-        pub token: Option<Bytes>,
+        /// Stateless retry token received in the first Initial
+        pub token: Bytes,
         /// First cryptographic message
         ///
         /// Only set for clients

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -178,7 +178,8 @@ pub struct Connection {
     authentication_failures: u64,
     /// Why the connection was lost, if it has been
     error: Option<ConnectionError>,
-    /// Sent in every outgoing Initial packet. Always empty for servers.
+    /// Sent in every outgoing Initial packet. Always empty for servers and after Initial keys are
+    /// discarded.
     retry_token: Bytes,
 
     //
@@ -1768,6 +1769,10 @@ impl Connection {
     fn discard_space(&mut self, now: Instant, space_id: SpaceId) {
         debug_assert!(space_id != SpaceId::Data);
         trace!("discarding {:?} keys", space_id);
+        if space_id == SpaceId::Initial {
+            // No longer needed
+            self.retry_token = Bytes::new();
+        }
         let space = &mut self.spaces[space_id];
         space.crypto = None;
         space.time_of_last_ack_eliciting_packet = None;

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -108,9 +108,7 @@ impl PacketBuilder {
                 src_cid: conn.handshake_cid,
                 dst_cid: conn.rem_cids.active(),
                 token: match conn.state {
-                    State::Handshake(ref state) if is_client => {
-                        state.token.clone().unwrap_or_else(Bytes::new)
-                    }
+                    State::Handshake(ref state) if is_client => state.token.clone(),
                     _ => Bytes::new(),
                 },
                 number,

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -39,6 +39,7 @@ impl PacketBuilder {
         conn: &mut Connection,
         version: u32,
     ) -> Option<PacketBuilder> {
+        let is_client = conn.side().is_client();
         // Initiate key update if we're approaching the confidentiality limit
         let confidentiality_limit = conn.spaces[space_id]
             .crypto
@@ -107,7 +108,9 @@ impl PacketBuilder {
                 src_cid: conn.handshake_cid,
                 dst_cid: conn.rem_cids.active(),
                 token: match conn.state {
-                    State::Handshake(ref state) => state.token.clone().unwrap_or_else(Bytes::new),
+                    State::Handshake(ref state) if is_client => {
+                        state.token.clone().unwrap_or_else(Bytes::new)
+                    }
                     _ => Bytes::new(),
                 },
                 number,


### PR DESCRIPTION
Resolves some correctness issues detected in interop testing, and makes us a bit better at detecting them ourselves.