### PR TITLE
Backport: Fix handling of invalid retry token lengths

### DIFF
--- a/quinn-proto/src/congestion/bbr/bw_estimation.rs
+++ b/quinn-proto/src/congestion/bbr/bw_estimation.rs
@@ -69,27 +69,25 @@ impl BandwidthEstimation {
             return;
         }
 
-        let send_rate;
-        if self.sent_time.unwrap() > self.prev_sent_time.unwrap() {
-            send_rate = BandwidthEstimation::bw_from_delta(
+        let send_rate = if self.sent_time.unwrap() > self.prev_sent_time.unwrap() {
+            BandwidthEstimation::bw_from_delta(
                 self.total_sent - self.prev_total_sent,
                 self.sent_time.unwrap() - self.prev_sent_time.unwrap(),
             )
-            .unwrap_or(0);
+            .unwrap_or(0)
         } else {
-            send_rate = u64::MAX; // will take the min of send and ack, so this is just a skip
-        }
+            u64::MAX // will take the min of send and ack, so this is just a skip
+        };
 
-        let ack_rate;
-        if self.prev_acked_time.is_none() {
-            ack_rate = 0;
+        let ack_rate = if self.prev_acked_time.is_none() {
+            0
         } else {
-            ack_rate = BandwidthEstimation::bw_from_delta(
+            BandwidthEstimation::bw_from_delta(
                 self.total_acked - self.prev_total_acked,
                 self.acked_time.unwrap() - self.prev_acked_time.unwrap(),
             )
-            .unwrap_or(0);
-        }
+            .unwrap_or(0)
+        };
 
         let bandwidth = send_rate.min(ack_rate);
         if !app_limited && self.max_filter.get() < bandwidth {

--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -51,10 +51,7 @@ impl Assembler {
     /// Get the the next chunk
     pub(crate) fn read(&mut self, max_length: usize, ordered: bool) -> Option<Chunk> {
         loop {
-            let mut chunk = match self.data.peek_mut() {
-                Some(chunk) => chunk,
-                None => return None,
-            };
+            let mut chunk = self.data.peek_mut()?;
 
             if ordered {
                 if chunk.offset > self.bytes_read {

--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -254,10 +254,11 @@ impl<'a> SendStream<'a> {
     /// # Panics
     /// - when applied to a receive stream
     pub fn reset(&mut self, error_code: VarInt) -> Result<(), UnknownStream> {
-        let stream = match self.state.send.get_mut(&self.id) {
-            Some(ss) => ss,
-            None => return Err(UnknownStream { _private: () }),
-        };
+        let stream = self
+            .state
+            .send
+            .get_mut(&self.id)
+            .ok_or(UnknownStream { _private: () })?;
 
         if matches!(stream.state, SendState::ResetSent) {
             // Redundant reset call
@@ -280,10 +281,11 @@ impl<'a> SendStream<'a> {
     /// # Panics
     /// - when applied to a receive stream
     pub fn set_priority(&mut self, priority: i32) -> Result<(), UnknownStream> {
-        let stream = match self.state.send.get_mut(&self.id) {
-            Some(ss) => ss,
-            None => return Err(UnknownStream { _private: () }),
-        };
+        let stream = self
+            .state
+            .send
+            .get_mut(&self.id)
+            .ok_or(UnknownStream { _private: () })?;
 
         stream.priority = priority;
         Ok(())
@@ -294,10 +296,11 @@ impl<'a> SendStream<'a> {
     /// # Panics
     /// - when applied to a receive stream
     pub fn priority(&self) -> Result<i32, UnknownStream> {
-        let stream = match self.state.send.get(&self.id) {
-            Some(ss) => ss,
-            None => return Err(UnknownStream { _private: () }),
-        };
+        let stream = self
+            .state
+            .send
+            .get(&self.id)
+            .ok_or(UnknownStream { _private: () })?;
 
         Ok(stream.priority)
     }

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -573,6 +573,9 @@ impl PlainHeader {
                 LongHeaderType::Initial => {
                     let token_len = buf.get_var()? as usize;
                     let token_start = buf.position() as usize;
+                    if token_len > buf.remaining() {
+                        return Err(PacketDecodeError::InvalidHeader("token out of bounds"));
+                    }
                     buf.advance(token_len);
 
                     let len = buf.get_var()?;

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -243,7 +243,7 @@ fn process_get(root: &Path, x: &[u8]) -> Result<Vec<u8>> {
         bail!("missing \\r\\n");
     }
     let x = &x[4..x.len() - 2];
-    let end = x.iter().position(|&c| c == b' ').unwrap_or_else(|| x.len());
+    let end = x.iter().position(|&c| c == b' ').unwrap_or(x.len());
     let path = str::from_utf8(&x[..end]).context("path is malformed UTF-8")?;
     let path = Path::new(&path);
     let mut real_path = PathBuf::from(root);


### PR DESCRIPTION
(cherry picked from commit c0ac7c5234a975edee8e51597cd6edb21e2c7bfe)