### PR TITLE
remove direct mio dependency

### DIFF
--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -17,7 +17,6 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 libc = "0.2.69"
-mio = { version = "0.8", features = ["net", "os-poll"] }
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.8", default-features = false }
 socket2 = "0.4"
 tracing = "0.1.10"


### PR DESCRIPTION
Unless I overlooked something, we don't use the mio UdpSocket for anything other than the `only_v6`, which can be easily replaced