### PR TITLE
async-std support, second try

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
-members = ["quinn", "quinn-proto", "quinn-udp", "bench", "perf", "fuzz"]
-default-members = ["quinn", "quinn-proto", "quinn-udp", "bench", "perf"]
+members = ["quinn", "quinn-proto", "quinn-udp", "bench", "perf", "fuzz", "quinn-runtime"]
+default-members = ["quinn", "quinn-proto", "quinn-udp", "bench", "perf", "quinn-runtime"]
 
 [profile.bench]
 debug = true

--- a/bench/src/bin/bulk.rs
+++ b/bench/src/bin/bulk.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use quinn::runtime::TokioRuntime;
 use structopt::StructOpt;
 use tokio::sync::Semaphore;
 use tracing::{info, trace};
@@ -59,7 +60,7 @@ fn main() {
     server_thread.join().expect("server thread");
 }
 
-async fn server(mut incoming: quinn::Incoming, opt: Opt) -> Result<()> {
+async fn server(mut incoming: quinn::Incoming<TokioRuntime>, opt: Opt) -> Result<()> {
     let mut server_tasks = Vec::new();
 
     // Handle only the expected amount of clients
@@ -174,7 +175,7 @@ async fn client(
 }
 
 async fn handle_client_stream(
-    connection: Arc<quinn::Connection>,
+    connection: Arc<quinn::Connection<TokioRuntime>>,
     upload_size: usize,
     read_unordered: bool,
 ) -> Result<(TransferResult, TransferResult)> {

--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -6,6 +6,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
+use quinn::runtime::TokioRuntime;
 use structopt::StructOpt;
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info};
@@ -195,7 +196,7 @@ async fn run(opt: Opt) -> Result<()> {
 }
 
 async fn drain_stream(
-    mut stream: quinn::RecvStream,
+    mut stream: quinn::RecvStream<TokioRuntime>,
     download: u64,
     stream_stats: OpenStreamStats,
 ) -> Result<()> {
@@ -234,7 +235,7 @@ async fn drain_stream(
 }
 
 async fn drive_uni(
-    connection: quinn::Connection,
+    connection: quinn::Connection<TokioRuntime>,
     acceptor: UniAcceptor,
     stream_stats: OpenStreamStats,
     concurrency: u64,
@@ -261,7 +262,7 @@ async fn drive_uni(
 }
 
 async fn request_uni(
-    send: quinn::SendStream,
+    send: quinn::SendStream<TokioRuntime>,
     acceptor: UniAcceptor,
     upload: u64,
     download: u64,
@@ -280,7 +281,7 @@ async fn request_uni(
 }
 
 async fn request(
-    mut send: quinn::SendStream,
+    mut send: quinn::SendStream<TokioRuntime>,
     mut upload: u64,
     download: u64,
     stream_stats: OpenStreamStats,
@@ -311,7 +312,7 @@ async fn request(
 }
 
 async fn drive_bi(
-    connection: quinn::Connection,
+    connection: quinn::Connection<TokioRuntime>,
     stream_stats: OpenStreamStats,
     concurrency: u64,
     upload: u64,
@@ -336,8 +337,8 @@ async fn drive_bi(
 }
 
 async fn request_bi(
-    send: quinn::SendStream,
-    recv: quinn::RecvStream,
+    send: quinn::SendStream<TokioRuntime>,
+    recv: quinn::RecvStream<TokioRuntime>,
     upload: u64,
     download: u64,
     stream_stats: OpenStreamStats,
@@ -348,7 +349,7 @@ async fn request_bi(
 }
 
 #[derive(Clone)]
-struct UniAcceptor(Arc<tokio::sync::Mutex<quinn::IncomingUniStreams>>);
+struct UniAcceptor(Arc<tokio::sync::Mutex<quinn::IncomingUniStreams<TokioRuntime>>>);
 
 struct SkipServerVerification;
 

--- a/perf/src/stats.rs
+++ b/perf/src/stats.rs
@@ -1,4 +1,5 @@
 use hdrhistogram::Histogram;
+use quinn::runtime::Runtime;
 use quinn::StreamId;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -132,7 +133,11 @@ impl Stats {
 pub struct OpenStreamStats(Arc<Mutex<Vec<Arc<StreamStats>>>>);
 
 impl OpenStreamStats {
-    pub fn new_sender(&self, stream: &quinn::SendStream, upload_size: u64) -> Arc<StreamStats> {
+    pub fn new_sender<RT: Runtime>(
+        &self,
+        stream: &quinn::SendStream<RT>,
+        upload_size: u64,
+    ) -> Arc<StreamStats> {
         let send_stream_stats = StreamStats {
             id: stream.id(),
             request_size: upload_size,
@@ -147,7 +152,11 @@ impl OpenStreamStats {
         send_stream_stats
     }
 
-    pub fn new_receiver(&self, stream: &quinn::RecvStream, download_size: u64) -> Arc<StreamStats> {
+    pub fn new_receiver<RT: Runtime>(
+        &self,
+        stream: &quinn::RecvStream<RT>,
+        download_size: u64,
+    ) -> Arc<StreamStats> {
         let recv_stream_stats = StreamStats {
             id: stream.id(),
             request_size: download_size,

--- a/quinn-runtime/Cargo.toml
+++ b/quinn-runtime/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "quinn-runtime"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/quinn-rs/quinn"
+description = "Abstractions for writing async-runtime-independent code"
+keywords = ["quic"]
+categories = ["network-programming", "asynchronous"]
+workspace = ".."
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tokio = { version = "1.0.1", features = ["net", "time"], optional = true }
+async-io = { version = "1.6", optional = true }
+async-std = { version = "1.11", optional = true }
+
+[features]
+runtime-tokio = [ "tokio" ]
+runtime-async-std = [ "async-io", "async-std" ]

--- a/quinn-runtime/src/async_std_runtime.rs
+++ b/quinn-runtime/src/async_std_runtime.rs
@@ -1,0 +1,100 @@
+use super::{AsyncTimer, AsyncWrappedUdpSocket, Runtime};
+use async_io::Async;
+use async_io::Timer;
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+impl AsyncWrappedUdpSocket for Async<std::net::UdpSocket> {
+    fn new(t: std::net::UdpSocket) -> io::Result<Self> {
+        Async::new(t)
+    }
+
+    #[cfg(unix)]
+    fn poll_read<T>(
+        &self,
+        f: impl FnOnce(&std::net::UdpSocket) -> io::Result<T>,
+        cx: &mut Context,
+    ) -> Poll<io::Result<T>> {
+        match Async::poll_readable(self, cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Ready(Ok(())) => Poll::Ready(f(self.get_ref())),
+        }
+    }
+    #[cfg(unix)]
+    fn poll_write<T>(
+        &mut self,
+        f: impl FnOnce(&std::net::UdpSocket) -> io::Result<T>,
+        cx: &mut Context,
+    ) -> Poll<io::Result<T>> {
+        match Async::poll_writable(self, cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Ready(Ok(())) => Poll::Ready(f(self.get_ref())),
+        }
+    }
+    #[cfg(unix)]
+    fn get_ref(&self) -> &std::net::UdpSocket {
+        Async::get_ref(self)
+    }
+
+    #[cfg(not(unix))]
+    fn poll_recv_from(
+        &self,
+        cx: &mut Context,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<(usize, std::net::SocketAddr)>> {
+        match Async::poll_readable(self, cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Ready(Ok(())) => Poll::Ready(self.get_ref().recv_from(buf)),
+        }
+    }
+    #[cfg(not(unix))]
+    fn poll_send_to(
+        &mut self,
+        cx: &mut Context,
+        buf: &[u8],
+        target: std::net::SocketAddr,
+    ) -> Poll<io::Result<usize>> {
+        match Async::poll_writable(self, cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Ready(Ok(())) => Poll::Ready(self.get_ref().send_to(buf, target)),
+        }
+    }
+    #[cfg(not(unix))]
+    fn local_addr(&self) -> io::Result<std::net::SocketAddr> {
+        self.get_ref().local_addr()
+    }
+}
+
+impl AsyncTimer for Timer {
+    fn new(t: Instant) -> Self {
+        Timer::at(t)
+    }
+    fn reset(mut self: Pin<&mut Self>, t: Instant) {
+        self.set_at(t)
+    }
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<()> {
+        Future::poll(self, cx).map(|_| ())
+    }
+}
+
+pub struct AsyncStdRuntime;
+
+impl Runtime for AsyncStdRuntime {
+    type AsyncWrappedUdpSocket = Async<std::net::UdpSocket>;
+    type Timer = Timer;
+
+    fn spawn<T>(future: T)
+    where
+        T: Future + Send + 'static,
+        T::Output: Send + 'static,
+    {
+        async_std::task::spawn(future);
+    }
+}

--- a/quinn-runtime/src/lib.rs
+++ b/quinn-runtime/src/lib.rs
@@ -1,0 +1,71 @@
+#[cfg(feature = "runtime-tokio")]
+mod tokio_runtime;
+#[cfg(feature = "runtime-tokio")]
+pub use tokio_runtime::*;
+
+#[cfg(feature = "runtime-async-std")]
+mod async_std_runtime;
+#[cfg(feature = "runtime-async-std")]
+pub use async_std_runtime::*;
+
+use std::fmt::Debug;
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+pub trait AsyncWrappedUdpSocket: Sized + Send + Debug {
+    fn new(t: std::net::UdpSocket) -> io::Result<Self>;
+
+    // On Unix we expect to be able to access the underlying std UdpSocket
+    // to be able to implement more advanced features
+    #[cfg(unix)]
+    fn poll_read<T>(
+        &self,
+        f: impl FnOnce(&std::net::UdpSocket) -> io::Result<T>,
+        cx: &mut Context,
+    ) -> Poll<io::Result<T>>;
+    #[cfg(unix)]
+    fn poll_write<T>(
+        &mut self,
+        f: impl FnOnce(&std::net::UdpSocket) -> io::Result<T>,
+        cx: &mut Context,
+    ) -> Poll<io::Result<T>>;
+    #[cfg(unix)]
+    fn get_ref(&self) -> &std::net::UdpSocket;
+
+    // On Non-Unix platforms we only expect to be able to do basic
+    // send_to / recv_from operations.
+    #[cfg(not(unix))]
+    fn poll_recv_from(
+        &self,
+        cx: &mut Context,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<(usize, std::net::SocketAddr)>>;
+    #[cfg(not(unix))]
+    fn poll_send_to(
+        &mut self,
+        cx: &mut Context,
+        buf: &[u8],
+        target: std::net::SocketAddr,
+    ) -> Poll<io::Result<usize>>;
+    #[cfg(not(unix))]
+    fn local_addr(&self) -> io::Result<std::net::SocketAddr>;
+}
+
+pub trait AsyncTimer: Sized + Send + Debug {
+    fn new(i: Instant) -> Self;
+    fn reset(self: Pin<&mut Self>, i: Instant);
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<()>;
+}
+
+pub trait Runtime: Send + 'static {
+    type AsyncWrappedUdpSocket: AsyncWrappedUdpSocket;
+    type Timer: AsyncTimer;
+
+    fn spawn<T>(future: T)
+    where
+        T: Future + Send + 'static,
+        T::Output: Send + 'static;
+}

--- a/quinn-runtime/src/tokio_runtime.rs
+++ b/quinn-runtime/src/tokio_runtime.rs
@@ -1,0 +1,111 @@
+use super::{AsyncTimer, AsyncWrappedUdpSocket, Runtime};
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+#[cfg(unix)]
+use tokio::io::unix::AsyncFd;
+#[cfg(not(unix))]
+use tokio::io::ReadBuf;
+use tokio::time::{sleep_until, Sleep};
+
+#[cfg(unix)]
+impl AsyncWrappedUdpSocket for AsyncFd<std::net::UdpSocket> {
+    fn new(t: std::net::UdpSocket) -> io::Result<Self> {
+        AsyncFd::new(t)
+    }
+    fn poll_read<T>(
+        &self,
+        f: impl FnOnce(&std::net::UdpSocket) -> io::Result<T>,
+        cx: &mut Context,
+    ) -> Poll<io::Result<T>> {
+        match AsyncFd::poll_read_ready(self, cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Ready(Ok(mut guard)) => Poll::Ready(
+                guard
+                    .try_io(|io| f(io.get_ref()))
+                    .unwrap_or_else(|_| Err(io::ErrorKind::WouldBlock.into())),
+            ),
+        }
+    }
+    fn poll_write<T>(
+        &mut self,
+        f: impl FnOnce(&std::net::UdpSocket) -> io::Result<T>,
+        cx: &mut Context,
+    ) -> Poll<io::Result<T>> {
+        match AsyncFd::poll_write_ready(self, cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Ready(Ok(mut guard)) => Poll::Ready(
+                guard
+                    .try_io(|io| f(io.get_ref()))
+                    .unwrap_or_else(|_| Err(io::ErrorKind::WouldBlock.into())),
+            ),
+        }
+    }
+    fn get_ref(&self) -> &std::net::UdpSocket {
+        AsyncFd::get_ref(self)
+    }
+}
+
+#[cfg(not(unix))]
+impl AsyncWrappedUdpSocket for tokio::net::UdpSocket {
+    fn new(t: std::net::UdpSocket) -> io::Result<Self> {
+        tokio::net::UdpSocket::from_std(t)
+    }
+    fn poll_recv_from(
+        &self,
+        cx: &mut Context,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<(usize, std::net::SocketAddr)>> {
+        let mut buf = ReadBuf::new(buf);
+        let addr = match tokio::net::UdpSocket::poll_recv_from(self, cx, &mut buf) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(addr) => addr,
+        }?;
+        Poll::Ready(Ok((buf.filled().len(), addr)))
+    }
+    fn poll_send_to(
+        &mut self,
+        cx: &mut Context,
+        buf: &[u8],
+        target: std::net::SocketAddr,
+    ) -> Poll<io::Result<usize>> {
+        tokio::net::UdpSocket::poll_send_to(self, cx, buf, target)
+    }
+    fn local_addr(&self) -> io::Result<std::net::SocketAddr> {
+        tokio::net::UdpSocket::local_addr(self)
+    }
+}
+
+impl AsyncTimer for Sleep {
+    fn new(t: Instant) -> Self {
+        sleep_until(t.into())
+    }
+    fn reset(self: Pin<&mut Self>, t: Instant) {
+        Sleep::reset(self, t.into())
+    }
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<()> {
+        Future::poll(self, cx)
+    }
+}
+
+pub struct TokioRuntime;
+
+impl Runtime for TokioRuntime {
+    #[cfg(unix)]
+    type AsyncWrappedUdpSocket = AsyncFd<std::net::UdpSocket>;
+    #[cfg(not(unix))]
+    type AsyncWrappedUdpSocket = tokio::net::UdpSocket;
+    type Timer = Sleep;
+
+    fn spawn<T>(future: T)
+    where
+        T: Future + Send + 'static,
+        T::Output: Send + 'static,
+    {
+        tokio::spawn(future);
+    }
+}

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -20,4 +20,4 @@ libc = "0.2.69"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.8", default-features = false }
 socket2 = "0.4"
 tracing = "0.1.10"
-tokio = { version = "1.0.1", features = ["net"] }
+runtime = { package = "quinn-runtime", path = "../quinn-runtime", version = "0.1" }

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -11,9 +11,9 @@ use std::{
 };
 
 use proto::{EcnCodepoint, Transmit};
-use tokio::io::unix::AsyncFd;
 
 use super::{cmsg, log_sendmsg_error, RecvMeta, UdpState, IO_ERROR_LOG_INTERVAL};
+use runtime::AsyncWrappedUdpSocket;
 
 #[cfg(target_os = "freebsd")]
 type IpTosTy = libc::c_uchar;
@@ -44,18 +44,18 @@ fn only_v6(sock: &std::net::UdpSocket) -> io::Result<bool> {
 /// Unlike a standard tokio UDP socket, this allows ECN bits to be read and written on some
 /// platforms.
 #[derive(Debug)]
-pub struct UdpSocket {
-    io: AsyncFd<std::net::UdpSocket>,
+pub struct UdpSocket<T> {
+    io: T,
     last_send_error: Instant,
 }
 
-impl UdpSocket {
-    pub fn from_std(socket: std::net::UdpSocket) -> io::Result<UdpSocket> {
+impl<T: AsyncWrappedUdpSocket> UdpSocket<T> {
+    pub fn from_std(socket: std::net::UdpSocket) -> io::Result<UdpSocket<T>> {
         socket.set_nonblocking(true)?;
         init(&socket)?;
         let now = Instant::now();
         Ok(UdpSocket {
-            io: AsyncFd::new(socket)?,
+            io: T::new(socket)?,
             last_send_error: now.checked_sub(2 * IO_ERROR_LOG_INTERVAL).unwrap_or(now),
         })
     }
@@ -68,11 +68,12 @@ impl UdpSocket {
     ) -> Poll<Result<usize, io::Error>> {
         loop {
             let last_send_error = &mut self.last_send_error;
-            let mut guard = ready!(self.io.poll_write_ready(cx))?;
-            if let Ok(res) =
-                guard.try_io(|io| send(state, io.get_ref(), last_send_error, transmits))
+            match ready!(self
+                .io
+                .poll_write(|io| send(state, io, last_send_error, transmits), cx))
             {
-                return Poll::Ready(res);
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {} // retry
+                res => break Poll::Ready(res),
             }
         }
     }
@@ -85,9 +86,9 @@ impl UdpSocket {
     ) -> Poll<io::Result<usize>> {
         debug_assert!(!bufs.is_empty());
         loop {
-            let mut guard = ready!(self.io.poll_read_ready(cx))?;
-            if let Ok(res) = guard.try_io(|io| recv(io.get_ref(), bufs, meta)) {
-                return Poll::Ready(res);
+            match ready!(self.io.poll_read(|io| recv(io, bufs, meta), cx)) {
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {} // retry
+                res => break Poll::Ready(res),
             }
         }
     }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.53"
 all-features = true
 
 [features]
-default = ["native-certs", "tls-rustls"]
+default = ["native-certs", "tls-rustls", "runtime-tokio"]
 # Records how long locks are held, and warns if they are held >= 1ms
 lock_tracking = []
 # Provides `ClientConfig::with_native_roots()` convenience method
@@ -23,12 +23,15 @@ native-certs = ["proto/native-certs"]
 tls-rustls = ["rustls", "webpki", "proto/tls-rustls", "ring"]
 # Enables `Endpoint::client` and `Endpoint::server` conveniences
 ring = ["proto/ring"]
+runtime-tokio = [ "tokio/time", "runtime/runtime-tokio" ]
+runtime-async-std = [ "async-io", "runtime/runtime-async-std" ]
 
 [badges]
 codecov = { repository = "djc/quinn" }
 maintenance = { status = "experimental" }
 
 [dependencies]
+async-io = { version = "1.6", optional = true }
 bytes = "1"
 # Enables futures::io::{AsyncRead, AsyncWrite} support for streams
 futures-io = { version = "0.3.19", optional = true }
@@ -36,14 +39,16 @@ futures-io = { version = "0.3.19", optional = true }
 futures-core = { version = "0.3.19", optional = true }
 rustc-hash = "1.1"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.8", default-features = false }
+runtime = { package = "quinn-runtime", path = "../quinn-runtime", version = "0.1" }
 rustls = { version = "0.20.3", default-features = false, features = ["quic"], optional = true }
 thiserror = "1.0.21"
 tracing = "0.1.10"
-tokio = { version = "1.0.1", features = ["rt", "time", "sync"] }
+tokio = { version = "1.0.1", features = ["sync"] }
 udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.1.0" }
 webpki = { version = "0.22", default-features = false, optional = true }
 
 [dev-dependencies]
+async-std = { version = "1.11", features = [ "attributes" ] }
 anyhow = "1.0.22"
 crc = "2"
 bencher = "0.1.5"
@@ -62,8 +67,16 @@ name = "server"
 required-features = ["tls-rustls"]
 
 [[example]]
+name = "server-async-std"
+required-features = ["tls-rustls", "runtime-async-std"]
+
+[[example]]
 name = "client"
 required-features = ["tls-rustls"]
+
+[[example]]
+name = "client-async-std"
+required-features = ["tls-rustls", "runtime-async-std"]
 
 [[example]]
 name = "insecure_connection"

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -9,6 +9,7 @@ use tokio::runtime::{Builder, Runtime};
 use tracing::error_span;
 use tracing_futures::Instrument as _;
 
+use quinn::runtime::TokioRuntime;
 use quinn::Endpoint;
 
 benchmark_group!(
@@ -106,7 +107,7 @@ impl Context {
             };
             let handle = runtime.spawn(
                 async move {
-                    let quinn::NewConnection {
+                    let quinn::NewConnection::<TokioRuntime> {
                         mut uni_streams, ..
                     } = incoming
                         .next()
@@ -136,7 +137,11 @@ impl Context {
     pub fn make_client(
         &self,
         server_addr: SocketAddr,
-    ) -> (quinn::Endpoint, quinn::Connection, Runtime) {
+    ) -> (
+        quinn::Endpoint<TokioRuntime>,
+        quinn::Connection<TokioRuntime>,
+        Runtime,
+    ) {
         let runtime = rt();
         let endpoint = {
             let _guard = runtime.enter();

--- a/quinn/examples/common/mod.rs
+++ b/quinn/examples/common/mod.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "rustls")]
 //! Commonly used code in most examples.
 
+use quinn::runtime::TokioRuntime;
 use quinn::{ClientConfig, Endpoint, Incoming, ServerConfig};
 use std::{error::Error, net::SocketAddr, sync::Arc};
 
@@ -13,7 +14,7 @@ use std::{error::Error, net::SocketAddr, sync::Arc};
 pub fn make_client_endpoint(
     bind_addr: SocketAddr,
     server_certs: &[&[u8]],
-) -> Result<Endpoint, Box<dyn Error>> {
+) -> Result<Endpoint<TokioRuntime>, Box<dyn Error>> {
     let client_cfg = configure_client(server_certs)?;
     let mut endpoint = Endpoint::client(bind_addr)?;
     endpoint.set_default_client_config(client_cfg);
@@ -28,7 +29,9 @@ pub fn make_client_endpoint(
 /// - a stream of incoming QUIC connections
 /// - server certificate serialized into DER format
 #[allow(unused)]
-pub fn make_server_endpoint(bind_addr: SocketAddr) -> Result<(Incoming, Vec<u8>), Box<dyn Error>> {
+pub fn make_server_endpoint(
+    bind_addr: SocketAddr,
+) -> Result<(Incoming<TokioRuntime>, Vec<u8>), Box<dyn Error>> {
     let (server_config, server_cert) = configure_server()?;
     let (_endpoint, incoming) = Endpoint::server(server_config, bind_addr)?;
     Ok((incoming, server_cert))

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -4,6 +4,7 @@
 
 use std::{error::Error, net::SocketAddr, sync::Arc};
 
+use quinn::runtime::TokioRuntime;
 use quinn::{ClientConfig, Endpoint};
 
 mod common;
@@ -36,7 +37,7 @@ async fn run_client(server_addr: SocketAddr) -> Result<(), Box<dyn Error>> {
     endpoint.set_default_client_config(client_cfg);
 
     // connect to server
-    let quinn::NewConnection { connection, .. } = endpoint
+    let quinn::NewConnection::<TokioRuntime> { connection, .. } = endpoint
         .connect(server_addr, "localhost")
         .unwrap()
         .await

--- a/quinn/examples/single_socket.rs
+++ b/quinn/examples/single_socket.rs
@@ -4,6 +4,7 @@
 
 use std::{error::Error, net::SocketAddr};
 
+use quinn::runtime::TokioRuntime;
 use quinn::Endpoint;
 
 mod common;
@@ -52,7 +53,7 @@ fn run_server(addr: SocketAddr) -> Result<Vec<u8>, Box<dyn Error>> {
 }
 
 /// Attempt QUIC connection with the given server address.
-async fn run_client(endpoint: &Endpoint, server_addr: SocketAddr) {
+async fn run_client(endpoint: &Endpoint<TokioRuntime>, server_addr: SocketAddr) {
     let connect = endpoint.connect(server_addr, "localhost").unwrap();
     let quinn::NewConnection { connection, .. } = connect.await.unwrap();
     println!("[client] connected: addr={}", connection.remote_address());

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -75,6 +75,7 @@ pub use crate::connection::{
 pub use crate::endpoint::{Endpoint, Incoming};
 pub use crate::recv_stream::{ReadError, ReadExactError, ReadToEndError, RecvStream};
 pub use crate::send_stream::{SendStream, StoppedError, WriteError};
+pub use runtime;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
Unlike the first try, this does not rely on mutually exclusive feature flags. Both runtime-async-std and runtime-tokio features can be enabled at the same time. The actual runtime used is chosen by the user when creating the endpoint.

This does not touch the synchronization primitives (still uses channels etc. from tokio, even when running under async-std), and thus keeps tokio as hard-coded dependency.

To-Do:

- [x] Tokio socket read/write paths needs to go via the AsyncFdReadyGuard again, otherwise it breaks
- [x] Fix windows / !unix compilation
- [x] Deal with lint errors that are not fixed by `cargo fmt` (" error: very complex type used. Consider factoring parts into `type` definitions")