### PR TITLE
Enable UDP GRO

### DIFF
--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -97,6 +97,7 @@ impl UdpSocket {
 pub fn udp_state() -> super::UdpState {
     super::UdpState {
         max_gso_segments: std::sync::atomic::AtomicUsize::new(1),
+        gro_segments: 1,
     }
 }
 

--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -77,8 +77,10 @@ impl UdpSocket {
         debug_assert!(!bufs.is_empty());
         let mut buf = ReadBuf::new(&mut bufs[0]);
         let addr = ready!(self.io.poll_recv_from(cx, &mut buf))?;
+        let len = buf.filled().len();
         meta[0] = RecvMeta {
-            len: buf.filled().len(),
+            len,
+            stride: len,
             addr,
             ecn: None,
             dst_ip: None,

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -68,6 +68,7 @@ pub struct RecvMeta {
     pub ecn: Option<EcnCodepoint>,
     /// The destination IP address which was encoded in this datagram
     pub dst_ip: Option<IpAddr>,
+    pub gso_size: Option<usize>,
 }
 
 impl Default for RecvMeta {
@@ -78,6 +79,7 @@ impl Default for RecvMeta {
             len: 0,
             ecn: None,
             dst_ip: None,
+            gso_size: None,
         }
     }
 }

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -65,10 +65,10 @@ impl Default for UdpState {
 pub struct RecvMeta {
     pub addr: SocketAddr,
     pub len: usize,
+    pub stride: usize,
     pub ecn: Option<EcnCodepoint>,
     /// The destination IP address which was encoded in this datagram
     pub dst_ip: Option<IpAddr>,
-    pub gso_size: Option<usize>,
 }
 
 impl Default for RecvMeta {
@@ -77,9 +77,9 @@ impl Default for RecvMeta {
         Self {
             addr: SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 0),
             len: 0,
+            stride: 0,
             ecn: None,
             dst_ip: None,
-            gso_size: None,
         }
     }
 }

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -37,6 +37,7 @@ pub const BATCH_SIZE: usize = imp::BATCH_SIZE;
 #[derive(Debug)]
 pub struct UdpState {
     max_gso_segments: AtomicUsize,
+    gro_segments: usize,
 }
 
 impl UdpState {
@@ -52,6 +53,15 @@ impl UdpState {
     #[inline]
     pub fn max_gso_segments(&self) -> usize {
         self.max_gso_segments.load(Ordering::Relaxed)
+    }
+
+    /// The number of segments to read when GRO is enabled. Used as a factor to
+    /// compute the receive buffer size.
+    ///
+    /// Returns 1 if the platform doesn't support GRO.
+    #[inline]
+    pub fn gro_segments(&self) -> usize {
+        self.gro_segments
     }
 }
 

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -135,8 +135,9 @@ fn init(io: &std::net::UdpSocket) -> io::Result<()> {
     }
     #[cfg(target_os = "linux")]
     {
+        // opportunistically try to enable GRO. See gro::gro_segments().
         let on: libc::c_int = 1;
-        let rc = unsafe {
+        unsafe {
             libc::setsockopt(
                 io.as_raw_fd(),
                 libc::SOL_UDP,
@@ -145,9 +146,6 @@ fn init(io: &std::net::UdpSocket) -> io::Result<()> {
                 mem::size_of_val(&on) as _,
             )
         };
-        if rc == -1 {
-            return Err(io::Error::last_os_error());
-        }
 
         if addr.is_ipv4() {
             let rc = unsafe {
@@ -422,6 +420,7 @@ fn recv(
 pub fn udp_state() -> UdpState {
     UdpState {
         max_gso_segments: AtomicUsize::new(gso::max_gso_segments()),
+        gro_segments: gro::gro_segments(),
     }
 }
 
@@ -621,5 +620,41 @@ mod gso {
 
     pub fn set_segment_size(_encoder: &mut cmsg::Encoder, _segment_size: u16) {
         panic!("Setting a segment size is not supported on current platform");
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod gro {
+    use super::*;
+
+    pub fn gro_segments() -> usize {
+        let socket = match std::net::UdpSocket::bind("[::]:0") {
+            Ok(socket) => socket,
+            Err(_) => return 1,
+        };
+
+        let on: libc::c_int = 1;
+        let rc = unsafe {
+            libc::setsockopt(
+                socket.as_raw_fd(),
+                libc::SOL_UDP,
+                libc::UDP_GRO,
+                &on as *const _ as _,
+                mem::size_of_val(&on) as _,
+            )
+        };
+
+        if rc != -1 {
+            10
+        } else {
+            1
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod gro {
+    pub fn gro_segments() -> usize {
+        1
     }
 }

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -515,7 +515,7 @@ fn decode_recv(
     let name = unsafe { name.assume_init() };
     let mut ecn_bits = 0;
     let mut dst_ip = None;
-    let mut gso_size = None;
+    let mut stride = len;
 
     let cmsg_iter = unsafe { cmsg::Iter::new(hdr) };
     for cmsg in cmsg_iter {
@@ -545,7 +545,7 @@ fn decode_recv(
             },
             #[cfg(target_os = "linux")]
             (libc::SOL_UDP, libc::UDP_GRO) => unsafe {
-                gso_size = Some(cmsg::decode::<libc::c_int>(cmsg) as usize);
+                stride = cmsg::decode::<libc::c_int>(cmsg) as usize;
             },
             _ => {}
         }
@@ -559,10 +559,10 @@ fn decode_recv(
 
     RecvMeta {
         len,
+        stride,
         addr,
         ecn: EcnCodepoint::from_bits(ecn_bits),
         dst_ip,
-        gso_size,
     }
 }
 

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -346,11 +346,13 @@ impl EndpointInner {
                 Poll::Ready(Ok(msgs)) => {
                     self.recv_limiter.record_work(msgs);
                     for (meta, buf) in metas.iter().zip(iovs.iter()).take(msgs) {
-                        for buf in buf[0..meta.len].chunks(meta.gso_size.unwrap_or(meta.len)) {
-                            let data: BytesMut = buf.into();
+                        let mut data: BytesMut = buf[0..meta.len].into();
+                        while !data.is_empty() {
+                            let buf =
+                                data.split_to(meta.gso_size.unwrap_or(meta.len).min(data.len()));
                             match self
                                 .inner
-                                .handle(now, meta.addr, meta.dst_ip, meta.ecn, data)
+                                .handle(now, meta.addr, meta.dst_ip, meta.ecn, buf)
                             {
                                 Some((handle, DatagramEvent::NewConnection(conn))) => {
                                     let conn = self.connections.insert(

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -348,8 +348,7 @@ impl EndpointInner {
                     for (meta, buf) in metas.iter().zip(iovs.iter()).take(msgs) {
                         let mut data: BytesMut = buf[0..meta.len].into();
                         while !data.is_empty() {
-                            let buf =
-                                data.split_to(meta.gso_size.unwrap_or(meta.len).min(data.len()));
+                            let buf = data.split_to(meta.stride.min(data.len()));
                             match self
                                 .inner
                                 .handle(now, meta.addr, meta.dst_ip, meta.ecn, buf)


### PR DESCRIPTION
Hello! Thanks for such a great lib! 🤗

As a way to learn quinn I started looking into the IO code and noticed that while GSO is supported, GRO isn't yet. This PR is my first stab at implementing it. Initial results seem promising:

No GRO:
```
Client 0 stats:
Overall download stats:

Transferred 1073741824 bytes on 1 streams in 2.96s (345.49 MiB/s)

Stream download metrics:

      │  Throughput   │ Duration 
──────┼───────────────┼──────────
 AVG  │  345.62 MiB/s │     2.96s
 P0   │  345.50 MiB/s │     2.96s
 P10  │  345.75 MiB/s │     2.96s
 P50  │  345.75 MiB/s │     2.96s
 P90  │  345.75 MiB/s │     2.96s
 P100 │  345.75 MiB/s │     2.96s

```

With GRO:
```
 Client 0 stats:
Overall download stats:

Transferred 1073741824 bytes on 1 streams in 2.51s (407.22 MiB/s)

Stream download metrics:

      │  Throughput   │ Duration 
──────┼───────────────┼──────────
 AVG  │  407.38 MiB/s │     2.52s
 P0   │  407.25 MiB/s │     2.51s
 P10  │  407.50 MiB/s │     2.52s
 P50  │  407.50 MiB/s │     2.52s
 P90  │  407.50 MiB/s │     2.52s
 P100 │  407.50 MiB/s │     2.52s
```

The existing tests pass, so hopefully I'm not benchmarking garbage.

Obviously the PR needs a lot more work - some things that come to mind:

- should this be conditionally enabled based on config? (GSO seems to be enabled unconditionally)
- should the GRO size be configurable? If the read buffers aren't large enough GRO is actually less performant than no GRO
- I'm testing on a 5.14 kernel, we need to find the minimum kernel version that supports GRO