### PR TITLE
Named futures + replace NewConnection with Connection methods

### DIFF
--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -70,7 +70,7 @@ pub async fn connect_client(
     let mut client_config = quinn::ClientConfig::new(Arc::new(crypto));
     client_config.transport_config(Arc::new(transport_config(&opt)));
 
-    let quinn::NewConnection { connection, .. } = endpoint
+    let connection = endpoint
         .connect_with(client_config, server_addr, "localhost")
         .unwrap()
         .await

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -39,6 +39,7 @@ futures-io = { version = "0.3.19", optional = true }
 # Implements futures::Stream for async streams such as `Incoming`
 futures-core = { version = "0.3.19", optional = true }
 rustc-hash = "1.1"
+pin-project-lite = "0.2"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.8", default-features = false }
 rustls = { version = "0.20.3", default-features = false, features = ["quic"], optional = true }
 thiserror = "1.0.21"

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -108,14 +108,11 @@ async fn run(options: Opt) -> Result<()> {
         .ok_or_else(|| anyhow!("no hostname specified"))?;
 
     eprintln!("connecting to {} at {}", host, remote);
-    let new_conn = endpoint
+    let conn = endpoint
         .connect(remote, host)?
         .await
         .map_err(|e| anyhow!("failed to connect: {}", e))?;
     eprintln!("connected at {:?}", start.elapsed());
-    let quinn::NewConnection {
-        connection: conn, ..
-    } = new_conn;
     let (mut send, recv) = conn
         .open_bi()
         .await

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -23,10 +23,10 @@ async fn run_server(addr: SocketAddr) {
     let (mut incoming, _server_cert) = make_server_endpoint(addr).unwrap();
     // accept a single connection
     let incoming_conn = incoming.next().await.unwrap();
-    let new_conn = incoming_conn.await.unwrap();
+    let conn = incoming_conn.await.unwrap();
     println!(
         "[server] connection accepted: addr={}",
-        new_conn.connection.remote_address()
+        conn.remote_address()
     );
 }
 
@@ -36,7 +36,7 @@ async fn run_client(server_addr: SocketAddr) -> Result<(), Box<dyn Error>> {
     endpoint.set_default_client_config(client_cfg);
 
     // connect to server
-    let quinn::NewConnection { connection, .. } = endpoint
+    let connection = endpoint
         .connect(server_addr, "localhost")
         .unwrap()
         .await

--- a/quinn/examples/single_socket.rs
+++ b/quinn/examples/single_socket.rs
@@ -41,7 +41,7 @@ fn run_server(addr: SocketAddr) -> Result<Vec<u8>, Box<dyn Error>> {
     let (mut incoming, server_cert) = make_server_endpoint(addr)?;
     // accept a single connection
     tokio::spawn(async move {
-        let quinn::NewConnection { connection, .. } = incoming.next().await.unwrap().await.unwrap();
+        let connection = incoming.next().await.unwrap().await.unwrap();
         println!(
             "[server] incoming connection: addr={}",
             connection.remote_address()
@@ -54,6 +54,6 @@ fn run_server(addr: SocketAddr) -> Result<Vec<u8>, Box<dyn Error>> {
 /// Attempt QUIC connection with the given server address.
 async fn run_client(endpoint: &Endpoint, server_addr: SocketAddr) {
     let connect = endpoint.connect(server_addr, "localhost").unwrap();
-    let quinn::NewConnection { connection, .. } = connect.await.unwrap();
+    let connection = connect.await.unwrap();
     println!("[client] connected: addr={}", connection.remote_address());
 }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -930,7 +930,8 @@ impl ConnectionInner {
                     }
                 }
                 Stream(StreamEvent::Available { dir }) => {
-                    self.stream_opening[dir as usize].notify_one();
+                    // Might mean any number of streams are ready, so we wake up everyone
+                    self.stream_opening[dir as usize].notify_waiters();
                 }
                 Stream(StreamEvent::Finished { id }) => {
                     if let Some(finishing) = self.finishing.remove(&id) {

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -70,8 +70,8 @@ pub use proto::{
 };
 
 pub use crate::connection::{
-    Connecting, Connection, Datagrams, IncomingBiStreams, IncomingUniStreams, NewConnection,
-    SendDatagramError, UnknownStream, ZeroRttAccepted,
+    AcceptBi, AcceptUni, Connecting, Connection, Datagrams, IncomingBiStreams, IncomingUniStreams,
+    NewConnection, ReadDatagram, SendDatagramError, UnknownStream, ZeroRttAccepted,
 };
 pub use crate::endpoint::{Endpoint, Incoming};
 pub use crate::recv_stream::{ReadError, ReadExactError, ReadToEndError, RecvStream};

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -71,7 +71,8 @@ pub use proto::{
 
 pub use crate::connection::{
     AcceptBi, AcceptUni, Connecting, Connection, Datagrams, IncomingBiStreams, IncomingUniStreams,
-    NewConnection, ReadDatagram, SendDatagramError, UnknownStream, ZeroRttAccepted,
+    NewConnection, OpenBi, OpenUni, ReadDatagram, SendDatagramError, UnknownStream,
+    ZeroRttAccepted,
 };
 pub use crate::endpoint::{Endpoint, Incoming};
 pub use crate::recv_stream::{ReadError, ReadExactError, ReadToEndError, RecvStream};

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -70,9 +70,8 @@ pub use proto::{
 };
 
 pub use crate::connection::{
-    AcceptBi, AcceptUni, Connecting, Connection, Datagrams, IncomingBiStreams, IncomingUniStreams,
-    NewConnection, OpenBi, OpenUni, ReadDatagram, SendDatagramError, UnknownStream,
-    ZeroRttAccepted,
+    AcceptBi, AcceptUni, Connecting, Connection, OpenBi, OpenUni, ReadDatagram, SendDatagramError,
+    UnknownStream, ZeroRttAccepted,
 };
 pub use crate::endpoint::{Endpoint, Incoming};
 pub use crate::recv_stream::{ReadError, ReadExactError, ReadToEndError, RecvStream};


### PR DESCRIPTION
Experimenting with a return to named 'static futures, motivated by downstream use cases. See e.g. https://github.com/hyperium/h3/pull/80.

Open questions:
- Which interfaces specifically need to be named?
- Is 'static needed, or just names?
- Are GATs + TAIT close enough that none of this matters?

Also included is an idea to drop `NewConnection` in favor of unobtrusive async methods on `Connection`, bundled because they would have to be rewritten to match this PR's approach if it move forwards. I'd like feedback on this change before I invest the effort to actually remove `NewConnection` and update all the examples/docs.