### PR TITLE
Prepare 0.8.3 release

### DIFF
--- a/bench/src/stats.rs
+++ b/bench/src/stats.rs
@@ -42,13 +42,10 @@ impl Stats {
 
         let print_metric = |label: &'static str, get_metric: fn(&Histogram<u64>) -> u64| {
             println!(
-                " {} │ {:7.2} MiB/s │ {:>9}",
+                " {} │ {:7.2} MiB/s │ {:>9.2?}",
                 label,
                 get_metric(&self.stream_stats.throughput_hist) as f64 / 1024.0 / 1024.0,
-                format!(
-                    "{:.2?}",
-                    Duration::from_millis(get_metric(&self.stream_stats.duration_hist))
-                )
+                Duration::from_millis(get_metric(&self.stream_stats.duration_hist))
             );
         };
 

--- a/perf/src/stats.rs
+++ b/perf/src/stats.rs
@@ -95,17 +95,11 @@ impl Stats {
 
         let print_metric = |label: &'static str, get_metric: fn(&Histogram<u64>) -> u64| {
             println!(
-                " {} │ {:>15} │ {:>17} │  {:>9} │ {:11.2} MiB/s │ {:13.2} MiB/s",
+                " {} │ {:>15.2?} │ {:>17.2?} │  {:>9.2?} │ {:11.2} MiB/s │ {:13.2} MiB/s",
                 label,
-                format!(
-                    "{:.2?}",
-                    Duration::from_micros(get_metric(&self.upload_duration))
-                ),
-                format!(
-                    "{:.2?}",
-                    Duration::from_micros(get_metric(&self.download_duration))
-                ),
-                format!("{:.2?}", Duration::from_micros(get_metric(&self.fbl))),
+                Duration::from_micros(get_metric(&self.upload_duration)),
+                Duration::from_micros(get_metric(&self.download_duration)),
+                Duration::from_micros(get_metric(&self.fbl)),
                 get_metric(&self.upload_throughput) as f64 / 1024.0 / 1024.0,
                 get_metric(&self.download_throughput) as f64 / 1024.0 / 1024.0,
             );

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-proto"
-version = "0.8.2"
+version = "0.8.3"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/quinn-rs/quinn"
 description = "State machine for the QUIC transport protocol"

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1091,6 +1091,14 @@ impl Connection {
         self.path.congestion.as_ref()
     }
 
+    /// Modify the number of remotely initiated streams that may be concurrently open
+    ///
+    /// No streams may be opened by the peer unless fewer than `count` are already open. Large
+    /// `count`s increase both minimum and worst-case memory consumption.
+    pub fn set_max_concurrent_streams(&mut self, dir: Dir, count: VarInt) {
+        self.streams.set_max_concurrent(dir, count);
+    }
+
     fn on_ack_received(
         &mut self,
         now: Instant,

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/quinn-rs/quinn"
 description = "UDP sockets with ECN information for the QUIC transport protocol"

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -18,7 +18,6 @@ maintenance = { status = "experimental" }
 [dependencies]
 futures-util = { version = "0.3.11", features = ["io"] }
 libc = "0.2.69"
-mio = { version = "0.7.7", features = ["net", "os-poll"] }
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.8", default-features = false }
 socket2 = "0.4"
 tracing = "0.1.10"

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -21,24 +21,42 @@ type IpTosTy = libc::c_uchar;
 #[cfg(not(target_os = "freebsd"))]
 type IpTosTy = libc::c_int;
 
+fn only_v6(sock: &std::net::UdpSocket) -> io::Result<bool> {
+    let raw_fd = sock.as_raw_fd();
+    let mut val: libc::c_int = 0;
+    let mut len = mem::size_of::<libc::c_int>() as libc::socklen_t;
+    let res = unsafe {
+        libc::getsockopt(
+            raw_fd,
+            libc::IPPROTO_IPV6,
+            libc::IPV6_V6ONLY,
+            &mut val as *mut _ as *mut _,
+            &mut len,
+        )
+    };
+    match res {
+        -1 => Err(io::Error::last_os_error()),
+        _ => Ok(val != 0),
+    }
+}
+
 /// Tokio-compatible UDP socket with some useful specializations.
 ///
 /// Unlike a standard tokio UDP socket, this allows ECN bits to be read and written on some
 /// platforms.
 #[derive(Debug)]
 pub struct UdpSocket {
-    io: AsyncFd<mio::net::UdpSocket>,
+    io: AsyncFd<std::net::UdpSocket>,
     last_send_error: Instant,
 }
 
 impl UdpSocket {
     pub fn from_std(socket: std::net::UdpSocket) -> io::Result<UdpSocket> {
         socket.set_nonblocking(true)?;
-        let io = mio::net::UdpSocket::from_std(socket);
-        init(&io)?;
+        init(&socket)?;
         let now = Instant::now();
         Ok(UdpSocket {
-            io: AsyncFd::new(io)?,
+            io: AsyncFd::new(socket)?,
             last_send_error: now.checked_sub(2 * IO_ERROR_LOG_INTERVAL).unwrap_or(now),
         })
     }
@@ -80,7 +98,7 @@ impl UdpSocket {
     }
 }
 
-fn init(io: &mio::net::UdpSocket) -> io::Result<()> {
+fn init(io: &std::net::UdpSocket) -> io::Result<()> {
     let mut cmsg_platform_space = 0;
     if cfg!(target_os = "linux") {
         cmsg_platform_space +=
@@ -100,7 +118,7 @@ fn init(io: &mio::net::UdpSocket) -> io::Result<()> {
     let addr = io.local_addr()?;
 
     // macos and ios do not support IP_RECVTOS on dual-stack sockets :(
-    if addr.is_ipv4() || ((!cfg!(any(target_os = "macos", target_os = "ios"))) && !io.only_v6()?) {
+    if addr.is_ipv4() || ((!cfg!(any(target_os = "macos", target_os = "ios"))) && !only_v6(io)?) {
         let on: libc::c_int = 1;
         let rc = unsafe {
             libc::setsockopt(
@@ -194,7 +212,7 @@ fn init(io: &mio::net::UdpSocket) -> io::Result<()> {
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
 fn send(
     state: &UdpState,
-    io: &mio::net::UdpSocket,
+    io: &std::net::UdpSocket,
     last_send_error: &mut Instant,
     transmits: &[Transmit],
 ) -> io::Result<usize> {
@@ -277,7 +295,7 @@ fn send(
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 fn send(
     _state: &UdpState,
-    io: &mio::net::UdpSocket,
+    io: &std::net::UdpSocket,
     last_send_error: &mut Instant,
     transmits: &[Transmit],
 ) -> io::Result<usize> {
@@ -317,7 +335,7 @@ fn send(
 
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
 fn recv(
-    io: &mio::net::UdpSocket,
+    io: &std::net::UdpSocket,
     bufs: &mut [IoSliceMut<'_>],
     meta: &mut [RecvMeta],
 ) -> io::Result<usize> {
@@ -360,7 +378,7 @@ fn recv(
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 fn recv(
-    io: &mio::net::UdpSocket,
+    io: &std::net::UdpSocket,
     bufs: &mut [IoSliceMut<'_>],
     meta: &mut [RecvMeta],
 ) -> io::Result<usize> {

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn"
-version = "0.8.2"
+version = "0.8.3"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/quinn-rs/quinn"
 description = "QUIC transport protocol implementation for Tokio"
@@ -33,7 +33,7 @@ bytes = "1"
 futures-util = { version = "0.3.11", default-features = false, features = ["io"] }
 futures-channel = "0.3.11"
 fxhash = "0.2.1"
-proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.8", default-features = false }
+proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.8.3", default-features = false }
 rustls = { version = "0.20.3", default-features = false, features = ["quic"], optional = true }
 thiserror = "1.0.21"
 tracing = "0.1.10"

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -512,6 +512,28 @@ impl Connection {
             .crypto_session()
             .export_keying_material(output, label, context)
     }
+
+    /// Modify the number of remotely initiated unidirectional streams that may be concurrently open
+    ///
+    /// No streams may be opened by the peer unless fewer than `count` are already open. Large
+    /// `count`s increase both minimum and worst-case memory consumption.
+    pub fn set_max_concurrent_uni_streams(&self, count: VarInt) {
+        let mut conn = self.0.lock("set_max_concurrent_uni_streams");
+        conn.inner.set_max_concurrent_streams(Dir::Uni, count);
+        // May need to send MAX_STREAMS to make progress
+        conn.wake();
+    }
+
+    /// Modify the number of remotely initiated bidirectional streams that may be concurrently open
+    ///
+    /// No streams may be opened by the peer unless fewer than `count` are already open. Large
+    /// `count`s increase both minimum and worst-case memory consumption.
+    pub fn set_max_concurrent_bi_streams(&self, count: VarInt) {
+        let mut conn = self.0.lock("set_max_concurrent_bi_streams");
+        conn.inner.set_max_concurrent_streams(Dir::Bi, count);
+        // May need to send MAX_STREAMS to make progress
+        conn.wake();
+    }
 }
 
 impl Clone for Connection {


### PR DESCRIPTION
Fixes https://github.com/quinn-rs/quinn/issues/1352. This addresses a pressing downstream demand while leaving us more time to work on in-flight breaking API changes (#1357, #1346) without risking excessive breaking-release churn.