### PR TITLE
Allow initial maximum UDP payload size to be configured

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -262,6 +262,7 @@ impl Connection {
                 remote,
                 config.initial_rtt,
                 config.congestion_controller_factory.build(now),
+                config.initial_max_udp_payload_size,
                 now,
                 path_validated,
             ),
@@ -2626,6 +2627,7 @@ impl Connection {
                 remote,
                 self.config.initial_rtt,
                 self.config.congestion_controller_factory.build(now),
+                self.config.initial_max_udp_payload_size,
                 now,
                 false,
             )

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -1,7 +1,7 @@
 use std::{cmp, net::SocketAddr, time::Duration, time::Instant};
 
 use super::pacing::Pacer;
-use crate::{congestion, packet::SpaceId, INITIAL_MAX_UDP_PAYLOAD_SIZE, TIMER_GRANULARITY};
+use crate::{congestion, packet::SpaceId, TIMER_GRANULARITY};
 
 /// Description of a particular network path
 pub struct PathData {
@@ -36,6 +36,7 @@ impl PathData {
         remote: SocketAddr,
         initial_rtt: Duration,
         congestion: Box<dyn congestion::Controller>,
+        initial_max_udp_payload_size: u16,
         now: Instant,
         validated: bool,
     ) -> Self {
@@ -46,7 +47,7 @@ impl PathData {
             pacing: Pacer::new(
                 initial_rtt,
                 congestion.initial_window(),
-                INITIAL_MAX_UDP_PAYLOAD_SIZE,
+                initial_max_udp_payload_size,
                 now,
             ),
             congestion,
@@ -55,7 +56,7 @@ impl PathData {
             validated,
             total_sent: 0,
             total_recvd: 0,
-            max_udp_payload_size: INITIAL_MAX_UDP_PAYLOAD_SIZE,
+            max_udp_payload_size: initial_max_udp_payload_size,
             first_packet_after_rtt_sample: None,
         }
     }

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -292,6 +292,7 @@ const LOC_CID_COUNT: u64 = 8;
 const RESET_TOKEN_SIZE: usize = 16;
 const MAX_CID_SIZE: usize = 20;
 const MIN_INITIAL_SIZE: u16 = 1200;
+/// <https://www.rfc-editor.org/rfc/rfc9000.html#name-datagram-size>
 const INITIAL_MAX_UDP_PAYLOAD_SIZE: u16 = 1200;
 const TIMER_GRANULARITY: Duration = Duration::from_millis(1);
 /// Maximum number of streams that can be uniquely identified by a stream ID


### PR DESCRIPTION
Motivated by prospective user request. Also potentially useful for benchmark experimentation.