### PR TITLE
Bump MSRV to 1.57

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,16 +12,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, beta, 1.53.0]
+        rust: [stable, beta, 1.57.0]
         exclude:
           - os: macos-latest
             rust: beta
           - os: macos-latest
-            rust: 1.53.0
+            rust: 1.57.0
           - os: windows-latest
             rust: beta
           - os: windows-latest
-            rust: 1.53.0
+            rust: 1.57.0
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Quinn is a pure-rust, async-compatible implementation of the IETF [QUIC][quic] t
   [rustls][rustls] and [*ring*][ring]
 - Application-layer datagrams for small, unreliable messages
 - Future-based async API
-- Minimum supported Rust version of 1.53.0
+- Minimum supported Rust version of 1.57.0
 
 ## Overview
 

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["quic"]
 categories = [ "network-programming", "asynchronous" ]
 workspace = ".."
 edition = "2018"
-rust-version = "1.53"
+rust-version = "1.57"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["quic"]
 categories = [ "network-programming", "asynchronous" ]
 workspace = ".."
 edition = "2018"
-rust-version = "1.53"
+rust-version = "1.57"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This is >6 months old and should address the CI failure.