### PR TITLE
Add data limits settings to connections

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1108,6 +1108,28 @@ impl Connection {
         self.streams.set_max_concurrent(dir, count);
     }
 
+    /// Maximum number of bytes the peer may transmit across all streams of a connection before
+    /// becoming blocked.
+    ///
+    /// This should be set to at least the expected connection latency multiplied by the maximum
+    /// desired throughput. Larger values can be useful to allow maximum throughput within a
+    /// stream while another is blocked.
+    pub fn set_receive_window(&mut self, value: VarInt) {
+        self.streams.set_receive_window(value);
+    }
+
+    /// Maximum number of bytes the peer may transmit without acknowledgement on any one stream
+    /// before becoming blocked.
+    ///
+    /// This should be set to at least the expected connection latency multiplied by the maximum
+    /// desired throughput. Setting this smaller than `receive_window` helps ensure that a single
+    /// stream doesn't monopolize receive buffers, which may otherwise occur if the application
+    /// chooses not to read from a large stream for a time while still requiring data on other
+    /// streams.
+    pub fn set_stream_receive_window(&mut self, value: VarInt) {
+        self.streams.set_stream_receive_window(value);
+    }
+
     fn on_ack_received(
         &mut self,
         now: Instant,

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -686,6 +686,16 @@ impl StreamsState {
         Ok(())
     }
 
+    /// Set `receive_window`
+    pub fn set_receive_window(&mut self, value: VarInt) {
+        self.receive_window = value.into();
+    }
+
+    /// Set `stream_receive_window`
+    pub fn set_stream_receive_window(&mut self, value: VarInt) {
+        self.stream_receive_window = value.into();
+    }
+
     /// Returns the maximum amount of data this is allowed to be written on the connection
     pub fn write_limit(&self) -> u64 {
         (self.max_data - self.data_sent).min(self.send_window - self.unacked_data)


### PR DESCRIPTION
Fix #1342

Although it's seemingly straightforward, I'm not sure `receive_window` is actually used to limit the data. There is a `received_max_data()` but it can only increase `max_data`, and I'm not seeing any reasoning why it can't be set to lower values. Anyone familiar with it are welcome to shed some light.