### PR TITLE
Configure receive window per connection

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1107,6 +1107,29 @@ impl Connection {
         self.streams.set_max_concurrent(dir, count);
     }
 
+    /// Set the maximum number of bytes the peer may transmit across all streams of a connection before
+    /// becoming blocked.
+    ///
+    /// This should be set to at least the expected connection latency multiplied by the maximum
+    /// desired throughput. Larger values can be useful to allow maximum throughput within a
+    /// stream while another is blocked.
+    pub fn set_receive_window(&mut self, receive_window: VarInt) {
+        self.streams.set_receive_window(receive_window);
+    }
+
+    /// Set the maximum number of bytes the peer may transmit without acknowledgement on any one stream
+    /// before becoming blocked.
+    ///
+    /// This should be set to at least the expected connection latency multiplied by the maximum
+    /// desired throughput. Setting this smaller than `receive_window` helps ensure that a single
+    /// stream doesn't monopolize receive buffers, which may otherwise occur if the application
+    /// chooses not to read from a large stream for a time while still requiring data on other
+    /// streams.
+    pub fn set_stream_receive_window(&mut self, stream_receive_window: VarInt) {
+        self.streams
+            .set_stream_receive_window(stream_receive_window);
+    }
+
     fn on_ack_received(
         &mut self,
         now: Instant,

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1107,14 +1107,11 @@ impl Connection {
         self.streams.set_max_concurrent(dir, count);
     }
 
-    /// Set the maximum number of bytes the peer may transmit across all streams of a connection before
-    /// becoming blocked.
-    ///
-    /// This should be set to at least the expected connection latency multiplied by the maximum
-    /// desired throughput. Larger values can be useful to allow maximum throughput within a
-    /// stream while another is blocked.
+    /// See [`TransportConfig::set_receive_window`]
     pub fn set_receive_window(&mut self, receive_window: VarInt) {
-        self.streams.set_receive_window(receive_window);
+        if self.streams.set_receive_window(receive_window) {
+            self.spaces[SpaceId::Data].pending.max_data = true;
+        }
     }
 
     fn on_ack_received(

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1107,7 +1107,7 @@ impl Connection {
         self.streams.set_max_concurrent(dir, count);
     }
 
-    /// See [`quinn::TransportConfig::receive_window()`]
+    /// See [`TransportConfig::receive_window()`]
     pub fn set_receive_window(&mut self, receive_window: VarInt) {
         if self.streams.set_receive_window(receive_window) {
             self.spaces[SpaceId::Data].pending.max_data = true;

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1107,7 +1107,7 @@ impl Connection {
         self.streams.set_max_concurrent(dir, count);
     }
 
-    /// See [`TransportConfig::set_receive_window`]
+    /// See [`quinn::TransportConfig::receive_window()`]
     pub fn set_receive_window(&mut self, receive_window: VarInt) {
         if self.streams.set_receive_window(receive_window) {
             self.spaces[SpaceId::Data].pending.max_data = true;

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1117,19 +1117,6 @@ impl Connection {
         self.streams.set_receive_window(receive_window);
     }
 
-    /// Set the maximum number of bytes the peer may transmit without acknowledgement on any one stream
-    /// before becoming blocked.
-    ///
-    /// This should be set to at least the expected connection latency multiplied by the maximum
-    /// desired throughput. Setting this smaller than `receive_window` helps ensure that a single
-    /// stream doesn't monopolize receive buffers, which may otherwise occur if the application
-    /// chooses not to read from a large stream for a time while still requiring data on other
-    /// streams.
-    pub fn set_stream_receive_window(&mut self, stream_receive_window: VarInt) {
-        self.streams
-            .set_stream_receive_window(stream_receive_window);
-    }
-
     fn on_ack_received(
         &mut self,
         now: Instant,

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -28,6 +28,10 @@ impl Recv {
         }
     }
 
+    pub(super) fn set_sent_max_stream_data(&mut self, max_stream_data: u64) {
+        self.sent_max_stream_data = max_stream_data;
+    }
+
     /// Process a STREAM frame
     ///
     /// Return value is `(number_of_new_bytes_ingested, stream_is_closed)`

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -28,10 +28,6 @@ impl Recv {
         }
     }
 
-    pub(super) fn set_sent_max_stream_data(&mut self, max_stream_data: u64) {
-        self.sent_max_stream_data = max_stream_data;
-    }
-
     /// Process a STREAM frame
     ///
     /// Return value is `(number_of_new_bytes_ingested, stream_is_closed)`

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -759,6 +759,14 @@ impl StreamsState {
         self.ensure_remote_streams(dir);
     }
 
+    pub fn set_receive_window(&mut self, receive_window: VarInt) {
+        self.receive_window = receive_window.into();
+    }
+
+    pub fn set_stream_receive_window(&mut self, stream_receive_window: VarInt) {
+        self.stream_receive_window = stream_receive_window.into();
+    }
+
     pub(super) fn insert(&mut self, remote: bool, id: StreamId) {
         let bi = id.dir() == Dir::Bi;
         if bi || !remote {

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -763,15 +763,6 @@ impl StreamsState {
         self.receive_window = receive_window.into();
     }
 
-    pub fn set_stream_receive_window(&mut self, stream_receive_window: VarInt) {
-        self.stream_receive_window = stream_receive_window.into();
-
-        // correct the existing streams
-        for recv in self.recv.values_mut() {
-            recv.set_sent_max_stream_data(self.stream_receive_window);
-        }
-    }
-
     pub(super) fn insert(&mut self, remote: bool, id: StreamId) {
         let bi = id.dir() == Dir::Bi;
         if bi || !remote {

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -765,6 +765,11 @@ impl StreamsState {
 
     pub fn set_stream_receive_window(&mut self, stream_receive_window: VarInt) {
         self.stream_receive_window = stream_receive_window.into();
+
+        // correct the existing streams
+        for recv in self.recv.values_mut() {
+            recv.set_sent_max_stream_data(self.stream_receive_window);
+        }
     }
 
     pub(super) fn insert(&mut self, remote: bool, id: StreamId) {

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -546,6 +546,18 @@ impl Connection {
         conn.wake();
     }
 
+    /// Set the maximum number of bytes the peer may transmit across all streams of a connection before
+    /// becoming blocked.
+    ///
+    /// This should be set to at least the expected connection latency multiplied by the maximum
+    /// desired throughput. Larger values can be useful to allow maximum throughput within a
+    /// stream while another is blocked.
+    pub fn set_receive_window(&mut self, receive_window: VarInt) {
+        let mut conn = self.0.lock("set_receive_window");
+        conn.inner.set_receive_window(receive_window);
+        conn.wake();
+    }
+
     /// Modify the number of remotely initiated bidirectional streams that may be concurrently open
     ///
     /// No streams may be opened by the peer unless fewer than `count` are already open. Large

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -546,12 +546,7 @@ impl Connection {
         conn.wake();
     }
 
-    /// Set the maximum number of bytes the peer may transmit across all streams of a connection before
-    /// becoming blocked.
-    ///
-    /// This should be set to at least the expected connection latency multiplied by the maximum
-    /// desired throughput. Larger values can be useful to allow maximum throughput within a
-    /// stream while another is blocked.
+    /// See [`quinn::TransportConfig::receive_window()`]
     pub fn set_receive_window(&self, receive_window: VarInt) {
         let mut conn = self.0.lock("set_receive_window");
         conn.inner.set_receive_window(receive_window);

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -552,7 +552,7 @@ impl Connection {
     /// This should be set to at least the expected connection latency multiplied by the maximum
     /// desired throughput. Larger values can be useful to allow maximum throughput within a
     /// stream while another is blocked.
-    pub fn set_receive_window(&mut self, receive_window: VarInt) {
+    pub fn set_receive_window(&self, receive_window: VarInt) {
         let mut conn = self.0.lock("set_receive_window");
         conn.inner.set_receive_window(receive_window);
         conn.wake();

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -546,7 +546,7 @@ impl Connection {
         conn.wake();
     }
 
-    /// See [`quinn::TransportConfig::receive_window()`]
+    /// See [`proto::TransportConfig::receive_window()`]
     pub fn set_receive_window(&self, receive_window: VarInt) {
         let mut conn = self.0.lock("set_receive_window");
         conn.inner.set_receive_window(receive_window);


### PR DESCRIPTION
Problem:
Currently the receive_window on the server side is obtained from the ServerConfig stored in the Endpoint, which will make all connections having the same receive_window and making per connection data limits difficult.

Solution:
Create interfaces to set the receive_window per connection. 

This is to address https://github.com/quinn-rs/quinn/issues/1342 to make receive_window configurable per connection. It only handles receive_window not the stream_receive_window which can be addressed in a separate PR.
