### PR TITLE
Fix build errors so quinn-proto can be used under wasm32-unknown-unknown

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -36,6 +36,10 @@ tinyvec = { version = "1.1", features = ["alloc"] }
 tracing = "0.1.10"
 webpki = { version = "0.22", default-features = false, optional = true }
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+# Choose appropriate feature set for getrandom, which is used via rand/rand_core
+getrandom = { version = "0.2", features = ["js"] }
+
 [dev-dependencies]
 assert_matches = "1.1"
 hex-literal = "0.3.0"

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -36,10 +36,6 @@ tinyvec = { version = "1.1", features = ["alloc"] }
 tracing = "0.1.10"
 webpki = { version = "0.22", default-features = false, optional = true }
 
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-# Choose appropriate feature set for getrandom, which is used via rand/rand_core
-getrandom = { version = "0.2", features = ["js"] }
-
 [dev-dependencies]
 assert_matches = "1.1"
 hex-literal = "0.3.0"

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -1,7 +1,9 @@
 use std::{convert::TryInto, fmt, num::TryFromIntError, sync::Arc, time::Duration};
 
-use rand::RngCore;
 use thiserror::Error;
+
+#[cfg(feature = "ring")]
+use rand::RngCore;
 
 use crate::{
     cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator},

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -743,7 +743,7 @@ impl Connection {
                     && !can_send.acks
                     && can_send.other
                     && (buf_capacity - builder.datagram_start)
-                        == self.path.max_udp_payload_size as _),
+                        == self.path.max_udp_payload_size as usize),
                 "SendableFrames was {:?}, but only ACKs have been written",
                 can_send
             );

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -147,7 +147,7 @@ impl Recv {
     ) -> Result<bool, TransportError> {
         // Validate final_offset
         if let Some(offset) = self.final_offset() {
-            if offset != final_offset.into() {
+            if offset != final_offset.into_inner() {
                 return Err(TransportError::FINAL_SIZE_ERROR("inconsistent value"));
             }
         } else if self.end > final_offset.into() {

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -282,7 +282,7 @@ impl StreamsState {
         self.on_stream_frame(!stopped, id);
 
         // Update flow control
-        Ok(if bytes_read != final_offset.into() {
+        Ok(if bytes_read != final_offset.into_inner() {
             // bytes_read is always <= end, so this won't underflow.
             self.data_recvd = self
                 .data_recvd


### PR DESCRIPTION
This fixes a handful of basic things so that `quinn-proto` (with no default features) cleanly builds under the `wasm32-unknown-unknown` target, and can be used with a browser-based `wasm-bindgen-test` runner.

* One of the transitive dependencies `getrandom` needs an additional feature to work in the browser
* There is a warning about an unused import when the `ring` feature is not in use
* There were some odd type inference failures:

```
   Compiling quinn-proto v0.8.0 (/home/tk/repos/quinn/quinn-proto)
error[E0283]: type annotations needed
   --> /home/tk/repos/quinn/quinn-proto/src/connection/streams/recv.rs:150:23
    |
150 |             if offset != final_offset.into() {
    |                       ^^ ------------------- this method call resolves to `T`
    |                       |
    |                       cannot infer type
    |
    = note: multiple `impl`s satisfying `u64: PartialEq<_>` found in the following crates: `core`, `serde_json`:
            - impl PartialEq for u64;
            - impl PartialEq<serde_json::value::Value> for u64;

error[E0283]: type annotations needed
   --> /home/tk/repos/quinn/quinn-proto/src/connection/streams/state.rs:285:26
    |
285 |         Ok(if bytes_read != final_offset.into() {
    |                          ^^ ------------------- this method call resolves to `T`
    |                          |
    |                          cannot infer type
    |
    = note: multiple `impl`s satisfying `u64: PartialEq<_>` found in the following crates: `core`, `serde_json`:
            - impl PartialEq for u64;
            - impl PartialEq<serde_json::value::Value> for u64;

error[E0282]: type annotations needed
   --> /home/tk/repos/quinn/quinn-proto/src/connection/mod.rs:746:62
    |
746 |                         == self.path.max_udp_payload_size as _),
    |                                                              ^ cannot infer type
    |
    = note: type must be known at this point
```

