### PR TITLE
Port fix for address layout reliance to 0.8

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,16 +12,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, beta, 1.53.0]
+        rust: [stable, beta, 1.57.0]
         exclude:
           - os: macos-latest
             rust: beta
           - os: macos-latest
-            rust: 1.53.0
+            rust: 1.57.0
           - os: windows-latest
             rust: beta
           - os: windows-latest
-            rust: 1.53.0
+            rust: 1.57.0
 
     runs-on: ${{ matrix.os }}
 

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.1.2"
+version = "0.1.3"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/quinn-rs/quinn"
 description = "UDP sockets with ECN information for the QUIC transport protocol"


### PR DESCRIPTION
I guess we should yank 0.1.{0,1,2}?

cc @est31 I'm not quite motivated to backport this to older versions than 0.8, but you might be interested.