### PR TITLE
Define `Connection::closed` helper to await connection termination

### DIFF
--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -218,7 +218,7 @@ impl Assembler {
 }
 
 /// A chunk of data from the receive stream
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Chunk {
     /// The offset in the stream
     pub offset: u64,

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -354,7 +354,7 @@ impl crypto::PacketKey for PacketKey {
         payload: &mut BytesMut,
     ) -> Result<(), CryptoError> {
         let plain = self
-            .decrypt_in_place(packet, &*header, payload.as_mut())
+            .decrypt_in_place(packet, header, payload.as_mut())
             .map_err(|_| CryptoError)?;
         let plain_len = plain.len();
         payload.truncate(plain_len);

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -212,7 +212,7 @@ fn send(
         unsafe { MaybeUninit::uninit().assume_init() };
     for (i, transmit) in transmits.iter().enumerate().take(BATCH_SIZE) {
         let dst_addr = unsafe {
-            std::ptr::write(
+            ptr::write(
                 addrs[i].as_mut_ptr(),
                 socket2::SockAddr::from(transmit.destination),
             );


### PR DESCRIPTION
This has come up several times, most recently in https://github.com/quinn-rs/quinn/issues/1395. While equivalent behavior is already possible by waiting for e.g. `IncomingUniStreams` to yield `Err` or `None`, this is substantially more discoverable.