### PR TITLE
Bump MSRV to 1.59

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,16 +12,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, beta, 1.57.0]
+        rust: [stable, beta, 1.59.0]
         exclude:
           - os: macos-latest
             rust: beta
           - os: macos-latest
-            rust: 1.57.0
+            rust: 1.59.0
           - os: windows-latest
             rust: beta
           - os: windows-latest
-            rust: 1.57.0
+            rust: 1.59.0
 
     runs-on: ${{ matrix.os }}
 

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["quic"]
 categories = [ "network-programming", "asynchronous" ]
 workspace = ".."
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.59"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["quic"]
 categories = [ "network-programming", "asynchronous" ]
 workspace = ".."
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.59"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Fixes CI failures with `time`. In theory we could avoid this because AFAICT it's only a dev-dependency, but I'm not sure how we can test without pulling in dev-dependencies, and 1.59 is ~6 months old onw anyway.