### PR TITLE
Check QUIC Bit that Short Header Packet set too

### DIFF
--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -575,7 +575,7 @@ impl PlainHeader {
                 });
             }
 
-            match LongHeaderType::from_byte(first, grease_quic_bit)? {
+            match LongHeaderType::from_byte(first)? {
                 LongHeaderType::Initial => {
                     let token_len = buf.get_var()? as usize;
                     let token_start = buf.position() as usize;
@@ -722,7 +722,7 @@ pub(crate) enum LongHeaderType {
 }
 
 impl LongHeaderType {
-    fn from_byte(b: u8, grease_quic_bit: bool) -> Result<Self, PacketDecodeError> {
+    fn from_byte(b: u8) -> Result<Self, PacketDecodeError> {
         use self::{LongHeaderType::*, LongType::*};
         debug_assert!(b & LONG_HEADER_FORM != 0, "not a long packet");
         Ok(match (b & 0x30) >> 4 {


### PR DESCRIPTION
Hi!
This PR would allow `Connection` to check Short Header Packets greasing QUIC Bit.

`PlainHeader::decode()` can check Long Header Packets with the QUIC Bit set to a value of 0. If `EndpointConfig` is not set grease_quic_bit with false, it raise `PacketDecodeError::InvalidHeader("fixed bit unset")`. But, in my understanding, Short Header Packets should be checked QUIC Bit too.

- https://www.rfc-editor.org/rfc/rfc9287.html#section-3.1-2
- https://www.rfc-editor.org/rfc/rfc9287.html#section-3.1-3

Thanks.