### PR TITLE
Accessor for free datagram send buffer space

### DIFF
--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -75,6 +75,17 @@ impl<'a> Datagrams<'a> {
     pub fn recv(&mut self) -> Option<Bytes> {
         self.conn.datagrams.recv()
     }
+
+    /// Bytes available in the outgoing datagram buffer
+    ///
+    /// When greater than zero, [`send`](Self::send)ing a datagram of at most this size is
+    /// guaranteed not to cause older datagrams to be dropped.
+    pub fn send_buffer_space(&self) -> usize {
+        self.conn
+            .config
+            .datagram_send_buffer_size
+            .saturating_sub(self.conn.datagrams.outgoing_total)
+    }
 }
 
 #[derive(Default)]

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -403,6 +403,19 @@ impl Connection {
             .max_size()
     }
 
+    /// Bytes available in the outgoing datagram buffer
+    ///
+    /// When greater than zero, calling [`send_datagram()`](Self::send_datagram) with a datagram of
+    /// at most this size is guaranteed not to cause older datagrams to be dropped.
+    pub fn datagram_send_buffer_space(&self) -> usize {
+        self.0
+            .state
+            .lock("datagram_send_buffer_space")
+            .inner
+            .datagrams()
+            .send_buffer_space()
+    }
+
     /// The peer's UDP address
     ///
     /// If `ServerConfig::migration` is `true`, clients may change addresses at will, e.g. when


### PR DESCRIPTION
Useful for applications which can adapt to variable bandwidth on the fly, such as video streaming. Motivated by discussion with an interested prospective user in that space.

Possible future work: a mechanism to be notified when the space increases, or perhaps reaches a threshold.