### PR TITLE
Expose a getter for the close reason

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -339,6 +339,13 @@ impl Connection {
             .clone()
     }
 
+    /// If the connection is closed, the reason why.
+    ///
+    /// Returns `None` if the connection is still open.
+    pub fn close_reason(&self) -> Option<ConnectionError> {
+        self.0.state.lock("close_reason").error.clone()
+    }
+
     /// Close the connection immediately.
     ///
     /// Pending operations will fail immediately with [`ConnectionError::LocallyClosed`]. Delivery


### PR DESCRIPTION
Convenient for applications which inspect the state of a connection lazily. Motivated by user request in the chatroom.