### PR TITLE
quinn-udp: bump version to 0.3

### DIFF
--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.2.0"
+version = "0.3.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/quinn-rs/quinn"
 description = "UDP sockets with ECN information for the QUIC transport protocol"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -42,7 +42,7 @@ proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.9", def
 rustls = { version = "0.20.3", default-features = false, features = ["quic"], optional = true }
 thiserror = "1.0.21"
 tracing = "0.1.10"
-tokio = { version = "1.0.1", features = ["sync"] }
+tokio = { version = "1.13.0", features = ["sync"] }
 udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.3" }
 webpki = { version = "0.22", default-features = false, optional = true }
 

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -43,7 +43,7 @@ rustls = { version = "0.20.3", default-features = false, features = ["quic"], op
 thiserror = "1.0.21"
 tracing = "0.1.10"
 tokio = { version = "1.0.1", features = ["sync"] }
-udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.2" }
+udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.3" }
 webpki = { version = "0.22", default-features = false, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
quinn-proto is a public dependency of quinn-udp (for example, `RecvMeta` exposes `EcnCodePoint`). #1429 bumped the version for quinn-proto and the dependency for quinn-udp, but not quinn-udp's version; do that here.

Since I was building in an old working directory I also noticed that I was unable to compile quinn with the tokio 1.9 that `Cargo.lock` was set to. Bump the tokio dependency up to 1.13 which is the oldest version that seems to compile.