### PR TITLE
Add --keylog command line option for perf client and server binaries.

### DIFF
--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -60,6 +60,9 @@ struct Opt {
     #[cfg(feature = "json-output")]
     #[clap(long)]
     json: Option<PathBuf>,
+    /// Perform NSS-compatible TLS key logging to the file specified in `SSLKEYLOGFILE`.
+    #[clap(long = "keylog")]
+    keylog: bool,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -114,6 +117,10 @@ async fn run(opt: Opt) -> Result<()> {
         .with_custom_certificate_verifier(SkipServerVerification::new())
         .with_no_client_auth();
     crypto.alpn_protocols = vec![b"perf".to_vec()];
+
+    if opt.keylog {
+        crypto.key_log = Arc::new(rustls::KeyLogFile::new());
+    }
 
     let cfg = quinn::ClientConfig::new(Arc::new(crypto));
 

--- a/perf/src/bin/perf_server.rs
+++ b/perf/src/bin/perf_server.rs
@@ -29,6 +29,9 @@ struct Opt {
     /// Whether to print connection statistics
     #[clap(long)]
     conn_stats: bool,
+    /// Perform NSS-compatible TLS key logging to the file specified in `SSLKEYLOGFILE`.
+    #[clap(long = "keylog")]
+    keylog: bool,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -73,6 +76,10 @@ async fn run(opt: Opt) -> Result<()> {
         .with_single_cert(cert, key)
         .unwrap();
     crypto.alpn_protocols = vec![b"perf".to_vec()];
+
+    if opt.keylog {
+        crypto.key_log = Arc::new(rustls::KeyLogFile::new());
+    }
 
     let server_config = quinn::ServerConfig::with_crypto(Arc::new(crypto));
 


### PR DESCRIPTION
This allow dumping crypto keys to disk using SSLKEYLOGFILE env var.