### PR TITLE
Preallocate output vector in poll_transmit().

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -489,7 +489,7 @@ impl Connection {
             _ => false,
         };
 
-        let mut buf = Vec::new();
+        let mut buf = Vec::with_capacity(max_datagrams * self.path.max_udp_payload_size as usize);
         // Reserving capacity can provide more capacity than we asked for.
         // However we are not allowed to write more than MTU size. Therefore
         // the maximum capacity is tracked separately.


### PR DESCRIPTION
This is a partial fix for #729 doing the whole optimization as suggested in this issue will require more work as output vector is put within Transmit { } struct, using a &[u8] will require adding a bunch of lifetime here and there. I started working on this but it will take more time.

This simple optimization lead to a performance increase of around 3% with default crypto and around 15% without packet encryption and decryption (using custom patch from PR1436).