### PR TITLE
Fix duplicate MAX_STREAMS transmit

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2591,7 +2591,9 @@ impl Connection {
             .packet_received(ack_eliciting);
 
         // Issue stream ID credit due to ACKs of outgoing finish/resets and incoming finish/resets
-        // on stopped streams
+        // on stopped streams. Incoming finishes/resets on open streams are not handled here as they
+        // are only freed, and hence only issue credit, once the application has been notified
+        // during a read on the stream.
         let pending = &mut self.spaces[SpaceId::Data].pending;
         for dir in Dir::iter() {
             if self.streams.take_max_streams_dirty(dir) {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2597,10 +2597,7 @@ impl Connection {
         let pending = &mut self.spaces[SpaceId::Data].pending;
         for dir in Dir::iter() {
             if self.streams.take_max_streams_dirty(dir) {
-                match dir {
-                    Dir::Uni => pending.max_uni_stream_id = true,
-                    Dir::Bi => pending.max_bi_stream_id = true,
-                }
+                pending.max_stream_id[dir as usize] = true;
             }
         }
 

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -296,7 +296,8 @@ impl<'a> Chunks<'a> {
         }
 
         let mut should_transmit = false;
-        // We issue additional stream ID credit iff a remotely-initiated stream stream is finished or reset
+        // We issue additional stream ID credit after the application is notified that a previously
+        // open stream has finished or been reset and we've therefore disposed of its state.
         if matches!(state, ChunksState::Finished | ChunksState::Reset(_))
             && self.streams.side != self.id.initiator()
         {

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -6,7 +6,7 @@ use tracing::debug;
 
 use super::{Retransmits, ShouldTransmit, StreamHalf, StreamId, StreamsState, UnknownStream};
 use crate::connection::assembler::{Assembler, Chunk, IllegalOrderedRead};
-use crate::{frame, Dir, TransportError, VarInt};
+use crate::{frame, TransportError, VarInt};
 
 #[derive(Debug, Default)]
 pub(super) struct Recv {
@@ -301,10 +301,7 @@ impl<'a> Chunks<'a> {
         if matches!(state, ChunksState::Finished | ChunksState::Reset(_))
             && self.streams.side != self.id.initiator()
         {
-            match self.id.dir() {
-                Dir::Uni => self.pending.max_uni_stream_id = true,
-                Dir::Bi => self.pending.max_bi_stream_id = true,
-            }
+            self.pending.max_stream_id[self.id.dir() as usize] = true;
             should_transmit = true;
         }
 

--- a/quinn-proto/src/connection/streams/send.rs
+++ b/quinn-proto/src/connection/streams/send.rs
@@ -218,7 +218,7 @@ impl<'a> BytesSource for ByteSlice<'a> {
         let chunk = Bytes::from(self.data[..limit].to_owned());
         self.data = &self.data[chunk.len()..];
 
-        let chunks_consumed = if self.data.is_empty() { 1 } else { 0 };
+        let chunks_consumed = usize::from(self.data.is_empty());
         (chunk, chunks_consumed)
     }
 }

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -32,7 +32,7 @@ pub struct StreamsState {
     /// Maximum number of remotely-initiated streams that may be opened over the lifetime of the
     /// connection so far, per direction
     max_remote: [u64; 2],
-    /// Number of streams that we've given the peer permission to open
+    /// Number of streams that we've given the peer permission to open and which aren't fully closed
     allocated_remote_count: [u64; 2],
     /// Size of the desired stream flow control window. May be smaller than `allocated_remote_count`
     /// due to `set_max_concurrent` calls.
@@ -447,6 +447,7 @@ impl StreamsState {
         if pending.max_uni_stream_id && buf.len() + 9 < max_size {
             pending.max_uni_stream_id = false;
             retransmits.get_or_create().max_uni_stream_id = true;
+            self.max_streams_dirty[Dir::Uni as usize] = false;
             trace!(
                 value = self.max_remote[Dir::Uni as usize],
                 "MAX_STREAMS (unidirectional)"
@@ -460,6 +461,7 @@ impl StreamsState {
         if pending.max_bi_stream_id && buf.len() + 9 < max_size {
             pending.max_bi_stream_id = false;
             retransmits.get_or_create().max_bi_stream_id = true;
+            self.max_streams_dirty[Dir::Bi as usize] = false;
             trace!(
                 value = self.max_remote[Dir::Bi as usize],
                 "MAX_STREAMS (bidirectional)"

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -854,7 +854,7 @@ impl FrameStruct for Datagram {
 
 impl Datagram {
     pub(crate) fn encode<W: BufMut>(&self, length: bool, out: &mut W) {
-        out.write(Type(*DATAGRAM_TYS.start() | if length { 1 } else { 0 })); // 1 byte
+        out.write(Type(*DATAGRAM_TYS.start() | u64::from(length))); // 1 byte
         if length {
             // Safe to unwrap because we check length sanity before queueing datagrams
             out.write(VarInt::from_u64(self.data.len() as u64).unwrap()); // <= 8 bytes

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -107,7 +107,7 @@ async fn run(options: Opt) -> Result<()> {
                 let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
                 let key = cert.serialize_private_key_der();
                 let cert = cert.serialize_der().unwrap();
-                fs::create_dir_all(&path).context("failed to create certificate directory")?;
+                fs::create_dir_all(path).context("failed to create certificate directory")?;
                 fs::write(&cert_path, &cert).context("failed to write certificate")?;
                 fs::write(&key_path, &key).context("failed to write private key")?;
                 (cert, key)

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -801,7 +801,7 @@ impl Drop for ConnectionRef {
 impl std::ops::Deref for ConnectionRef {
     type Target = ConnectionInner;
     fn deref(&self) -> &Self::Target {
-        &*self.0
+        &self.0
     }
 }
 


### PR DESCRIPTION
When the application observes a stream finish or reset, we dispose of its state via `StreamsState::stream_freed`, and queue a transmit of stream flow control credit directly on the `Connection`. `stream_freed` however also sets `StreamsState::max_streams_dirty`, which is polled each time we receive a packet to see whether a stream has become fully closed due to an incoming frame. Together, these led to a MAX_STREAMS frame being transmit both immediately, and following the next packet receipt. We prevent that by unsetting the appropriate `max_streams_dirty` flags when sending `MAX_STREAMS`.