### PR TITLE
Fix stream open futures sometimes waiting on the wrong notification

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -628,7 +628,7 @@ fn poll_open<'a>(
             // `state` lock ensures we didn't race with readiness
             Poll::Pending => return Poll::Pending,
             // Spurious wakeup, get a new future
-            Poll::Ready(()) => notify.set(conn.shared.stream_incoming[dir as usize].notified()),
+            Poll::Ready(()) => notify.set(conn.shared.stream_opening[dir as usize].notified()),
         }
     }
 }
@@ -813,7 +813,10 @@ pub struct ConnectionInner {
 
 #[derive(Debug, Default)]
 pub(crate) struct Shared {
+    /// Notified when new streams may be locally initiated due to an increase in stream ID flow
+    /// control budget
     stream_opening: [Notify; 2],
+    /// Notified when the peer has initiated a new stream
     stream_incoming: [Notify; 2],
     datagrams: Notify,
     closed: Notify,


### PR DESCRIPTION
After a spurious wakeup, `Connection::open_uni` and `open_bi` would switch to waiting for notifications about incoming streams, rather than the intended notification about new stream ID flow control budget. This was probably a copy-paste error from `poll_accept`.

Let's get a patch release out as soon as this is merged.