### PR TITLE
Update clap and examples

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -54,7 +54,7 @@ directories-next = "2"
 rand = "0.8"
 rcgen = "0.10.0"
 rustls-pemfile = "1.0.0"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.0.26", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["rt", "rt-multi-thread", "time", "macros", "sync"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -33,7 +33,7 @@ struct Opt {
     host: Option<String>,
 
     /// Custom certificate authority to trust, in DER format
-    #[clap(parse(from_os_str), long = "ca")]
+    #[clap(value_parser = clap::value_parser!(PathBuf), long = "ca")]
     ca: Option<PathBuf>,
 
     /// Simulate NAT rebinding after connecting

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -24,13 +24,13 @@ struct Opt {
     #[clap(long = "keylog")]
     keylog: bool,
     /// directory to serve files from
-    #[clap(parse(from_os_str))]
+    #[clap(value_parser = clap::value_parser!(PathBuf))]
     root: PathBuf,
     /// TLS private key in PEM format
-    #[clap(parse(from_os_str), short = 'k', long = "key", requires = "cert")]
+    #[clap(value_parser = clap::value_parser!(PathBuf), short = 'k', long = "key", requires = "cert")]
     key: Option<PathBuf>,
     /// TLS certificate in PEM format
-    #[clap(parse(from_os_str), short = 'c', long = "cert", requires = "key")]
+    #[clap(value_parser = clap::value_parser!(PathBuf), short = 'c', long = "cert", requires = "key")]
     cert: Option<PathBuf>,
     /// Enable stateless retries
     #[clap(long = "stateless-retry")]


### PR DESCRIPTION
Updates clap to 4.0.26 and fixes errors in examples.