### PR TITLE
fix: don't bail if setting IP_RECVTOS fails

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,16 +12,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, beta, 1.57.0]
+        rust: [stable, beta, 1.59.0]
         exclude:
           - os: macos-latest
             rust: beta
           - os: macos-latest
-            rust: 1.57.0
+            rust: 1.59.0
           - os: windows-latest
             rust: beta
           - os: windows-latest
-            rust: 1.57.0
+            rust: 1.59.0
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Quinn is a pure-rust, async-compatible implementation of the IETF [QUIC][quic] t
   [rustls][rustls] and [*ring*][ring]
 - Application-layer datagrams for small, unreliable messages
 - Future-based async API
-- Minimum supported Rust version of 1.51.0
+- Minimum supported Rust version of 1.59.0
 
 ## Overview
 

--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -218,7 +218,7 @@ impl Assembler {
 }
 
 /// A chunk of data from the receive stream
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Chunk {
     /// The offset in the stream
     pub offset: u64,

--- a/quinn-proto/src/connection/streams/send.rs
+++ b/quinn-proto/src/connection/streams/send.rs
@@ -218,7 +218,7 @@ impl<'a> BytesSource for ByteSlice<'a> {
         let chunk = Bytes::from(self.data[..limit].to_owned());
         self.data = &self.data[chunk.len()..];
 
-        let chunks_consumed = if self.data.is_empty() { 1 } else { 0 };
+        let chunks_consumed = usize::from(self.data.is_empty());
         (chunk, chunks_consumed)
     }
 }

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -354,7 +354,7 @@ impl crypto::PacketKey for PacketKey {
         payload: &mut BytesMut,
     ) -> Result<(), CryptoError> {
         let plain = self
-            .decrypt_in_place(packet, &*header, payload.as_mut())
+            .decrypt_in_place(packet, header, payload.as_mut())
             .map_err(|_| CryptoError)?;
         let plain_len = plain.len();
         payload.truncate(plain_len);

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -850,7 +850,7 @@ impl FrameStruct for Datagram {
 
 impl Datagram {
     pub(crate) fn encode<W: BufMut>(&self, length: bool, out: &mut W) {
-        out.write(Type(*DATAGRAM_TYS.start() | if length { 1 } else { 0 })); // 1 byte
+        out.write(Type(*DATAGRAM_TYS.start() | u64::from(length))); // 1 byte
         if length {
             // Safe to unwrap because we check length sanity before queueing datagrams
             out.write(VarInt::from_u64(self.data.len() as u64).unwrap()); // <= 8 bytes

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -108,7 +108,7 @@ async fn run(options: Opt) -> Result<()> {
                 let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
                 let key = cert.serialize_private_key_der();
                 let cert = cert.serialize_der().unwrap();
-                fs::create_dir_all(&path).context("failed to create certificate directory")?;
+                fs::create_dir_all(path).context("failed to create certificate directory")?;
                 fs::write(&cert_path, &cert).context("failed to write certificate")?;
                 fs::write(&key_path, &key).context("failed to write private key")?;
                 (cert, key)


### PR DESCRIPTION
old macOS versions don't have it, so if you try say `connection` example on macOS 10.11, it'll error with IoError 42 - Protocol not available.

I'm not sure if you're wanting a tracing log, or if you're planning on another 0.8.x release but we're still on it until we do our next non-bugfix release where we'll go to 0.9. Easily can be applied to 0.9/main too.