### PR TITLE
Fix GSO / GRO auto detection when IPv6 is disabled.

### DIFF
--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -571,7 +571,9 @@ mod gso {
     pub fn max_gso_segments() -> usize {
         const GSO_SIZE: libc::c_int = 1500;
 
-        let socket = match std::net::UdpSocket::bind("[::]:0") {
+        let socket = match std::net::UdpSocket::bind("[::]:0")
+            .or_else(|_| std::net::UdpSocket::bind("127.0.0.1:0"))
+        {
             Ok(socket) => socket,
             Err(_) => return 1,
         };
@@ -618,7 +620,9 @@ mod gro {
     use super::*;
 
     pub fn gro_segments() -> usize {
-        let socket = match std::net::UdpSocket::bind("[::]:0") {
+        let socket = match std::net::UdpSocket::bind("[::]:0")
+            .or_else(|_| std::net::UdpSocket::bind("127.0.0.1:0"))
+        {
             Ok(socket) => socket,
             Err(_) => return 1,
         };


### PR DESCRIPTION
One of my Linux test machine has IPv6 disabled. While doing some bench and test on it, i noticed that GSO / GRO were not enabled. Here is a small fix to fallback to an IPv4 loopback in case it failed on IPv6 loopback.