### PR TITLE
connection: wake 'stopped' streams on stream finish events

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -963,6 +963,9 @@ impl State {
                         // If the finishing stream was already dropped, there's nothing more to do.
                         let _ = finishing.send(None);
                     }
+                    if let Some(stopped) = self.stopped.remove(&id) {
+                        stopped.wake();
+                    }
                 }
                 Stream(StreamEvent::Stopped { id, error_code }) => {
                     if let Some(stopped) = self.stopped.remove(&id) {

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -307,6 +307,13 @@ impl Future for Stopped<'_> {
     }
 }
 
+impl<'a> Drop for Stopped<'a> {
+    fn drop(&mut self) {
+        let mut conn = self.stream.conn.state.lock("Stopped::drop");
+        conn.stopped.remove(&self.stream.stream);
+    }
+}
+
 /// Future produced by [`SendStream::write()`].
 ///
 /// [`SendStream::write()`]: crate::SendStream::write


### PR DESCRIPTION
In the event that the SendStream Stopped future is polled once and then dropped before the remote side has stopped the stream, and instead the stream has been finished, the waker registered in the connection stopped map is never removed and is effectively "leaked" until the connection is closed. This can lead to a large amount of memory being retained when a connection is very long lived and many streams are used over the life of that connection.

This particular issue can be seen with this type of usage of SendStream::stopped: https://github.com/bmwill/anemo/blob/main/crates/anemo/src/network/request_handler.rs#L170-L177.

This is one such way to fix this memory retention, although it may not be the project's preferred way. Another option would potentially be to remove the waker from the hash map in a `Drop` impl for the `Stopped` type.