### PR TITLE
Add support for IP_RECVORIGDSTADDR socket option.

### DIFF
--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -86,6 +86,7 @@ impl UdpSocketState {
             addr: addr.as_socket().unwrap(),
             ecn: None,
             dst_ip: None,
+            dst_addr: None,
         };
         Ok(1)
     }

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -78,6 +78,7 @@ pub struct RecvMeta {
     pub ecn: Option<EcnCodepoint>,
     /// The destination IP address which was encoded in this datagram
     pub dst_ip: Option<IpAddr>,
+    pub dst_addr: Option<SocketAddr>,
 }
 
 impl Default for RecvMeta {
@@ -89,6 +90,7 @@ impl Default for RecvMeta {
             stride: 0,
             ecn: None,
             dst_ip: None,
+            dst_addr: None,
         }
     }
 }

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -134,6 +134,7 @@ impl UdpSocketState {
             addr: addr.as_socket().unwrap(),
             ecn: None,
             dst_ip: None,
+            dst_addr: None,
         };
         Ok(1)
     }


### PR DESCRIPTION
When enabled on a socket with IP_TRANSPARENT, it populates metadata
with the original destination (IP:port) for traffic redirected with
TPROXY.

Signed-off-by: Piotr Sikora <piotr@aviatrix.com>