### PR TITLE
Route logs via `log` crate by default when `tracing` isn't used

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -17,10 +17,12 @@ all-features = true
 maintenance = { status = "experimental" }
 
 [features]
-default = ["tls-rustls"]
+default = ["tls-rustls", "log"]
 tls-rustls = ["rustls", "webpki", "ring"]
 # Provides `ClientConfig::with_native_roots()` convenience method
 native-certs = ["rustls-native-certs"]
+# Write logs via the `log` crate when no `tracing` subscriber exists
+log = ["tracing/log"]
 
 [dependencies]
 arbitrary = { version = "1.0.1", features = ["derive"], optional = true }

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -12,6 +12,11 @@ edition = "2018"
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+default = ["log"]
+# Write logs via the `log` crate when no `tracing` subscriber exists
+log = ["tracing/log"]
+
 [badges]
 maintenance = { status = "experimental" }
 

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.59"
 all-features = true
 
 [features]
-default = ["native-certs", "tls-rustls", "runtime-tokio"]
+default = ["native-certs", "tls-rustls", "runtime-tokio", "log"]
 # Records how long locks are held, and warns if they are held >= 1ms
 lock_tracking = []
 # Provides `ClientConfig::with_native_roots()` convenience method
@@ -25,6 +25,8 @@ tls-rustls = ["rustls", "webpki", "proto/tls-rustls", "ring"]
 ring = ["proto/ring"]
 runtime-tokio = ["tokio/time", "tokio/rt", "tokio/net"]
 runtime-async-std = ["async-io", "async-std"]
+# Write logs via the `log` crate when no `tracing` subscriber exists
+log = ["tracing/log", "proto/log", "udp/log"]
 
 [badges]
 codecov = { repository = "djc/quinn" }
@@ -43,7 +45,7 @@ rustls = { version = "0.20.3", default-features = false, features = ["quic"], op
 thiserror = "1.0.21"
 tracing = "0.1.10"
 tokio = { version = "1.13.0", features = ["sync"] }
-udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.3" }
+udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.3", default-features = false }
 webpki = { version = "0.22", default-features = false, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Prompted by #1472. The inter-crate edges aren't strictly necessary since `tracing`'s features will be unified across all crates, but ensuring a consistent feature state seems tidy.