### PR TITLE
Fail gracefully on attempts to connect to an unspecified IP address

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -366,7 +366,7 @@ impl Endpoint {
         if self.is_full() {
             return Err(ConnectError::TooManyConnections);
         }
-        if remote.port() == 0 {
+        if remote.port() == 0 || remote.ip().is_unspecified() {
             return Err(ConnectError::InvalidRemoteAddress(remote));
         }
 


### PR DESCRIPTION
Silent failure here has tripped up multiple users, most recently in https://github.com/quinn-rs/quinn/issues/1472.