### PR TITLE
Re-export udp::{RecvMeta, UdpState} for AsyncUdpSocket

### DIFF
--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -63,6 +63,7 @@ pub use proto::{
     ConnectionClose, ConnectionError, EndpointConfig, IdleTimeout, ServerConfig, StreamId,
     Transmit, TransportConfig, VarInt,
 };
+pub use udp::{RecvMeta, UdpState};
 
 pub use crate::connection::{
     AcceptBi, AcceptUni, Connecting, Connection, OpenBi, OpenUni, ReadDatagram, SendDatagramError,

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -63,7 +63,7 @@ pub use proto::{
     ConnectionClose, ConnectionError, EndpointConfig, IdleTimeout, ServerConfig, StreamId,
     Transmit, TransportConfig, VarInt,
 };
-pub use udp::{RecvMeta, UdpState};
+pub use udp;
 
 pub use crate::connection::{
     AcceptBi, AcceptUni, Connecting, Connection, OpenBi, OpenUni, ReadDatagram, SendDatagramError,


### PR DESCRIPTION
To implement `AsyncUdpSocket` Trait from `quinn` crate, we must use the types `RecvMeta` and `UdpState`. However, current version of quinn does not re-export them, so anyone who wants to implement the trait needs importing another `quinn-udp` crate. This PR fixes this problem by re-export them in `quinn` crate.