### PR TITLE
Improve error when connecting with an unsupported version

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -369,6 +369,9 @@ impl Endpoint {
         if remote.port() == 0 || remote.ip().is_unspecified() {
             return Err(ConnectError::InvalidRemoteAddress(remote));
         }
+        if !self.config.supported_versions.contains(&config.version) {
+            return Err(ConnectError::UnsupportedVersion);
+        }
 
         let remote_id = RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid();
         trace!(initial_dcid = %remote_id);
@@ -830,7 +833,7 @@ pub enum ConnectError {
     /// Use `Endpoint::connect_with` to specify a client configuration.
     #[error("no default client config")]
     NoDefaultClientConfig,
-    /// The cryptographic layer does not support the specified QUIC version
+    /// The local endpoint does not support the QUIC version specified in the client configuration
     #[error("unsupported QUIC version")]
     UnsupportedVersion,
 }


### PR DESCRIPTION
If the cryptographic layer supports a version not in the local endpoint's supported versions list, a connection was initiated but all packets returned by a compatible peer were dropped. This is a relatively easy configuration error to make.

Fixes #1481.