### PR TITLE
[WIP] Introducing conformance testing crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
-members = ["quinn", "quinn-proto", "quinn-udp", "bench", "perf", "fuzz"]
-default-members = ["quinn", "quinn-proto", "quinn-udp", "bench", "perf"]
+members = ["quinn", "quinn-proto", "quinn-test", "quinn-udp", "quinn-visibility", "bench", "perf", "fuzz"]
+default-members = ["quinn", "quinn-proto", "quinn-test", "quinn-udp", "quinn-visibility", "bench", "perf"]
 
 [profile.bench]
 debug = true

--- a/perf/src/noprotection.rs
+++ b/perf/src/noprotection.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::sync::Arc;
 
 use bytes::BytesMut;
@@ -129,6 +130,10 @@ impl crypto::ClientConfig for NoProtectionClientConfig {
 
         Ok(Box::new(NoProtectionSession::new(tls)))
     }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl crypto::ServerConfig for NoProtectionServerConfig {
@@ -153,6 +158,10 @@ impl crypto::ServerConfig for NoProtectionServerConfig {
         let tls = self.inner.clone().start_session(version, params);
 
         Box::new(NoProtectionSession::new(tls))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -23,10 +23,12 @@ tls-rustls = ["rustls", "webpki", "ring"]
 native-certs = ["rustls-native-certs"]
 # Write logs via the `log` crate when no `tracing` subscriber exists
 log = ["tracing/log"]
+integration-tests = []
 
 [dependencies]
 arbitrary = { version = "1.0.1", features = ["derive"], optional = true }
 bytes = "1"
+quinn-visibility = { path = "../quinn-visibility" }
 rustc-hash = "1.1"
 rand = "0.8"
 ring = { version = "0.16.7", optional = true }
@@ -41,6 +43,7 @@ webpki = { version = "0.22", default-features = false, optional = true }
 [dev-dependencies]
 assert_matches = "1.1"
 hex-literal = "0.3.0"
+quinn-test = { path = "../quinn-test" }
 rcgen = "0.10.0"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
 lazy_static = "1"

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -24,6 +24,7 @@ use crate::{
 /// for higher bandwidths and latencies increases worst-case memory consumption, but does not impair
 /// performance at lower bandwidths and latencies. The default configuration is tuned for a 100Mbps
 /// link with a 100ms round trip time.
+#[cfg_attr(any(test, feature = "integration-tests"), quinn_visibility::make(pub))]
 pub struct TransportConfig {
     pub(crate) max_concurrent_bidi_streams: VarInt,
     pub(crate) max_concurrent_uni_streams: VarInt,
@@ -320,6 +321,7 @@ impl fmt::Debug for TransportConfig {
 ///
 /// Default values should be suitable for most internet applications.
 #[derive(Clone)]
+#[cfg_attr(any(test, feature = "integration-tests"), quinn_visibility::make(pub))]
 pub struct EndpointConfig {
     pub(crate) reset_key: Arc<dyn HmacKey>,
     pub(crate) max_udp_payload_size: VarInt,
@@ -439,6 +441,7 @@ impl Default for EndpointConfig {
 ///
 /// Default values should be suitable for most internet applications.
 #[derive(Clone)]
+#[cfg_attr(any(test, feature = "integration-tests"), quinn_visibility::make(pub))]
 pub struct ServerConfig {
     /// Transport configuration to use for incoming connections
     pub transport: Arc<TransportConfig>,

--- a/quinn-proto/src/connection/cid_state.rs
+++ b/quinn-proto/src/connection/cid_state.rs
@@ -182,7 +182,6 @@ impl CidState {
         self.retire_seq
     }
 
-    #[cfg(test)]
     pub(crate) fn active_seq(&self) -> (u64, u64) {
         let mut min = u64::MAX;
         let mut max = u64::MIN;
@@ -197,7 +196,6 @@ impl CidState {
         (min, max)
     }
 
-    #[cfg(test)]
     pub(crate) fn assign_retire_seq(&mut self, v: u64) -> u64 {
         // Cannot retire more CIDs than what have been issued
         debug_assert!(v <= *self.active_seq.iter().max().unwrap() + 1);

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3066,13 +3066,13 @@ impl Connection {
 
     /// The number of bytes of packets containing retransmittable frames that have not been
     /// acknowledged or declared lost.
-    #[cfg(test)]
+    #[cfg_attr(feature = "integration-tests", quinn_visibility::make(pub))]
     pub(crate) fn bytes_in_flight(&self) -> u64 {
         self.in_flight.bytes
     }
 
     /// Number of bytes worth of non-ack-only packets that may be sent
-    #[cfg(test)]
+    #[cfg_attr(feature = "integration-tests", quinn_visibility::make(pub))]
     pub(crate) fn congestion_window(&self) -> u64 {
         self.path
             .congestion
@@ -3081,7 +3081,7 @@ impl Connection {
     }
 
     /// Whether no timers but keepalive, idle and pushnewcid are running
-    #[cfg(test)]
+    #[cfg_attr(feature = "integration-tests", quinn_visibility::make(pub))]
     pub(crate) fn is_idle(&self) -> bool {
         Timer::VALUES
             .iter()
@@ -3092,40 +3092,40 @@ impl Connection {
     }
 
     /// Total number of outgoing packets that have been deemed lost
-    #[cfg(test)]
+    #[cfg_attr(feature = "integration-tests", quinn_visibility::make(pub))]
     pub(crate) fn lost_packets(&self) -> u64 {
         self.lost_packets
     }
 
     /// Whether explicit congestion notification is in use on outgoing packets.
-    #[cfg(test)]
-    pub(crate) fn using_ecn(&self) -> bool {
+    #[cfg(any(test, feature = "integration-tests"))]
+    pub fn using_ecn(&self) -> bool {
         self.path.sending_ecn
     }
 
     /// The number of received bytes in the current path
-    #[cfg(test)]
-    pub(crate) fn total_recvd(&self) -> u64 {
+    #[cfg(any(test, feature = "integration-tests"))]
+    pub fn total_recvd(&self) -> u64 {
         self.path.total_recvd
     }
 
-    #[cfg(test)]
-    pub(crate) fn active_local_cid_seq(&self) -> (u64, u64) {
+    #[cfg(any(test, feature = "integration-tests"))]
+    pub fn active_local_cid_seq(&self) -> (u64, u64) {
         self.local_cid_state.active_seq()
     }
 
     /// Instruct the peer to replace previously issued CIDs by sending a NEW_CONNECTION_ID frame
     /// with updated `retire_prior_to` field set to `v`
-    #[cfg(test)]
-    pub(crate) fn rotate_local_cid(&mut self, v: u64, now: Instant) {
+    #[cfg(any(test, feature = "integration-tests"))]
+    pub fn rotate_local_cid(&mut self, v: u64, now: Instant) {
         let n = self.local_cid_state.assign_retire_seq(v);
         self.endpoint_events
             .push_back(EndpointEventInner::NeedIdentifiers(now, n));
     }
 
     /// Check the current active remote CID sequence
-    #[cfg(test)]
-    pub(crate) fn active_rem_cid_seq(&self) -> u64 {
+    #[cfg(any(test, feature = "integration-tests"))]
+    pub fn active_rem_cid_seq(&self) -> u64 {
         self.rem_cids.active_seq()
     }
 

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -56,7 +56,8 @@ pub trait Session: Send + 'static {
     ///
     /// This should be called with the contents of `CRYPTO` frames. If it returns `Ok`, the
     /// caller should call `write_handshake()` to check if the crypto protocol has anything
-    /// to send to the peer.
+    /// to send to the peer. This method will only return `true` the first time that
+    /// handshake data is available. Future calls will always return false.
     ///
     /// On success, returns `true` iff `self.handshake_data()` has been populated.
     fn read_handshake(&mut self, buf: &[u8]) -> Result<bool, TransportError>;
@@ -117,6 +118,9 @@ pub trait ClientConfig: Send + Sync {
         server_name: &str,
         params: &TransportParameters,
     ) -> Result<Box<dyn Session>, ConnectError>;
+
+    /// Returns Self for use in down-casting to extract implementation details.
+    fn as_any(&self) -> &dyn Any;
 }
 
 /// Server-side configuration for the crypto protocol
@@ -142,6 +146,9 @@ pub trait ServerConfig: Send + Sync {
         version: u32,
         params: &TransportParameters,
     ) -> Box<dyn Session>;
+
+    /// Returns Self for use in down-casting to extract implementation details
+    fn as_any(&self) -> &dyn Any;
 }
 
 /// Keys used to protect packet payloads

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -265,6 +265,10 @@ impl crypto::ClientConfig for rustls::ClientConfig {
             ),
         }))
     }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl crypto::ServerConfig for rustls::ServerConfig {
@@ -316,6 +320,10 @@ impl crypto::ServerConfig for rustls::ServerConfig {
         let mut result = [0; 16];
         result.copy_from_slice(tag.as_ref());
         result
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -712,8 +712,8 @@ impl Endpoint {
         &self.config
     }
 
-    #[cfg(test)]
-    pub(crate) fn known_connections(&self) -> usize {
+    #[cfg(any(test, feature = "integration-tests"))]
+    pub fn known_connections(&self) -> usize {
         let x = self.connections.len();
         debug_assert_eq!(x, self.connection_ids_initial.len());
         // Not all connections have known reset tokens
@@ -723,8 +723,8 @@ impl Endpoint {
         x
     }
 
-    #[cfg(test)]
-    pub(crate) fn known_cids(&self) -> usize {
+    #[cfg(any(test, feature = "integration-tests"))]
+    pub fn known_cids(&self) -> usize {
         self.connection_ids.len()
     }
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1,25 +1,30 @@
-use std::{
-    convert::TryInto,
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
-    sync::Arc,
-    time::{Duration, Instant},
-};
-
-use assert_matches::assert_matches;
-use bytes::Bytes;
-use hex_literal::hex;
-use rand::RngCore;
-use ring::hmac;
-use rustls::internal::msgs::enums::AlertDescription;
-use tracing::info;
+mod util;
 
 use super::*;
 use crate::{
     cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator},
     frame::FrameStruct,
 };
-mod util;
+use assert_matches::assert_matches;
+use bytes::Bytes;
+use hex_literal::hex;
+use quinn_test::rustls::suite;
+use rand::RngCore;
+use ring::hmac;
+use rustls::internal::msgs::enums::AlertDescription;
+use std::{
+    convert::TryInto,
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tracing::info;
 use util::*;
+
+#[test]
+fn example() {
+    suite().lifecycle()
+}
 
 #[test]
 fn version_negotiate_server() {

--- a/quinn-proto/src/transport_error.rs
+++ b/quinn-proto/src/transport_error.rs
@@ -49,6 +49,7 @@ pub struct Code(u64);
 
 impl Code {
     /// Create QUIC error code from TLS alert code
+    #[cfg_attr(any(test, feature = "integration-tests"), quinn_visibility::make(pub))]
     pub(crate) fn crypto(code: u8) -> Self {
         Code(0x100 | u64::from(code))
     }

--- a/quinn-proto/src/varint.rs
+++ b/quinn-proto/src/varint.rs
@@ -17,6 +17,10 @@ use arbitrary::Arbitrary;
 pub struct VarInt(pub(crate) u64);
 
 impl VarInt {
+    /// An error used for integration testing.
+    #[cfg(any(test, feature = "integration-tests"))]
+    pub const TEST_ERROR: VarInt = VarInt(42);
+
     /// The largest representable value
     pub const MAX: VarInt = VarInt((1 << 62) - 1);
     /// The largest encoded value length

--- a/quinn-test/Cargo.toml
+++ b/quinn-test/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "quinn-test"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/quinn-rs/quinn"
+description = "Conformance testing library for quinn and crypto providers"
+keywords = ["quic"]
+categories = ["network-programming", "asynchronous"]
+workspace = ".."
+edition = "2021"
+rust-version = "1.59"
+
+[dependencies]
+assert_matches = "1.5.0"
+bytes = "1"
+hex-literal = "0.3.0"
+lazy_static = "1.4.0"
+quinn-proto = { path = "../quinn-proto", features = ["integration-tests"] }
+rand = "0.8"
+rcgen = "0.10.0"
+ring = { version = "0.16.7" }
+rustls = { version = "0.20.4", default-features = false, features = ["quic"] }
+tracing = "0.1.10"
+tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
+

--- a/quinn-test/src/cert.rs
+++ b/quinn-test/src/cert.rs
@@ -1,0 +1,58 @@
+use lazy_static::lazy_static;
+use rcgen::{BasicConstraints, CertificateParams, IsCa};
+
+/// Certificate Authority utility that can create new leaf certs.
+pub struct Ca(rcgen::Certificate);
+
+impl Ca {
+    /// Creates a new CA.
+    pub fn new() -> Self {
+        let mut params = CertificateParams::new(&[] as &[String]);
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        Self(rcgen::Certificate::from_params(params).unwrap())
+    }
+
+    /// Gets this CA's certificate.
+    pub fn cert(&self) -> Vec<u8> {
+        self.0.serialize_der().unwrap()
+    }
+
+    /// Creates a new leaf cert signed by this CA.
+    pub fn new_leaf(&self, subject_alt_names: impl Into<Vec<String>>) -> Leaf {
+        let cert = rcgen::generate_simple_self_signed(subject_alt_names).unwrap();
+        let private_key = cert.serialize_private_key_der();
+        let cert = cert.serialize_der_with_signer(&self.0).unwrap();
+        Leaf {
+            private_key,
+            chain: vec![cert, self.cert()],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Leaf {
+    /// The certificate chain, starting with the leaf certificate and ending with the root CA.
+    pub chain: Vec<Vec<u8>>,
+    pub private_key: Vec<u8>,
+}
+
+impl Leaf {
+    pub fn new() -> Self {
+        Self {
+            chain: Vec::new(),
+            private_key: Vec::new(),
+        }
+    }
+}
+
+lazy_static! {
+    pub static ref CA: Ca = Ca::new();
+    pub static ref SERVER_CERT: Leaf = CA.new_leaf(vec!["localhost".into()]);
+    pub static ref CLIENT_CERT: Leaf = CA.new_leaf(vec!["client.com".into()]);
+
+    /// Generate a big fat certificate that can't fit inside the initial anti-amplification limit
+    pub static ref BIG_CERT: Leaf = CA.new_leaf(Some("localhost".into())
+            .into_iter()
+            .chain((0..1000).map(|x| format!("foo_{}", x)))
+            .collect::<Vec<_>>());
+}

--- a/quinn-test/src/endpoint.rs
+++ b/quinn-test/src/endpoint.rs
@@ -1,0 +1,375 @@
+use crate::{min_opt, split_transmit, CLIENT_PORTS, SERVER_PORTS};
+use assert_matches::assert_matches;
+use quinn_proto::{
+    ClientConfig, Connection, ConnectionEvent, ConnectionHandle, DatagramEvent, Datagrams,
+    EcnCodepoint, Endpoint, EndpointConfig, EndpointEvent, Event, RecvStream, SendStream,
+    ServerConfig, StreamId, Streams, Transmit,
+};
+use std::collections::{HashMap, VecDeque};
+use std::io::Write;
+use std::net::{Ipv6Addr, SocketAddr, UdpSocket};
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use std::{env, io, mem, str};
+use tracing::{info, info_span, trace};
+
+/// The maximum of datagrams TestEndpoint will produce via `poll_transmit`
+const MAX_DATAGRAMS: usize = 10;
+
+pub struct Pair {
+    pub server: TestEndpoint,
+    pub client: TestEndpoint,
+    pub time: Instant,
+    // One-way
+    pub latency: Duration,
+    /// Number of spin bit flips
+    pub spins: u64,
+    last_spin: bool,
+}
+
+impl Pair {
+    pub fn new(endpoint_config: Arc<EndpointConfig>, server_config: Arc<ServerConfig>) -> Self {
+        let server = Endpoint::new(endpoint_config.clone(), Some(server_config));
+        let client = Endpoint::new(endpoint_config, None);
+
+        Pair::new_from_endpoint(client, server)
+    }
+
+    pub fn new_from_endpoint(client: Endpoint, server: Endpoint) -> Self {
+        let server_addr = SocketAddr::new(
+            Ipv6Addr::LOCALHOST.into(),
+            SERVER_PORTS.lock().unwrap().next().unwrap(),
+        );
+        let client_addr = SocketAddr::new(
+            Ipv6Addr::LOCALHOST.into(),
+            CLIENT_PORTS.lock().unwrap().next().unwrap(),
+        );
+        Self {
+            server: TestEndpoint::new(server, server_addr),
+            client: TestEndpoint::new(client, client_addr),
+            time: Instant::now(),
+            latency: Duration::new(0, 0),
+            spins: 0,
+            last_spin: false,
+        }
+    }
+
+    /// Returns whether the connection is not idle
+    pub fn step(&mut self) -> bool {
+        self.drive_client();
+        self.drive_server();
+        if self.client.is_idle() && self.server.is_idle() {
+            return false;
+        }
+
+        let client_t = self.client.next_wakeup();
+        let server_t = self.server.next_wakeup();
+        match min_opt(client_t, server_t) {
+            Some(t) if Some(t) == client_t => {
+                if t != self.time {
+                    self.time = self.time.max(t);
+                    trace!("advancing to {:?} for client", self.time);
+                }
+                true
+            }
+            Some(t) if Some(t) == server_t => {
+                if t != self.time {
+                    self.time = self.time.max(t);
+                    trace!("advancing to {:?} for server", self.time);
+                }
+                true
+            }
+            Some(_) => unreachable!(),
+            None => false,
+        }
+    }
+
+    /// Advance time until both connections are idle
+    pub fn drive(&mut self) {
+        while self.step() {}
+    }
+
+    pub fn drive_client(&mut self) {
+        let span = info_span!("client");
+        let _guard = span.enter();
+        self.client.drive(self.time, self.server.addr);
+        for x in self.client.outbound.drain(..) {
+            const LONG_HEADER_FORM: u8 = 0x80;
+            const SPIN_BIT: u8 = 0x20;
+            if x.contents[0] & LONG_HEADER_FORM == 0 {
+                let spin = x.contents[0] & SPIN_BIT != 0;
+                self.spins += (spin == self.last_spin) as u64;
+                self.last_spin = spin;
+            }
+            if let Some(ref socket) = self.client.socket {
+                socket.send_to(&x.contents, x.destination).unwrap();
+            }
+            if self.server.addr == x.destination {
+                self.server
+                    .inbound
+                    .push_back((self.time + self.latency, x.ecn, x.contents));
+            }
+        }
+    }
+
+    pub fn drive_server(&mut self) {
+        let span = info_span!("server");
+        let _guard = span.enter();
+        self.server.drive(self.time, self.client.addr);
+        for x in self.server.outbound.drain(..) {
+            if let Some(ref socket) = self.server.socket {
+                socket.send_to(&x.contents, x.destination).unwrap();
+            }
+            if self.client.addr == x.destination {
+                self.client
+                    .inbound
+                    .push_back((self.time + self.latency, x.ecn, x.contents));
+            }
+        }
+    }
+
+    pub fn connect(&mut self, config: ClientConfig) -> (ConnectionHandle, ConnectionHandle) {
+        info!("connecting");
+        let client_ch = self.begin_connect(config);
+        self.drive();
+        let server_ch = self.server.assert_accept();
+        self.finish_connect(client_ch, server_ch);
+        (client_ch, server_ch)
+    }
+
+    /// Just start connecting the client
+    pub fn begin_connect(&mut self, config: ClientConfig) -> ConnectionHandle {
+        let span = info_span!("client");
+        let _guard = span.enter();
+        let (client_ch, client_conn) = self
+            .client
+            .connect(config, self.server.addr, "localhost")
+            .unwrap();
+        self.client.connections.insert(client_ch, client_conn);
+        client_ch
+    }
+
+    fn finish_connect(&mut self, client_ch: ConnectionHandle, server_ch: ConnectionHandle) {
+        assert_matches!(
+            self.client_conn_mut(client_ch).poll(),
+            Some(Event::HandshakeDataReady)
+        );
+        assert_matches!(
+            self.client_conn_mut(client_ch).poll(),
+            Some(Event::Connected { .. })
+        );
+        assert_matches!(
+            self.server_conn_mut(server_ch).poll(),
+            Some(Event::HandshakeDataReady)
+        );
+        assert_matches!(
+            self.server_conn_mut(server_ch).poll(),
+            Some(Event::Connected { .. })
+        );
+    }
+
+    pub fn client_conn_mut(&mut self, ch: ConnectionHandle) -> &mut Connection {
+        self.client.connections.get_mut(&ch).unwrap()
+    }
+
+    pub fn client_streams(&mut self, ch: ConnectionHandle) -> Streams<'_> {
+        self.client_conn_mut(ch).streams()
+    }
+
+    pub fn client_send(&mut self, ch: ConnectionHandle, s: StreamId) -> SendStream<'_> {
+        self.client_conn_mut(ch).send_stream(s)
+    }
+
+    pub fn client_recv(&mut self, ch: ConnectionHandle, s: StreamId) -> RecvStream<'_> {
+        self.client_conn_mut(ch).recv_stream(s)
+    }
+
+    pub fn client_datagrams(&mut self, ch: ConnectionHandle) -> Datagrams<'_> {
+        self.client_conn_mut(ch).datagrams()
+    }
+
+    pub fn server_conn_mut(&mut self, ch: ConnectionHandle) -> &mut Connection {
+        self.server.connections.get_mut(&ch).unwrap()
+    }
+
+    pub fn server_streams(&mut self, ch: ConnectionHandle) -> Streams<'_> {
+        self.server_conn_mut(ch).streams()
+    }
+
+    pub fn server_send(&mut self, ch: ConnectionHandle, s: StreamId) -> SendStream<'_> {
+        self.server_conn_mut(ch).send_stream(s)
+    }
+
+    pub fn server_recv(&mut self, ch: ConnectionHandle, s: StreamId) -> RecvStream<'_> {
+        self.server_conn_mut(ch).recv_stream(s)
+    }
+
+    pub fn server_datagrams(&mut self, ch: ConnectionHandle) -> Datagrams<'_> {
+        self.server_conn_mut(ch).datagrams()
+    }
+}
+
+pub struct TestEndpoint {
+    pub endpoint: Endpoint,
+    pub addr: SocketAddr,
+    socket: Option<UdpSocket>,
+    timeout: Option<Instant>,
+    pub outbound: VecDeque<Transmit>,
+    delayed: VecDeque<Transmit>,
+    pub inbound: VecDeque<(Instant, Option<EcnCodepoint>, Vec<u8>)>,
+    accepted: Option<ConnectionHandle>,
+    pub connections: HashMap<ConnectionHandle, Connection>,
+    conn_events: HashMap<ConnectionHandle, VecDeque<ConnectionEvent>>,
+}
+
+impl TestEndpoint {
+    fn new(endpoint: Endpoint, addr: SocketAddr) -> Self {
+        let socket = if env::var_os("SSLKEYLOGFILE").is_some() {
+            let socket = UdpSocket::bind(addr).expect("failed to bind UDP socket");
+            socket
+                .set_read_timeout(Some(Duration::new(0, 10_000_000)))
+                .unwrap();
+            Some(socket)
+        } else {
+            None
+        };
+        Self {
+            endpoint,
+            addr,
+            socket,
+            timeout: None,
+            outbound: VecDeque::new(),
+            delayed: VecDeque::new(),
+            inbound: VecDeque::new(),
+            accepted: None,
+            connections: HashMap::default(),
+            conn_events: HashMap::default(),
+        }
+    }
+
+    pub fn drive(&mut self, now: Instant, remote: SocketAddr) {
+        if let Some(ref socket) = self.socket {
+            loop {
+                let mut buf = [0; 8192];
+                if socket.recv_from(&mut buf).is_err() {
+                    break;
+                }
+            }
+        }
+
+        while self.inbound.front().map_or(false, |x| x.0 <= now) {
+            let (recv_time, ecn, packet) = self.inbound.pop_front().unwrap();
+            if let Some((ch, event)) =
+                self.endpoint
+                    .handle(recv_time, remote, None, ecn, packet.as_slice().into())
+            {
+                match event {
+                    DatagramEvent::NewConnection(conn) => {
+                        self.connections.insert(ch, conn);
+                        self.accepted = Some(ch);
+                    }
+                    DatagramEvent::ConnectionEvent(event) => {
+                        self.conn_events
+                            .entry(ch)
+                            .or_insert_with(VecDeque::new)
+                            .push_back(event);
+                    }
+                }
+            }
+        }
+
+        while let Some(x) = self.poll_transmit() {
+            self.outbound.extend(split_transmit(x));
+        }
+
+        let mut endpoint_events: Vec<(ConnectionHandle, EndpointEvent)> = vec![];
+        for (ch, conn) in self.connections.iter_mut() {
+            if self.timeout.map_or(false, |x| x <= now) {
+                self.timeout = None;
+                conn.handle_timeout(now);
+            }
+
+            for (_, mut events) in self.conn_events.drain() {
+                for event in events.drain(..) {
+                    conn.handle_event(event);
+                }
+            }
+
+            while let Some(event) = conn.poll_endpoint_events() {
+                endpoint_events.push((*ch, event));
+            }
+
+            while let Some(x) = conn.poll_transmit(now, MAX_DATAGRAMS) {
+                self.outbound.extend(split_transmit(x));
+            }
+            self.timeout = conn.poll_timeout();
+        }
+
+        for (ch, event) in endpoint_events {
+            if let Some(event) = self.handle_event(ch, event) {
+                if let Some(conn) = self.connections.get_mut(&ch) {
+                    conn.handle_event(event);
+                }
+            }
+        }
+    }
+
+    pub fn next_wakeup(&self) -> Option<Instant> {
+        let next_inbound = self.inbound.front().map(|x| x.0);
+        min_opt(self.timeout, next_inbound)
+    }
+
+    fn is_idle(&self) -> bool {
+        self.connections.values().all(|x| x.is_idle())
+    }
+
+    pub fn delay_outbound(&mut self) {
+        assert!(self.delayed.is_empty());
+        mem::swap(&mut self.delayed, &mut self.outbound);
+    }
+
+    pub fn finish_delay(&mut self) {
+        self.outbound.extend(self.delayed.drain(..));
+    }
+
+    pub fn assert_accept(&mut self) -> ConnectionHandle {
+        self.accepted.take().expect("server didn't connect")
+    }
+}
+
+impl Deref for TestEndpoint {
+    type Target = Endpoint;
+    fn deref(&self) -> &Endpoint {
+        &self.endpoint
+    }
+}
+
+impl DerefMut for TestEndpoint {
+    fn deref_mut(&mut self) -> &mut Endpoint {
+        &mut self.endpoint
+    }
+}
+
+pub fn subscribe() -> tracing::subscriber::DefaultGuard {
+    let sub = tracing_subscriber::FmtSubscriber::builder()
+        .with_max_level(tracing::Level::TRACE)
+        .with_writer(|| TestWriter)
+        .finish();
+    tracing::subscriber::set_default(sub)
+}
+
+struct TestWriter;
+
+impl Write for TestWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        print!(
+            "{}",
+            str::from_utf8(buf).expect("tried to log invalid UTF-8")
+        );
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        io::stdout().flush()
+    }
+}

--- a/quinn-test/src/lib.rs
+++ b/quinn-test/src/lib.rs
@@ -1,0 +1,150 @@
+pub mod cert;
+pub mod rustls;
+pub mod suite;
+
+mod endpoint;
+
+use lazy_static::lazy_static;
+use quinn_proto::{crypto, Transmit};
+use std::cmp;
+use std::ops::RangeFrom;
+use std::sync::{Arc, Mutex};
+
+/// Configuration for client-side endpoints.
+pub struct ClientConfig {
+    /// The certificate for the client.
+    pub cert: cert::Leaf,
+
+    /// The list of allowed peers for validation.
+    pub allowed_peers: Vec<cert::Leaf>,
+
+    /// The ALPN protocols offered by the client.
+    pub alpn_protocols: Vec<Vec<u8>>,
+
+    /// If true, the client will present its certificate to the server.
+    pub enable_client_auth: bool,
+}
+
+// impl ClientConfig {
+//     pub fn new() -> Self {
+//         Self {
+//             cert: cert::Leaf::new(),
+//             allowed_peers: Vec::new(),
+//             alpn_protocols: Vec::new(),
+//             enable_client_auth: false,
+//         }
+//     }
+// }
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        Self {
+            cert: cert::CLIENT_CERT.clone(),
+            allowed_peers: vec![cert::SERVER_CERT.clone()],
+            alpn_protocols: default_alpn(),
+            enable_client_auth: false,
+        }
+    }
+}
+
+/// Configuration for server-side endpoints.
+pub struct ServerConfig {
+    /// The certificate for the server.
+    pub cert: cert::Leaf,
+
+    /// The ALPN protocols accepted by the server.
+    pub alpn_protocols: Vec<Vec<u8>>,
+
+    /// If true, the server will verify the certificate presented by the client against
+    /// the value in [allowed_peers].
+    pub enable_client_auth: bool,
+
+    /// The list of allowed peers for validation. Only used if [enable_client_auth] is `true`.
+    pub allowed_peers: Vec<cert::Leaf>,
+}
+
+// impl ServerConfig {
+//     pub fn new() -> Self {
+//         Self {
+//             cert: cert::Leaf::new(),
+//             allowed_peers: Vec::new(),
+//             alpn_protocols: Vec::new(),
+//             enable_client_auth: false,
+//         }
+//     }
+// }
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            cert: cert::SERVER_CERT.clone(),
+            allowed_peers: vec![cert::CLIENT_CERT.clone()],
+            alpn_protocols: default_alpn(),
+            enable_client_auth: false,
+        }
+    }
+}
+
+/// A provider for crypto config for client and server test endpoints.
+pub trait CryptoProvider {
+    /// Creates the crypto config for a client-side endpoint.
+    fn new_client(&self, cfg: ClientConfig) -> Box<dyn crypto::ClientConfig>;
+
+    /// Creates the crypto config for a client-side endpoint. The generated
+    /// config reuses the same underlying session cache from the previous configuration.
+    fn new_client_reuse_session(
+        &self,
+        cfg: ClientConfig,
+        prev: &Box<dyn crypto::ClientConfig>,
+    ) -> Box<dyn crypto::ClientConfig>;
+
+    /// Creates the crypto config for a server-side endpoint.
+    fn new_server(&self, cfg: ServerConfig) -> Box<dyn crypto::ServerConfig>;
+
+    /// Creates a new random HMAC key.
+    fn new_hmac_key(&self) -> Arc<dyn crypto::HmacKey>;
+}
+
+pub(crate) fn default_alpn() -> Vec<Vec<u8>> {
+    vec![b"h3".to_vec()]
+}
+
+pub(crate) fn min_opt<T: Ord>(x: Option<T>, y: Option<T>) -> Option<T> {
+    match (x, y) {
+        (Some(x), Some(y)) => Some(cmp::min(x, y)),
+        (Some(x), _) => Some(x),
+        (_, Some(y)) => Some(y),
+        _ => None,
+    }
+}
+
+pub(crate) fn split_transmit(transmit: Transmit) -> Vec<Transmit> {
+    let segment_size = match transmit.segment_size {
+        Some(segment_size) => segment_size,
+        _ => return vec![transmit],
+    };
+
+    let mut offset = 0;
+    let mut transmits = Vec::new();
+    while offset < transmit.contents.len() {
+        let end = (offset + segment_size).min(transmit.contents.len());
+
+        let contents = transmit.contents[offset..end].to_vec();
+        transmits.push(Transmit {
+            destination: transmit.destination,
+            ecn: transmit.ecn,
+            contents,
+            segment_size: None,
+            src_ip: transmit.src_ip,
+        });
+
+        offset = end;
+    }
+
+    transmits
+}
+
+lazy_static! {
+    pub(crate) static ref SERVER_PORTS: Mutex<RangeFrom<u16>> = Mutex::new(4433..);
+    pub(crate) static ref CLIENT_PORTS: Mutex<RangeFrom<u16>> = Mutex::new(44433..);
+}

--- a/quinn-test/src/rustls.rs
+++ b/quinn-test/src/rustls.rs
@@ -1,0 +1,134 @@
+use crate::cert::Leaf;
+use crate::suite::Suite;
+use crate::{ClientConfig, CryptoProvider, ServerConfig};
+use quinn_proto::crypto;
+use rand::RngCore;
+use ring;
+use std::sync::Arc;
+
+/// Creates a new rustls-based [CryptoProvider]
+pub fn new_provider() -> Arc<dyn CryptoProvider> {
+    Arc::new(RustlsProvider())
+}
+
+/// Creates a new test [Suite] that uses the rustls [CryptoProvider] for both client and server.
+pub fn suite() -> Suite {
+    Suite::new(new_provider(), new_provider())
+}
+
+struct RustlsProvider();
+
+impl CryptoProvider for RustlsProvider {
+    fn new_client(&self, cfg: ClientConfig) -> Box<dyn crypto::ClientConfig> {
+        Box::new(new_rustls_client(cfg))
+    }
+
+    fn new_client_reuse_session(
+        &self,
+        cfg: ClientConfig,
+        prev: &Box<dyn crypto::ClientConfig>,
+    ) -> Box<dyn crypto::ClientConfig> {
+        let prev = prev
+            .as_any()
+            .downcast_ref::<rustls::ClientConfig>()
+            .unwrap();
+        let mut out = new_rustls_client(cfg);
+        out.session_storage = prev.session_storage.clone();
+        Box::new(out)
+    }
+
+    fn new_server(&self, cfg: ServerConfig) -> Box<dyn crypto::ServerConfig> {
+        Box::new(new_rustls_server(cfg))
+    }
+
+    fn new_hmac_key(&self) -> Arc<dyn crypto::HmacKey> {
+        Arc::new(new_ring_hmac_key())
+    }
+}
+
+/// Underlying method for creating the crypto configuration.
+pub fn new_rustls_client(in_: ClientConfig) -> rustls::ClientConfig {
+    // Create the cert store containing the server certs.
+    let mut server_certs = rustls::RootCertStore::empty();
+    for allowed_cert in peer_certs(in_.allowed_peers) {
+        server_certs.add(&allowed_cert).unwrap();
+    }
+
+    let builder = rustls::ClientConfig::builder()
+        .with_safe_default_cipher_suites()
+        .with_safe_default_kx_groups()
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap()
+        .with_root_certificates(server_certs);
+
+    let mut out = if in_.enable_client_auth {
+        let key = rustls::PrivateKey(in_.cert.private_key.clone());
+        let mut certs = Vec::new();
+        for cert in in_.cert.chain {
+            certs.push(rustls::Certificate(cert.clone()));
+        }
+        builder.with_single_cert(certs, key).unwrap()
+    } else {
+        builder.with_no_client_auth()
+    };
+
+    out.key_log = Arc::new(rustls::KeyLogFile::new());
+    out.alpn_protocols = in_.alpn_protocols;
+    out.enable_early_data = true;
+    out
+}
+
+pub fn new_rustls_server(in_: ServerConfig) -> rustls::ServerConfig {
+    let key = rustls::PrivateKey(in_.cert.private_key);
+    let mut certs = Vec::new();
+    for cert in in_.cert.chain {
+        certs.push(rustls::Certificate(cert.clone()));
+    }
+    let mut out = if in_.enable_client_auth {
+        rustls::ServerConfig::builder()
+            .with_safe_default_cipher_suites()
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .unwrap()
+            .with_client_cert_verifier({
+                let mut store = rustls::RootCertStore::empty();
+                for allowed_cert in peer_certs(in_.allowed_peers) {
+                    store.add(&allowed_cert).unwrap();
+                }
+                rustls::server::AllowAnyAuthenticatedClient::new(store)
+            })
+            .with_single_cert(certs, key)
+            .unwrap()
+    } else {
+        // Client auth is disabled: allow all clients.
+        let mut out = rustls::ServerConfig::builder()
+            .with_safe_default_cipher_suites()
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .unwrap()
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .unwrap();
+        out.max_early_data_size = u32::MAX;
+        out
+    };
+    out.alpn_protocols = in_.alpn_protocols;
+    out
+}
+
+pub fn new_ring_hmac_key() -> ring::hmac::Key {
+    let mut reset_key = vec![0; 64];
+    let mut rng = rand::thread_rng();
+    rng.fill_bytes(&mut reset_key);
+    ring::hmac::Key::new(ring::hmac::HMAC_SHA256, &reset_key)
+}
+
+fn peer_certs(peers: Vec<Leaf>) -> Vec<rustls::Certificate> {
+    let mut out = Vec::new();
+    for allowed_peer in peers {
+        for cert in allowed_peer.chain {
+            out.push(rustls::Certificate(cert.clone()));
+        }
+    }
+    out
+}

--- a/quinn-visibility/Cargo.toml
+++ b/quinn-visibility/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "quinn-visibility"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0"

--- a/quinn-visibility/src/lib.rs
+++ b/quinn-visibility/src/lib.rs
@@ -1,0 +1,54 @@
+use proc_macro::TokenStream;
+use syn::__private::ToTokens;
+use syn::{
+    parse_macro_input, Error, Item, ItemConst, ItemEnum, ItemExternCrate, ItemFn, ItemMacro2,
+    ItemMod, ItemStatic, ItemStruct, ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse,
+    Visibility,
+};
+
+/// A modified version of the macro from https://github.com/danielhenrymantilla/visibility.rs
+/// (https://crates.io/crates/visibility). This version of the macro will automatically apply
+/// struct visibility to its fields. This is useful for testing, since struct construction
+/// requires that all fields are visible at the call site.
+#[proc_macro_attribute]
+pub fn make(attrs: TokenStream, input: TokenStream) -> TokenStream {
+    let visibility: Visibility = parse_macro_input!(attrs);
+    let mut input: Item = parse_macro_input!(input);
+
+    match input {
+        Item::Const(ItemConst { ref mut vis, .. }) => *vis = visibility,
+        Item::Enum(ItemEnum { ref mut vis, .. }) => *vis = visibility,
+        Item::ExternCrate(ItemExternCrate { ref mut vis, .. }) => *vis = visibility,
+        Item::Fn(ItemFn { ref mut vis, .. }) => *vis = visibility,
+        // Item::ForeignMod(ItemForeignMod { ref mut vis, .. }) => *vis = visibility,
+        // Item::Impl(ItemImpl { ref mut vis, .. }) => *vis = visibility,
+        // Item::Macro(ItemMacro { ref mut vis, .. }) => *vis = visibility,
+        Item::Macro2(ItemMacro2 { ref mut vis, .. }) => *vis = visibility,
+        Item::Mod(ItemMod { ref mut vis, .. }) => *vis = visibility,
+        Item::Static(ItemStatic { ref mut vis, .. }) => *vis = visibility,
+        Item::Struct(ItemStruct {
+            ref mut vis,
+            ref mut fields,
+            ..
+        }) => {
+            // Apply the visibility changes to all fields as well as the struct, itself.
+            *vis = visibility.clone();
+            for field in fields {
+                field.vis = visibility.clone();
+            }
+        }
+        Item::Trait(ItemTrait { ref mut vis, .. }) => *vis = visibility,
+        Item::TraitAlias(ItemTraitAlias { ref mut vis, .. }) => *vis = visibility,
+        Item::Type(ItemType { ref mut vis, .. }) => *vis = visibility,
+        Item::Union(ItemUnion { ref mut vis, .. }) => *vis = visibility,
+        Item::Use(ItemUse { ref mut vis, .. }) => *vis = visibility,
+        // Item::Verbatim(TokenStream { ref mut vis, .. }) => *vis = visibility,
+        _ => {
+            return Error::new_spanned(&input, "Cannot override the `#[visibility]` of this item")
+                .to_compile_error()
+                .into()
+        }
+    }
+
+    input.into_token_stream().into()
+}


### PR DESCRIPTION
Based on an idea proposed in #1488. Creates a separate crate for testing crypto providers. The new crate `quinn-test` contains a copy of the original testing code from `quinn-proto`, but refactored to introduce the idea of a `CryptoProvider` that is used to provide crypto client/server config for the endpoints. A `Suite` combines a client and server `CryptoProvider` and contains all of the testing methods.