### PR TITLE
Support external crypto implementations.

### DIFF
--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -56,7 +56,8 @@ pub trait Session: Send + 'static {
     ///
     /// This should be called with the contents of `CRYPTO` frames. If it returns `Ok`, the
     /// caller should call `write_handshake()` to check if the crypto protocol has anything
-    /// to send to the peer.
+    /// to send to the peer. This method will only return `true` the first time that
+    /// handshake data is available. Future calls will always return false.
     ///
     /// On success, returns `true` iff `self.handshake_data()` has been populated.
     fn read_handshake(&mut self, buf: &[u8]) -> Result<bool, TransportError>;

--- a/quinn-proto/src/transport_error.rs
+++ b/quinn-proto/src/transport_error.rs
@@ -49,7 +49,7 @@ pub struct Code(u64);
 
 impl Code {
     /// Create QUIC error code from TLS alert code
-    pub(crate) fn crypto(code: u8) -> Self {
+    pub fn crypto(code: u8) -> Self {
         Code(0x100 | u64::from(code))
     }
 }


### PR DESCRIPTION
These changes are needed for the BoringSSL crypto provider (#1488), which will reside in a separate repository.