### PR TITLE
docs(quinn): remove restriction to tokio

### DIFF
--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -1,4 +1,4 @@
-//! QUIC transport protocol support for Tokio
+//! QUIC transport protocol implementation
 //!
 //! [QUIC](https://en.wikipedia.org/wiki/QUIC) is a modern transport protocol addressing
 //! shortcomings of TCP, such as head-of-line blocking, poor security, slow handshakes, and


### PR DESCRIPTION
With https://github.com/quinn-rs/quinn/pull/1364 `quinn` is no longer restricted to `tokio`. Commit updates the crate heading accordingly.

Note that I don't feel strongly about this. Just a drive-by contribution.