### PR TITLE
Provider-based crypto tests 

### DIFF
--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -56,7 +56,8 @@ pub trait Session: Send + 'static {
     ///
     /// This should be called with the contents of `CRYPTO` frames. If it returns `Ok`, the
     /// caller should call `write_handshake()` to check if the crypto protocol has anything
-    /// to send to the peer.
+    /// to send to the peer. This method will only return `true` the first time that
+    /// handshake data is available. Future calls will always return false.
     ///
     /// On success, returns `true` iff `self.handshake_data()` has been populated.
     fn read_handshake(&mut self, buf: &[u8]) -> Result<bool, TransportError>;

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -71,7 +71,7 @@ mod cid_generator;
 pub use crate::cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator};
 
 mod token;
-use token::{ResetToken, RetryToken};
+pub use token::{ResetToken, RetryToken};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;

--- a/quinn-proto/src/tests/certs.rs
+++ b/quinn-proto/src/tests/certs.rs
@@ -1,0 +1,58 @@
+use lazy_static::lazy_static;
+use rcgen::{BasicConstraints, CertificateParams, IsCa};
+
+/// Certificate Authority utility that can create new leaf certs.
+pub struct Ca(rcgen::Certificate);
+
+impl Ca {
+    /// Creates a new CA.
+    pub fn new() -> Self {
+        let mut params = CertificateParams::new(&[] as &[String]);
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        Self(rcgen::Certificate::from_params(params).unwrap())
+    }
+
+    /// Gets this CA's certificate.
+    pub fn cert(&self) -> Vec<u8> {
+        self.0.serialize_der().unwrap()
+    }
+
+    /// Creates a new leaf cert signed by this CA.
+    pub fn new_leaf(&self, subject_alt_names: impl Into<Vec<String>>) -> Leaf {
+        let cert = rcgen::generate_simple_self_signed(subject_alt_names).unwrap();
+        let private_key = cert.serialize_private_key_der();
+        let cert = cert.serialize_der_with_signer(&self.0).unwrap();
+        Leaf {
+            private_key,
+            chain: vec![cert, self.cert()],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Leaf {
+    /// The certificate chain, starting with the leaf certificate and ending with the root CA.
+    pub chain: Vec<Vec<u8>>,
+    pub private_key: Vec<u8>,
+}
+
+impl Leaf {
+    pub fn new() -> Self {
+        Self {
+            chain: Vec::new(),
+            private_key: Vec::new(),
+        }
+    }
+}
+
+lazy_static! {
+    pub static ref CA: Ca = Ca::new();
+    pub static ref SERVER_CERT: Leaf = CA.new_leaf(vec!["localhost".into()]);
+    pub static ref CLIENT_CERT: Leaf = CA.new_leaf(vec!["client.com".into()]);
+
+    /// Generate a big fat certificate that can't fit inside the initial anti-amplification limit
+    pub static ref BIG_CERT: Leaf = CA.new_leaf(Some("localhost".into())
+            .into_iter()
+            .chain((0..1000).map(|x| format!("foo_{}", x)))
+            .collect::<Vec<_>>());
+}

--- a/quinn-proto/src/tests/provider.rs
+++ b/quinn-proto/src/tests/provider.rs
@@ -1,0 +1,94 @@
+use crate::crypto;
+use crate::tests::certs::{Leaf, CLIENT_CERT, SERVER_CERT};
+use crate::tests::provider_rustls::RustlsProvider;
+use std::any::Any;
+use std::sync::Arc;
+
+/// Return the [CryptoProvider] to be use for the client.
+pub fn client() -> Arc<dyn CryptoProvider> {
+    Arc::new(RustlsProvider {})
+}
+
+/// Return the [CryptoProvider] to be used for the server.
+pub fn server() -> Arc<dyn CryptoProvider> {
+    Arc::new(RustlsProvider {})
+}
+
+/// Configuration for client-side endpoints.
+pub struct ClientConfig {
+    /// The certificate for the client.
+    pub cert: Leaf,
+
+    /// The list of allowed peers for validation.
+    pub allowed_peers: Vec<Leaf>,
+
+    /// The ALPN protocols offered by the client.
+    pub alpn_protocols: Vec<Vec<u8>>,
+
+    /// If true, the client will present its certificate to the server.
+    pub enable_client_auth: bool,
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        Self {
+            cert: CLIENT_CERT.clone(),
+            allowed_peers: vec![SERVER_CERT.clone()],
+            alpn_protocols: default_alpn(),
+            enable_client_auth: false,
+        }
+    }
+}
+
+/// Configuration for server-side endpoints.
+pub struct ServerConfig {
+    /// The certificate for the server.
+    pub cert: Leaf,
+
+    /// The ALPN protocols accepted by the server.
+    pub alpn_protocols: Vec<Vec<u8>>,
+
+    /// If true, the server will verify the certificate presented by the client against
+    /// the value in [allowed_peers].
+    pub enable_client_auth: bool,
+
+    /// The list of allowed peers for validation. Only used if [enable_client_auth] is `true`.
+    pub allowed_peers: Vec<Leaf>,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            cert: SERVER_CERT.clone(),
+            allowed_peers: vec![CLIENT_CERT.clone()],
+            alpn_protocols: default_alpn(),
+            enable_client_auth: false,
+        }
+    }
+}
+
+/// A provider for crypto config for client and server test endpoints.
+pub trait CryptoProvider {
+    /// Creates the crypto config for a client-side endpoint.
+    fn new_client(&self, cfg: ClientConfig) -> Box<dyn crypto::ClientConfig>;
+
+    /// Creates two clients that share the same underlying session cache.
+    fn new_clients_with_shared_session_cache(
+        &self,
+        cfg1: ClientConfig,
+        cfg2: ClientConfig,
+    ) -> (Box<dyn crypto::ClientConfig>, Box<dyn crypto::ClientConfig>);
+
+    /// Creates the crypto config for a server-side endpoint.
+    fn new_server(&self, cfg: ServerConfig) -> Box<dyn crypto::ServerConfig>;
+
+    /// Creates a new random HMAC key.
+    fn new_hmac_key(&self) -> Arc<dyn crypto::HmacKey>;
+
+    /// Extracts the selected alpn protocol from handshake data.
+    fn handshake_data_alpn(&self, handshake_data: Option<Box<dyn Any>>) -> Vec<u8>;
+}
+
+fn default_alpn() -> Vec<Vec<u8>> {
+    vec![b"h3".to_vec()]
+}

--- a/quinn-proto/src/tests/provider_rustls.rs
+++ b/quinn-proto/src/tests/provider_rustls.rs
@@ -1,0 +1,132 @@
+use crate::crypto;
+use crate::tests::certs::Leaf;
+use crate::tests::provider::{ClientConfig, CryptoProvider, ServerConfig};
+use rand::RngCore;
+use ring;
+use std::any::Any;
+use std::sync::Arc;
+
+/// A rustls-based [CryptoProvider]
+pub struct RustlsProvider;
+
+impl CryptoProvider for RustlsProvider {
+    fn new_client(&self, cfg: ClientConfig) -> Box<dyn crypto::ClientConfig> {
+        Box::new(new_rustls_client(cfg))
+    }
+
+    fn new_clients_with_shared_session_cache(
+        &self,
+        cfg1: ClientConfig,
+        cfg2: ClientConfig,
+    ) -> (Box<dyn crypto::ClientConfig>, Box<dyn crypto::ClientConfig>) {
+        let out1 = new_rustls_client(cfg1);
+        let mut out2 = new_rustls_client(cfg2);
+        out2.session_storage = out1.session_storage.clone();
+        (Box::new(out1), Box::new(out2))
+    }
+
+    fn new_server(&self, cfg: ServerConfig) -> Box<dyn crypto::ServerConfig> {
+        Box::new(new_rustls_server(cfg))
+    }
+
+    fn new_hmac_key(&self) -> Arc<dyn crypto::HmacKey> {
+        Arc::new(new_ring_hmac_key())
+    }
+
+    fn handshake_data_alpn(&self, hd: Option<Box<dyn Any>>) -> Vec<u8> {
+        hd.unwrap()
+            .downcast::<crypto::rustls::HandshakeData>()
+            .unwrap()
+            .protocol
+            .as_ref()
+            .unwrap()
+            .clone()
+    }
+}
+
+/// Underlying method for creating the crypto configuration.
+pub fn new_rustls_client(in_: ClientConfig) -> rustls::ClientConfig {
+    // Create the cert store containing the server certs.
+    let mut server_certs = rustls::RootCertStore::empty();
+    for allowed_cert in peer_certs(in_.allowed_peers) {
+        server_certs.add(&allowed_cert).unwrap();
+    }
+
+    let builder = rustls::ClientConfig::builder()
+        .with_safe_default_cipher_suites()
+        .with_safe_default_kx_groups()
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap()
+        .with_root_certificates(server_certs);
+
+    let mut out = if in_.enable_client_auth {
+        let key = rustls::PrivateKey(in_.cert.private_key.clone());
+        let mut certs = Vec::new();
+        for cert in in_.cert.chain {
+            certs.push(rustls::Certificate(cert.clone()));
+        }
+        builder.with_single_cert(certs, key).unwrap()
+    } else {
+        builder.with_no_client_auth()
+    };
+
+    out.key_log = Arc::new(rustls::KeyLogFile::new());
+    out.alpn_protocols = in_.alpn_protocols;
+    out.enable_early_data = true;
+    out
+}
+
+pub fn new_rustls_server(in_: ServerConfig) -> rustls::ServerConfig {
+    let key = rustls::PrivateKey(in_.cert.private_key);
+    let mut certs = Vec::new();
+    for cert in in_.cert.chain {
+        certs.push(rustls::Certificate(cert.clone()));
+    }
+    let mut out = if in_.enable_client_auth {
+        rustls::ServerConfig::builder()
+            .with_safe_default_cipher_suites()
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .unwrap()
+            .with_client_cert_verifier({
+                let mut store = rustls::RootCertStore::empty();
+                for allowed_cert in peer_certs(in_.allowed_peers) {
+                    store.add(&allowed_cert).unwrap();
+                }
+                rustls::server::AllowAnyAuthenticatedClient::new(store)
+            })
+            .with_single_cert(certs, key)
+            .unwrap()
+    } else {
+        // Client auth is disabled: allow all clients.
+        let mut out = rustls::ServerConfig::builder()
+            .with_safe_default_cipher_suites()
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .unwrap()
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .unwrap();
+        out.max_early_data_size = u32::MAX;
+        out
+    };
+    out.alpn_protocols = in_.alpn_protocols;
+    out
+}
+
+pub fn new_ring_hmac_key() -> ring::hmac::Key {
+    let mut reset_key = vec![0; 64];
+    let mut rng = rand::thread_rng();
+    rng.fill_bytes(&mut reset_key);
+    ring::hmac::Key::new(ring::hmac::HMAC_SHA256, &reset_key)
+}
+
+fn peer_certs(peers: Vec<Leaf>) -> Vec<rustls::Certificate> {
+    let mut out = Vec::new();
+    for allowed_peer in peers {
+        for cert in allowed_peer.chain {
+            out.push(rustls::Certificate(cert.clone()));
+        }
+    }
+    out
+}

--- a/quinn-proto/src/token.rs
+++ b/quinn-proto/src/token.rs
@@ -13,6 +13,9 @@ use crate::{
     RESET_TOKEN_SIZE,
 };
 
+/// Retry token
+///
+/// Used for address validation.
 pub struct RetryToken<'a> {
     /// The destination connection ID set in the very first packet from the client
     pub orig_dst_cid: ConnectionId,
@@ -23,7 +26,7 @@ pub struct RetryToken<'a> {
 }
 
 impl<'a> RetryToken<'a> {
-    pub fn encode(
+    pub(crate) fn encode(
         &self,
         key: &dyn HandshakeTokenKey,
         address: &SocketAddr,
@@ -51,7 +54,7 @@ impl<'a> RetryToken<'a> {
         token
     }
 
-    pub fn from_bytes(
+    pub(crate) fn from_bytes(
         key: &dyn HandshakeTokenKey,
         address: &SocketAddr,
         retry_src_cid: &ConnectionId,
@@ -100,7 +103,8 @@ impl<'a> RetryToken<'a> {
     }
 
     const MAX_ADDITIONAL_DATA_SIZE: usize = 39; // max(ipv4, ipv6) + port + retry_src_cid
-    pub const RANDOM_BYTES_LEN: usize = 32;
+
+    pub(crate) const RANDOM_BYTES_LEN: usize = 32;
 }
 
 /// Stateless reset token
@@ -118,6 +122,11 @@ impl ResetToken {
         let mut result = [0; RESET_TOKEN_SIZE];
         result.copy_from_slice(&signature[..RESET_TOKEN_SIZE]);
         result.into()
+    }
+
+    /// Returns an empty token.
+    pub fn none() -> Self {
+        Self([0; RESET_TOKEN_SIZE])
     }
 }
 

--- a/quinn-proto/src/transport_error.rs
+++ b/quinn-proto/src/transport_error.rs
@@ -49,7 +49,7 @@ pub struct Code(u64);
 
 impl Code {
     /// Create QUIC error code from TLS alert code
-    pub(crate) fn crypto(code: u8) -> Self {
+    pub fn crypto(code: u8) -> Self {
         Code(0x100 | u64::from(code))
     }
 }

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -94,6 +94,67 @@ macro_rules! make_struct {
             pub(crate) preferred_address: Option<PreferredAddress>,
         }
 
+        impl TransportParameters {
+            $($(#[$doc])*
+            #[inline]
+            pub fn $name (&self) -> u64 {
+                self.$name.0
+            })*
+
+            /// Does the endpoint support active connection migration
+            #[inline]
+            pub fn disable_active_migration(&self) -> bool {
+                self.disable_active_migration
+            }
+
+            /// Maximum size for datagram frames
+            #[inline]
+            pub fn max_datagram_frame_size(&self) -> Option<u64> {
+                self.max_datagram_frame_size.map_or(None, |x| Some(x.0))
+            }
+
+            /// The value that the endpoint included in the Source Connection ID field of the first
+            /// Initial packet it sends for the connection
+            #[inline]
+            pub fn initial_src_cid(&self) -> Option<ConnectionId> {
+                self.initial_src_cid
+            }
+
+            /// The endpoint is willing to receive QUIC packets containing any value for the fixed
+            /// bit
+            #[inline]
+            pub fn grease_quic_bit(&self) -> bool {
+                self.grease_quic_bit
+            }
+
+            // Server-only
+            /// The value of the Destination Connection ID field from the first Initial packet sent
+            /// by the client
+            #[inline]
+            pub fn original_dst_cid(&self) -> Option<ConnectionId> {
+                self.original_dst_cid
+            }
+
+            /// The value that the server included in the Source Connection ID field of a Retry
+            /// packet
+            #[inline]
+            pub fn retry_src_cid(&self) -> Option<ConnectionId> {
+                self.retry_src_cid
+            }
+
+            /// Token used by the client to verify a stateless reset from the server
+            #[inline]
+            pub fn stateless_reset_token(&self) -> Option<ResetToken> {
+                self.stateless_reset_token
+            }
+
+            /// The server's preferred address for communication after handshake completion
+            #[inline]
+            pub fn preferred_address(&self) -> Option<PreferredAddress> {
+                self.preferred_address
+            }
+        }
+
         impl Default for TransportParameters {
             /// Standard defaults, used if the peer does not supply a given parameter.
             fn default() -> Self {
@@ -186,10 +247,14 @@ impl TransportParameters {
 ///
 /// This is communicated as a transport parameter during TLS session establishment.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub(crate) struct PreferredAddress {
+pub struct PreferredAddress {
+    /// The server's IPv4 address.
     pub address_v4: Option<SocketAddrV4>,
+    /// The server's IPv6 address.
     pub address_v6: Option<SocketAddrV6>,
+    /// The connection ID.
     pub connection_id: ConnectionId,
+    /// The reset token.
     pub stateless_reset_token: ResetToken,
 }
 

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -107,7 +107,8 @@ impl Endpoint {
         Self::new_with_runtime(config, server_config, Box::new(socket), Arc::new(runtime))
     }
 
-    fn new_with_runtime(
+    /// Construct an endpoint with arbitrary configuration and pre-constructed async socket.
+    pub fn new_with_runtime(
         config: EndpointConfig,
         server_config: Option<ServerConfig>,
         socket: Box<dyn AsyncUdpSocket>,


### PR DESCRIPTION
This allows the crypto integration tests to be run against any crypto provider. For now, only rustls is supported. This will be updated in the future once the boringssl provider has landed.

Requires #1496.