### PR TITLE
Borrow `self` in read_to_end, rather than consuming

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn"
-version = "0.9.3"
+version = "0.10.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/quinn-rs/quinn"
 description = "Versatile QUIC transport protocol implementation"

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -113,7 +113,7 @@ async fn run(options: Opt) -> Result<()> {
         .await
         .map_err(|e| anyhow!("failed to connect: {}", e))?;
     eprintln!("connected at {:?}", start.elapsed());
-    let (mut send, recv) = conn
+    let (mut send, mut recv) = conn
         .open_bi()
         .await
         .map_err(|e| anyhow!("failed to open stream: {}", e))?;

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -205,7 +205,7 @@ async fn handle_connection(root: Arc<Path>, conn: quinn::Connecting) -> Result<(
 
 async fn handle_request(
     root: Arc<Path>,
-    (mut send, recv): (quinn::SendStream, quinn::RecvStream),
+    (mut send, mut recv): (quinn::SendStream, quinn::RecvStream),
 ) -> Result<()> {
     let req = recv
         .read_to_end(64 * 1024)

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -140,7 +140,7 @@ fn read_after_close() {
             .await
             .expect("connect");
         tokio::time::sleep_until(Instant::now() + Duration::from_millis(100)).await;
-        let stream = new_conn.accept_uni().await.expect("incoming streams");
+        let mut stream = new_conn.accept_uni().await.expect("incoming streams");
         let msg = stream
             .read_to_end(usize::max_value())
             .await
@@ -211,7 +211,7 @@ async fn accept_after_close() {
         .expect("connection");
 
     // ...and read what was sent.
-    let stream = receiver.accept_uni().await.expect("incoming streams");
+    let mut stream = receiver.accept_uni().await.expect("incoming streams");
     let msg = stream
         .read_to_end(usize::max_value())
         .await
@@ -262,7 +262,7 @@ async fn zero_rtt() {
             let connection = incoming.into_0rtt().unwrap_or_else(|_| unreachable!()).0;
             let c = connection.clone();
             tokio::spawn(async move {
-                while let Ok(x) = c.accept_uni().await {
+                while let Ok(mut x) = c.accept_uni().await {
                     let msg = x.read_to_end(usize::max_value()).await.unwrap();
                     assert_eq!(msg, MSG);
                 }
@@ -285,7 +285,7 @@ async fn zero_rtt() {
     tokio::spawn(async move {
         // Buy time for the driver to process the server's NewSessionTicket
         tokio::time::sleep_until(Instant::now() + Duration::from_millis(100)).await;
-        let stream = connection.accept_uni().await.expect("incoming streams");
+        let mut stream = connection.accept_uni().await.expect("incoming streams");
         let msg = stream
             .read_to_end(usize::max_value())
             .await
@@ -309,7 +309,7 @@ async fn zero_rtt() {
         s.finish().await.expect("0-RTT finish");
     });
 
-    let stream = connection.accept_uni().await.expect("incoming streams");
+    let mut stream = connection.accept_uni().await.expect("incoming streams");
     let msg = stream
         .read_to_end(usize::max_value())
         .await
@@ -493,7 +493,7 @@ fn run_echo(args: EchoArgs) {
 
             for i in 0..args.nr_streams {
                 println!("Opening stream {i}");
-                let (mut send, recv) = new_conn.open_bi().await.expect("stream open");
+                let (mut send, mut recv) = new_conn.open_bi().await.expect("stream open");
                 let msg = gen_data(args.stream_size, SEED);
 
                 let send_task = async {
@@ -650,7 +650,7 @@ async fn rebind_recv() {
         .unwrap();
     info!("rebound");
     write_send.notify_one();
-    let stream = connection.accept_uni().await.unwrap();
+    let mut stream = connection.accept_uni().await.unwrap();
     assert_eq!(stream.read_to_end(MSG.len()).await.unwrap(), MSG);
     server.await.unwrap();
 }

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -91,7 +91,7 @@ fn connect_n_nodes_to_1_and_send_1mb_data() {
     }
 }
 
-async fn read_from_peer(stream: quinn::RecvStream) -> Result<(), quinn::ConnectionError> {
+async fn read_from_peer(mut stream: quinn::RecvStream) -> Result<(), quinn::ConnectionError> {
     let crc = crc::Crc::<u32>::new(&crc::CRC_32_ISO_HDLC);
     match stream.read_to_end(1024 * 1024 * 5).await {
         Ok(data) => {


### PR DESCRIPTION
Allows `RecvStream::stop` to be called with custom error codes if `ReadToEndError::TooLong` is encountered.

See also discussion in #1493.