### PR TITLE
quinn-proto v0.10.0 w/ rustls v0.21.0

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -12,7 +12,7 @@ bytes = "1"
 hdrhistogram = { version = "7.2", default-features = false }
 quinn = { path = "../quinn" }
 rcgen = "0.10.0"
-rustls = { version = "0.20", default-features = false, features = ["quic"] }
+rustls = { version = "0.21.0", default-features = false, features = ["quic"] }
 clap = { version = "3.2", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["rt", "sync"] }
 tracing = "0.1.10"

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -17,7 +17,7 @@ hdrhistogram = { version = "7.2", default-features = false }
 quinn = { path = "../quinn" }
 quinn-proto = { path = "../quinn-proto" }
 rcgen = "0.10.0"
-rustls = { version = "0.20", default-features = false, features = ["dangerous_configuration"] }
+rustls = { version = "0.21.0", default-features = false, features = ["dangerous_configuration"] }
 rustls-pemfile = "1.0.0"
 serde = { version = "1.0", features = ["derive"], optional = true  }
 serde_json = { version = "1.0", optional = true }

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -30,7 +30,7 @@ bytes = "1"
 rustc-hash = "1.1"
 rand = "0.8"
 ring = { version = "0.16.7", optional = true }
-rustls = { version = "0.20.4", default-features = false, features = ["quic"], optional = true }
+rustls = { version = "0.21.0", default-features = false, features = ["quic"], optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 slab = "0.4"
 thiserror = "1.0.21"

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-proto"
-version = "0.9.3"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.59"
 license = "MIT OR Apache-2.0"

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -23,7 +23,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 libc = "0.2.69"
-proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.9", default-features = false }
+proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.10", default-features = false }
 socket2 = "0.4" # 0.5.1 has an MSRV of 1.63
 tracing = "0.1.10"
 

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -40,8 +40,8 @@ bytes = "1"
 futures-io = { version = "0.3.19", optional = true }
 rustc-hash = "1.1"
 pin-project-lite = "0.2"
-proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.9", default-features = false }
-rustls = { version = "0.20.3", default-features = false, features = ["quic"], optional = true }
+proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.10", default-features = false }
+rustls = { version = "0.21.0", default-features = false, features = ["quic"], optional = true }
 thiserror = "1.0.21"
 tracing = "0.1.10"
 tokio = { version = "1.13.0", features = ["sync"] }


### PR DESCRIPTION
# Description 

Update branch for quinn-proto v0.10.0, using Rustls v0.21.0

### deps: upgrade rustls v0.20.3 -> v0.21.0.
This commit updates Quinn's dependency on Rustls from v0.20.3 to v0.21.0.

This release includes a handful of small breaking changes which are resolved alongside the upgrade.

### quinn-proto: bump version 0.9.2 -> 0.10.0.

As part of upgrading the quinn-proto rustls dependency we must do a semver incompatible version bump since rustls is exposed as part of the public API.

### Blocking tasks

- [x] Review
- [x] Wait for upstream Rustls v0.21.0 release
- [x] Replace patch with update to use released tag
- [x] Rebase on main
