### PR TITLE
Fallback to not using ECN if IP_TOS is not supported

### DIFF
--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -43,6 +43,7 @@ pub struct UdpState {
     /// If enabled, we assume that old kernel is used and switch to fallback mode.
     /// In particular, we do not use IP_TOS cmsg_type in this case,
     /// which is not supported on Linux <3.13 and results in not sending the UDP packet at all.
+    #[cfg(not(windows))]
     sendmsg_einval: AtomicBool,
 }
 
@@ -72,12 +73,14 @@ impl UdpState {
 
     /// Returns true if we previously got an EINVAL error from `sendmsg` or `sendmmsg` syscall.
     #[inline]
+    #[cfg(not(windows))]
     pub fn sendmsg_einval(&self) -> bool {
         self.sendmsg_einval.load(Ordering::Relaxed)
     }
 
     /// Sets the flag indicating we got EINVAL error from `sendmsg` or `sendmmsg` syscall.
     #[inline]
+    #[cfg(not(windows))]
     pub fn set_sendmsg_einval(&self) {
         self.sendmsg_einval.store(true, Ordering::Relaxed)
     }


### PR DESCRIPTION
On Linux <3.13 sendmsg/sendmmsg system calls
return EINVAL without sending anything if they encounter an `IP_TOS` cmsg. To ensure we can still send
on such systems, remember if we got an EINVAL error and switch to "fallback mode" in which we do not try to transmit ECN at all and only use well-supported features.