### PR TITLE
Do not require &mut self in AsyncUdpSocket::poll_send

### DIFF
--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -1,5 +1,6 @@
 use std::{
     io::{self, IoSliceMut},
+    sync::Mutex,
     time::Instant,
 };
 
@@ -13,14 +14,14 @@ use super::{log_sendmsg_error, RecvMeta, UdpSockRef, UdpState, IO_ERROR_LOG_INTE
 /// reduced performance compared to that enabled by some target-specific interfaces.
 #[derive(Debug)]
 pub struct UdpSocketState {
-    last_send_error: Instant,
+    last_send_error: Mutex<Instant>,
 }
 
 impl UdpSocketState {
     pub fn new() -> Self {
         let now = Instant::now();
         Self {
-            last_send_error: now.checked_sub(2 * IO_ERROR_LOG_INTERVAL).unwrap_or(now),
+            last_send_error: Mutex::new(now.checked_sub(2 * IO_ERROR_LOG_INTERVAL).unwrap_or(now)),
         }
     }
 
@@ -29,7 +30,7 @@ impl UdpSocketState {
     }
 
     pub fn send(
-        &mut self,
+        &self,
         socket: UdpSockRef<'_>,
         _state: &UdpState,
         transmits: &[Transmit],
@@ -58,7 +59,7 @@ impl UdpSocketState {
                     //   Those are not fatal errors, since the
                     //   configuration can be dynamically changed.
                     // - Destination unreachable errors have been observed for other
-                    log_sendmsg_error(&mut self.last_send_error, e, transmit);
+                    log_sendmsg_error(&self.last_send_error, e, transmit);
                     sent += 1;
                 }
             }

--- a/quinn/src/runtime.rs
+++ b/quinn/src/runtime.rs
@@ -35,7 +35,7 @@ pub trait AsyncUdpSocket: Send + Debug + 'static {
     /// Send UDP datagrams from `transmits`, or register to be woken if sending may succeed in the
     /// future
     fn poll_send(
-        &mut self,
+        &self,
         state: &UdpState,
         cx: &mut Context,
         transmits: &[Transmit],

--- a/quinn/src/runtime/async_std.rs
+++ b/quinn/src/runtime/async_std.rs
@@ -50,7 +50,7 @@ struct UdpSocket {
 
 impl AsyncUdpSocket for UdpSocket {
     fn poll_send(
-        &mut self,
+        &self,
         state: &udp::UdpState,
         cx: &mut Context,
         transmits: &[proto::Transmit],

--- a/quinn/src/runtime/tokio.rs
+++ b/quinn/src/runtime/tokio.rs
@@ -52,12 +52,12 @@ struct UdpSocket {
 
 impl AsyncUdpSocket for UdpSocket {
     fn poll_send(
-        &mut self,
+        &self,
         state: &udp::UdpState,
         cx: &mut Context,
         transmits: &[proto::Transmit],
     ) -> Poll<io::Result<usize>> {
-        let inner = &mut self.inner;
+        let inner = &self.inner;
         let io = &self.io;
         loop {
             ready!(io.poll_send_ready(cx))?;


### PR DESCRIPTION
I am currently running into the issue that it requires a large amount of locking when implementing a custom `AsyncUdpSocket`, because `poll_send` at the moment requires `&mut self`. 

So I looked into the reason that is (given that a regular `UdpSocket::send` does not require mutable access), and it turned out to only need write access to the `last_send_error` time. As the simplest option I put that behind a `Mutex`, which I think will be fine, but open to discussion of other variants, e.g. storing it in an atomic type or similar. 

