### PR TITLE
Bump quinn-proto version

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-proto"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 rust-version = "1.59"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Provides API changes needed by https://github.com/quinn-rs/quinn-boring/pull/2.