### PR TITLE
Warn on clippy's use_self lint

### DIFF
--- a/quinn-proto/src/cid_generator.rs
+++ b/quinn-proto/src/cid_generator.rs
@@ -46,7 +46,7 @@ impl RandomConnectionIdGenerator {
         debug_assert!(cid_len <= MAX_CID_SIZE);
         Self {
             cid_len,
-            ..RandomConnectionIdGenerator::default()
+            ..Self::default()
         }
     }
 

--- a/quinn-proto/src/coding.rs
+++ b/quinn-proto/src/coding.rs
@@ -17,7 +17,7 @@ pub trait Codec: Sized {
 }
 
 impl Codec for u8 {
-    fn decode<B: Buf>(buf: &mut B) -> Result<u8> {
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self> {
         if buf.remaining() < 1 {
             return Err(UnexpectedEnd);
         }
@@ -29,7 +29,7 @@ impl Codec for u8 {
 }
 
 impl Codec for u16 {
-    fn decode<B: Buf>(buf: &mut B) -> Result<u16> {
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self> {
         if buf.remaining() < 2 {
             return Err(UnexpectedEnd);
         }
@@ -41,7 +41,7 @@ impl Codec for u16 {
 }
 
 impl Codec for u32 {
-    fn decode<B: Buf>(buf: &mut B) -> Result<u32> {
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self> {
         if buf.remaining() < 4 {
             return Err(UnexpectedEnd);
         }
@@ -53,7 +53,7 @@ impl Codec for u32 {
 }
 
 impl Codec for u64 {
-    fn decode<B: Buf>(buf: &mut B) -> Result<u64> {
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self> {
         if buf.remaining() < 8 {
             return Err(UnexpectedEnd);
         }
@@ -65,7 +65,7 @@ impl Codec for u64 {
 }
 
 impl Codec for Ipv4Addr {
-    fn decode<B: Buf>(buf: &mut B) -> Result<Ipv4Addr> {
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self> {
         if buf.remaining() < 4 {
             return Err(UnexpectedEnd);
         }
@@ -79,7 +79,7 @@ impl Codec for Ipv4Addr {
 }
 
 impl Codec for Ipv6Addr {
-    fn decode<B: Buf>(buf: &mut B) -> Result<Ipv6Addr> {
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self> {
         if buf.remaining() < 16 {
             return Err(UnexpectedEnd);
         }

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -254,7 +254,7 @@ impl Default for TransportConfig {
                                                         // stalls
         const STREAM_RWND: u32 = MAX_STREAM_BANDWIDTH / 1000 * EXPECTED_RTT;
 
-        TransportConfig {
+        Self {
             max_concurrent_bidi_streams: 100u32.into(),
             max_concurrent_uni_streams: 100u32.into(),
             max_idle_timeout: Some(VarInt(10_000)),
@@ -664,13 +664,13 @@ pub enum ConfigError {
 
 impl From<TryFromIntError> for ConfigError {
     fn from(_: TryFromIntError) -> Self {
-        ConfigError::OutOfBounds
+        Self::OutOfBounds
     }
 }
 
 impl From<VarIntBoundsExceeded> for ConfigError {
     fn from(_: VarIntBoundsExceeded) -> Self {
-        ConfigError::OutOfBounds
+        Self::OutOfBounds
     }
 }
 

--- a/quinn-proto/src/congestion/bbr/bw_estimation.rs
+++ b/quinn-proto/src/congestion/bbr/bw_estimation.rs
@@ -44,7 +44,7 @@ impl BandwidthEstimation {
         };
 
         let send_rate = if self.sent_time > prev_sent_time {
-            BandwidthEstimation::bw_from_delta(
+            Self::bw_from_delta(
                 self.total_sent - self.prev_total_sent,
                 self.sent_time - prev_sent_time,
             )
@@ -54,7 +54,7 @@ impl BandwidthEstimation {
         };
 
         let ack_rate = match self.prev_acked_time {
-            Some(prev_acked_time) => BandwidthEstimation::bw_from_delta(
+            Some(prev_acked_time) => Self::bw_from_delta(
                 self.total_acked - self.prev_total_acked,
                 now - prev_acked_time,
             )
@@ -93,7 +93,7 @@ impl BandwidthEstimation {
 
 impl Default for BandwidthEstimation {
     fn default() -> Self {
-        BandwidthEstimation {
+        Self {
             total_acked: 0,
             prev_total_acked: 0,
             acked_time: None,

--- a/quinn-proto/src/congestion/bbr/mod.rs
+++ b/quinn-proto/src/congestion/bbr/mod.rs
@@ -609,7 +609,7 @@ enum RecoveryState {
 
 impl RecoveryState {
     pub fn in_recovery(&self) -> bool {
-        !matches!(self, RecoveryState::NotInRecovery)
+        !matches!(self, Self::NotInRecovery)
     }
 }
 

--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -228,7 +228,7 @@ pub struct Chunk {
 
 impl Chunk {
     fn new(offset: u64, bytes: Bytes) -> Self {
-        Chunk { offset, bytes }
+        Self { offset, bytes }
     }
 }
 
@@ -290,7 +290,7 @@ impl Buffer {
 impl Ord for Buffer {
     // Invert ordering based on offset (max-heap, min offset first),
     // prioritize longer chunks at the same offset.
-    fn cmp(&self, other: &Buffer) -> Ordering {
+    fn cmp(&self, other: &Self) -> Ordering {
         self.offset
             .cmp(&other.offset)
             .reverse()
@@ -299,13 +299,13 @@ impl Ord for Buffer {
 }
 
 impl PartialOrd for Buffer {
-    fn partial_cmp(&self, other: &Buffer) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl PartialEq for Buffer {
-    fn eq(&self, other: &Buffer) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         (self.offset, self.bytes.len()) == (other.offset, other.bytes.len())
     }
 }
@@ -322,13 +322,13 @@ enum State {
 
 impl State {
     fn is_ordered(&self) -> bool {
-        matches!(self, State::Ordered)
+        matches!(self, Self::Ordered)
     }
 }
 
 impl Default for State {
     fn default() -> Self {
-        State::Ordered
+        Self::Ordered
     }
 }
 

--- a/quinn-proto/src/connection/cid_state.rs
+++ b/quinn-proto/src/connection/cid_state.rs
@@ -32,7 +32,7 @@ impl CidState {
         let mut active_seq = FxHashSet::default();
         // Add sequence number of CID used in handshaking into tracking set
         active_seq.insert(0);
-        let mut this = CidState {
+        let mut this = Self {
             retire_timestamp: VecDeque::new(),
             issued: 1, // One CID is already supplied during handshaking
             active_seq,

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3211,15 +3211,15 @@ pub enum ConnectionError {
 impl From<Close> for ConnectionError {
     fn from(x: Close) -> Self {
         match x {
-            Close::Connection(reason) => ConnectionError::ConnectionClosed(reason),
-            Close::Application(reason) => ConnectionError::ApplicationClosed(reason),
+            Close::Connection(reason) => Self::ConnectionClosed(reason),
+            Close::Application(reason) => Self::ApplicationClosed(reason),
         }
     }
 }
 
 // For compatibility with API consumers
 impl From<ConnectionError> for io::Error {
-    fn from(x: ConnectionError) -> io::Error {
+    fn from(x: ConnectionError) -> Self {
         use self::ConnectionError::*;
         let kind = match x {
             TimedOut => io::ErrorKind::TimedOut,
@@ -3227,7 +3227,7 @@ impl From<ConnectionError> for io::Error {
             ApplicationClosed(_) | ConnectionClosed(_) => io::ErrorKind::ConnectionAborted,
             TransportError(_) | VersionMismatch | LocallyClosed => io::ErrorKind::Other,
         };
-        io::Error::new(kind, x)
+        Self::new(kind, x)
     }
 }
 
@@ -3243,25 +3243,25 @@ pub enum State {
 
 impl State {
     fn closed<R: Into<Close>>(reason: R) -> Self {
-        State::Closed(state::Closed {
+        Self::Closed(state::Closed {
             reason: reason.into(),
         })
     }
 
     fn is_handshake(&self) -> bool {
-        matches!(*self, State::Handshake(_))
+        matches!(*self, Self::Handshake(_))
     }
 
     fn is_established(&self) -> bool {
-        matches!(*self, State::Established)
+        matches!(*self, Self::Established)
     }
 
     fn is_closed(&self) -> bool {
-        matches!(*self, State::Closed(_) | State::Draining | State::Drained)
+        matches!(*self, Self::Closed(_) | Self::Draining | Self::Drained)
     }
 
     fn is_drained(&self) -> bool {
-        matches!(*self, State::Drained)
+        matches!(*self, Self::Drained)
     }
 }
 

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -38,7 +38,7 @@ impl PacketBuilder {
         ack_eliciting: bool,
         conn: &mut Connection,
         version: u32,
-    ) -> Option<PacketBuilder> {
+    ) -> Option<Self> {
         // Initiate key update if we're approaching the confidentiality limit
         let confidentiality_limit = conn.spaces[space_id]
             .crypto
@@ -142,7 +142,7 @@ impl PacketBuilder {
         );
         let max_size = buffer_capacity - partial_encode.start - partial_encode.header_len - tag_len;
 
-        Some(PacketBuilder {
+        Some(Self {
             datagram_start,
             space: space_id,
             partial_encode,
@@ -210,11 +210,7 @@ impl PacketBuilder {
     }
 
     /// Encrypt packet, returning the length of the packet and whether padding was added
-    pub fn finish(
-        self: PacketBuilder,
-        conn: &mut Connection,
-        buffer: &mut Vec<u8>,
-    ) -> (usize, bool) {
+    pub fn finish(self, conn: &mut Connection, buffer: &mut Vec<u8>) -> (usize, bool) {
         let pad = buffer.len() < self.min_size;
         if pad {
             trace!("PADDING * {}", self.min_size - buffer.len());

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -40,7 +40,7 @@ impl PathData {
         now: Instant,
         validated: bool,
     ) -> Self {
-        PathData {
+        Self {
             remote,
             rtt: RttEstimator::new(initial_rtt),
             sending_ecn: true,
@@ -61,10 +61,10 @@ impl PathData {
         }
     }
 
-    pub fn from_previous(remote: SocketAddr, prev: &PathData, now: Instant) -> Self {
+    pub fn from_previous(remote: SocketAddr, prev: &Self, now: Instant) -> Self {
         let congestion = prev.congestion.clone_box();
         let smoothed_rtt = prev.rtt.get();
-        PathData {
+        Self {
             remote,
             rtt: prev.rtt,
             pacing: Pacer::new(

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -280,12 +280,12 @@ impl ::std::ops::BitOrAssign<ThinRetransmits> for Retransmits {
     }
 }
 
-impl ::std::iter::FromIterator<Retransmits> for Retransmits {
+impl ::std::iter::FromIterator<Self> for Retransmits {
     fn from_iter<T>(iter: T) -> Self
     where
-        T: IntoIterator<Item = Retransmits>,
+        T: IntoIterator<Item = Self>,
     {
-        let mut result = Retransmits::default();
+        let mut result = Self::default();
         for packet in iter {
             result |= packet;
         }

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -369,7 +369,7 @@ pub enum ReadableError {
 
 impl From<IllegalOrderedRead> for ReadableError {
     fn from(_: IllegalOrderedRead) -> Self {
-        ReadableError::IllegalOrderedRead
+        Self::IllegalOrderedRead
     }
 }
 
@@ -381,6 +381,6 @@ enum RecvState {
 
 impl Default for RecvState {
     fn default() -> Self {
-        RecvState::Recv { size: None }
+        Self::Recv { size: None }
     }
 }

--- a/quinn-proto/src/connection/timer.rs
+++ b/quinn-proto/src/connection/timer.rs
@@ -22,14 +22,14 @@ pub(crate) enum Timer {
 
 impl Timer {
     pub(crate) const VALUES: [Self; 8] = [
-        Timer::LossDetection,
-        Timer::Idle,
-        Timer::Close,
-        Timer::KeyDiscard,
-        Timer::PathValidation,
-        Timer::KeepAlive,
-        Timer::Pacing,
-        Timer::PushNewCid,
+        Self::LossDetection,
+        Self::Idle,
+        Self::Close,
+        Self::KeyDiscard,
+        Self::PathValidation,
+        Self::KeepAlive,
+        Self::Pacing,
+        Self::PushNewCid,
     ];
 }
 

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -219,6 +219,6 @@ pub struct UnsupportedVersion;
 
 impl From<UnsupportedVersion> for ConnectError {
     fn from(_: UnsupportedVersion) -> Self {
-        ConnectError::UnsupportedVersion
+        Self::UnsupportedVersion
     }
 }

--- a/quinn-proto/src/crypto/ring.rs
+++ b/quinn-proto/src/crypto/ring.rs
@@ -49,6 +49,6 @@ impl crypto::AeadKey for aead::LessSafeKey {
 
 impl From<ring::error::Unspecified> for CryptoError {
     fn from(_: ring::error::Unspecified) -> Self {
-        CryptoError
+        Self
     }
 }

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -19,8 +19,8 @@ use crate::{
 impl From<Side> for rustls::Side {
     fn from(s: Side) -> Self {
         match s {
-            Side::Client => rustls::Side::Client,
-            Side::Server => rustls::Side::Server,
+            Side::Client => Self::Client,
+            Side::Server => Self::Server,
         }
     }
 }

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -778,7 +778,7 @@ pub(crate) struct ConnectionMeta {
 pub struct ConnectionHandle(pub usize);
 
 impl From<ConnectionHandle> for usize {
-    fn from(x: ConnectionHandle) -> usize {
+    fn from(x: ConnectionHandle) -> Self {
         x.0
     }
 }

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -40,7 +40,7 @@ impl Type {
 
 impl coding::Codec for Type {
     fn decode<B: Buf>(buf: &mut B) -> coding::Result<Self> {
-        Ok(Type(buf.get_var()?))
+        Ok(Self(buf.get_var()?))
     }
     fn encode<B: BufMut>(&self, buf: &mut B) {
         buf.write_var(self.0);
@@ -203,7 +203,7 @@ impl Frame {
     }
 
     pub fn is_ack_eliciting(&self) -> bool {
-        !matches!(*self, Frame::Ack(_) | Frame::Padding | Frame::Close(_))
+        !matches!(*self, Self::Ack(_) | Self::Padding | Self::Close(_))
     }
 }
 
@@ -216,25 +216,25 @@ pub enum Close {
 impl Close {
     pub(crate) fn encode<W: BufMut>(&self, out: &mut W, max_len: usize) {
         match *self {
-            Close::Connection(ref x) => x.encode(out, max_len),
-            Close::Application(ref x) => x.encode(out, max_len),
+            Self::Connection(ref x) => x.encode(out, max_len),
+            Self::Application(ref x) => x.encode(out, max_len),
         }
     }
 }
 
 impl From<TransportError> for Close {
     fn from(x: TransportError) -> Self {
-        Close::Connection(x.into())
+        Self::Connection(x.into())
     }
 }
 impl From<ConnectionClose> for Close {
     fn from(x: ConnectionClose) -> Self {
-        Close::Connection(x)
+        Self::Connection(x)
     }
 }
 impl From<ApplicationClose> for Close {
     fn from(x: ApplicationClose) -> Self {
-        Close::Application(x)
+        Self::Application(x)
     }
 }
 
@@ -262,7 +262,7 @@ impl fmt::Display for ConnectionClose {
 
 impl From<TransportError> for ConnectionClose {
     fn from(x: TransportError) -> Self {
-        ConnectionClose {
+        Self {
             error_code: x.code,
             frame_type: x.frame,
             reason: x.reason.into(),
@@ -464,7 +464,7 @@ pub struct StreamMeta {
 // This manual implementation exists because `Default` is not implemented for `StreamId`
 impl Default for StreamMeta {
     fn default() -> Self {
-        StreamMeta {
+        Self {
             id: StreamId(0),
             offsets: 0..0,
             fin: false,
@@ -540,13 +540,13 @@ impl IterErr {
 
 impl From<UnexpectedEnd> for IterErr {
     fn from(_: UnexpectedEnd) -> Self {
-        IterErr::UnexpectedEnd
+        Self::UnexpectedEnd
     }
 }
 
 impl Iter {
     pub fn new(payload: Bytes) -> Self {
-        Iter {
+        Self {
             bytes: io::Cursor::new(payload),
             last_ty: None,
         }

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -17,6 +17,7 @@
 // Fixes welcome:
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::too_many_arguments)]
+#![warn(clippy::use_self)]
 
 use std::{
     fmt,
@@ -91,12 +92,12 @@ pub mod fuzzing {
 
     impl<'arbitrary> Arbitrary<'arbitrary> for TransportParameters {
         fn arbitrary(u: &mut Unstructured<'arbitrary>) -> Result<Self> {
-            Ok(TransportParameters {
+            Ok(Self {
                 initial_max_streams_bidi: u.arbitrary()?,
                 initial_max_streams_uni: u.arbitrary()?,
                 ack_delay_exponent: u.arbitrary()?,
                 max_udp_payload_size: u.arbitrary()?,
-                ..TransportParameters::default()
+                ..Self::default()
             })
         }
     }
@@ -114,7 +115,7 @@ pub mod fuzzing {
             let bytes: Vec<u8> = Vec::arbitrary(u)?;
             let mut buf = BytesMut::new();
             buf.put_slice(&bytes[..]);
-            Ok(PacketParams {
+            Ok(Self {
                 local_cid_len,
                 buf,
                 grease_quic_bit: bool::arbitrary(u)?,
@@ -148,22 +149,22 @@ impl Side {
     #[inline]
     /// Shorthand for `self == Side::Client`
     pub fn is_client(self) -> bool {
-        self == Side::Client
+        self == Self::Client
     }
 
     #[inline]
     /// Shorthand for `self == Side::Server`
     pub fn is_server(self) -> bool {
-        self == Side::Server
+        self == Self::Server
     }
 }
 
 impl ops::Not for Side {
-    type Output = Side;
-    fn not(self) -> Side {
+    type Output = Self;
+    fn not(self) -> Self {
         match self {
-            Side::Client => Side::Server,
-            Side::Server => Side::Client,
+            Self::Client => Self::Server,
+            Self::Server => Self::Client,
         }
     }
 }
@@ -180,7 +181,7 @@ pub enum Dir {
 
 impl Dir {
     fn iter() -> impl Iterator<Item = Self> {
-        [Dir::Bi, Dir::Uni].iter().cloned()
+        [Self::Bi, Self::Uni].iter().cloned()
     }
 }
 
@@ -222,7 +223,7 @@ impl fmt::Display for StreamId {
 impl StreamId {
     /// Create a new StreamId
     pub fn new(initiator: Side, dir: Dir, index: u64) -> Self {
-        StreamId(index << 2 | (dir as u64) << 1 | initiator as u64)
+        Self(index << 2 | (dir as u64) << 1 | initiator as u64)
     }
     /// Which side of a connection initiated the stream
     pub fn initiator(self) -> Side {
@@ -247,8 +248,8 @@ impl StreamId {
 }
 
 impl From<StreamId> for VarInt {
-    fn from(x: StreamId) -> VarInt {
-        unsafe { VarInt::from_u64_unchecked(x.0) }
+    fn from(x: StreamId) -> Self {
+        unsafe { Self::from_u64_unchecked(x.0) }
     }
 }
 
@@ -259,8 +260,8 @@ impl From<VarInt> for StreamId {
 }
 
 impl coding::Codec for StreamId {
-    fn decode<B: bytes::Buf>(buf: &mut B) -> coding::Result<StreamId> {
-        VarInt::decode(buf).map(|x| StreamId(x.into_inner()))
+    fn decode<B: bytes::Buf>(buf: &mut B) -> coding::Result<Self> {
+        VarInt::decode(buf).map(|x| Self(x.into_inner()))
     }
     fn encode<B: bytes::BufMut>(&self, buf: &mut B) {
         VarInt::from_u64(self.0).unwrap().encode(buf);

--- a/quinn-proto/src/range_set/array_range_set.rs
+++ b/quinn-proto/src/range_set/array_range_set.rs
@@ -68,7 +68,7 @@ impl ArrayRangeSet {
         false
     }
 
-    pub fn subtract(&mut self, other: &ArrayRangeSet) {
+    pub fn subtract(&mut self, other: &Self) {
         // TODO: This can potentially be made more efficient, since the we know
         // individual ranges are not overlapping, and the next range must start
         // after the last one finished

--- a/quinn-proto/src/range_set/btree_range_set.rs
+++ b/quinn-proto/src/range_set/btree_range_set.rs
@@ -161,13 +161,13 @@ impl RangeSet {
         }
     }
 
-    pub fn add(&mut self, other: &RangeSet) {
+    pub fn add(&mut self, other: &Self) {
         for (&start, &end) in &other.0 {
             self.insert(start..end);
         }
     }
 
-    pub fn subtract(&mut self, other: &RangeSet) {
+    pub fn subtract(&mut self, other: &Self) {
         for (&start, &end) in &other.0 {
             self.remove(start..end);
         }

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -34,7 +34,7 @@ impl Pair {
         let server = Endpoint::new(endpoint_config.clone(), Some(Arc::new(server_config)));
         let client = Endpoint::new(endpoint_config, None);
 
-        Pair::new_from_endpoint(client, server)
+        Self::new_from_endpoint(client, server)
     }
 
     pub fn new_from_endpoint(client: Endpoint, server: Endpoint) -> Self {
@@ -215,7 +215,7 @@ impl Pair {
 
 impl Default for Pair {
     fn default() -> Self {
-        Pair::new(Default::default(), server_config())
+        Self::new(Default::default(), server_config())
     }
 }
 

--- a/quinn-proto/src/token.rs
+++ b/quinn-proto/src/token.rs
@@ -122,7 +122,7 @@ impl ResetToken {
 }
 
 impl PartialEq for ResetToken {
-    fn eq(&self, other: &ResetToken) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         crate::constant_time::eq(&self.0, &other.0)
     }
 }

--- a/quinn-proto/src/transport_error.rs
+++ b/quinn-proto/src/transport_error.rs
@@ -50,13 +50,13 @@ pub struct Code(u64);
 impl Code {
     /// Create QUIC error code from TLS alert code
     pub fn crypto(code: u8) -> Self {
-        Code(0x100 | u64::from(code))
+        Self(0x100 | u64::from(code))
     }
 }
 
 impl coding::Codec for Code {
     fn decode<B: Buf>(buf: &mut B) -> coding::Result<Self> {
-        Ok(Code(buf.get_var()?))
+        Ok(Self(buf.get_var()?))
     }
     fn encode<B: BufMut>(&self, buf: &mut B) {
         buf.write_var(self.0)
@@ -64,7 +64,7 @@ impl coding::Codec for Code {
 }
 
 impl From<Code> for u64 {
-    fn from(x: Code) -> u64 {
+    fn from(x: Code) -> Self {
         x.0
     }
 }

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -125,7 +125,7 @@ impl TransportParameters {
         initial_src_cid: ConnectionId,
         server_config: Option<&ServerConfig>,
     ) -> Self {
-        TransportParameters {
+        Self {
             initial_src_cid: Some(initial_src_cid),
             initial_max_streams_bidi: config.max_concurrent_bidi_streams,
             initial_max_streams_uni: config.max_concurrent_uni_streams,
@@ -152,10 +152,7 @@ impl TransportParameters {
 
     /// Check that these parameters are legal when resuming from
     /// certain cached parameters
-    pub(crate) fn validate_resumption_from(
-        &self,
-        cached: &TransportParameters,
-    ) -> Result<(), TransportError> {
+    pub(crate) fn validate_resumption_from(&self, cached: &Self) -> Result<(), TransportError> {
         if cached.active_connection_id_limit > self.active_connection_id_limit
             || cached.initial_max_data > self.initial_max_data
             || cached.initial_max_stream_data_bidi_local > self.initial_max_stream_data_bidi_local
@@ -261,15 +258,15 @@ pub enum Error {
 impl From<Error> for TransportError {
     fn from(e: Error) -> Self {
         match e {
-            Error::IllegalValue => TransportError::TRANSPORT_PARAMETER_ERROR("illegal value"),
-            Error::Malformed => TransportError::TRANSPORT_PARAMETER_ERROR("malformed"),
+            Error::IllegalValue => Self::TRANSPORT_PARAMETER_ERROR("illegal value"),
+            Error::Malformed => Self::TRANSPORT_PARAMETER_ERROR("malformed"),
         }
     }
 }
 
 impl From<UnexpectedEnd> for Error {
     fn from(_: UnexpectedEnd) -> Self {
-        Error::Malformed
+        Self::Malformed
     }
 }
 
@@ -337,7 +334,7 @@ impl TransportParameters {
     /// Decode `TransportParameters` from buffer
     pub fn read<R: Buf>(side: Side, r: &mut R) -> Result<Self, Error> {
         // Initialize to protocol-specified defaults
-        let mut params = TransportParameters::default();
+        let mut params = Self::default();
 
         // State to check for duplicate transport parameters.
         macro_rules! param_state {

--- a/quinn-proto/src/varint.rs
+++ b/quinn-proto/src/varint.rs
@@ -18,19 +18,19 @@ pub struct VarInt(pub(crate) u64);
 
 impl VarInt {
     /// The largest representable value
-    pub const MAX: VarInt = VarInt((1 << 62) - 1);
+    pub const MAX: Self = Self((1 << 62) - 1);
     /// The largest encoded value length
     pub const MAX_SIZE: usize = 8;
 
     /// Construct a `VarInt` infallibly
     pub const fn from_u32(x: u32) -> Self {
-        VarInt(x as u64)
+        Self(x as u64)
     }
 
     /// Succeeds iff `x` < 2^62
     pub fn from_u64(x: u64) -> Result<Self, VarIntBoundsExceeded> {
         if x < 2u64.pow(62) {
-            Ok(VarInt(x))
+            Ok(Self(x))
         } else {
             Err(VarIntBoundsExceeded)
         }
@@ -42,7 +42,7 @@ impl VarInt {
     ///
     /// `x` must be less than 2^62.
     pub const unsafe fn from_u64_unchecked(x: u64) -> Self {
-        VarInt(x)
+        Self(x)
     }
 
     /// Extract the integer value
@@ -68,26 +68,26 @@ impl VarInt {
 }
 
 impl From<VarInt> for u64 {
-    fn from(x: VarInt) -> u64 {
+    fn from(x: VarInt) -> Self {
         x.0
     }
 }
 
 impl From<u8> for VarInt {
     fn from(x: u8) -> Self {
-        VarInt(x.into())
+        Self(x.into())
     }
 }
 
 impl From<u16> for VarInt {
     fn from(x: u16) -> Self {
-        VarInt(x.into())
+        Self(x.into())
     }
 }
 
 impl From<u32> for VarInt {
     fn from(x: u32) -> Self {
-        VarInt(x.into())
+        Self(x.into())
     }
 }
 
@@ -95,7 +95,7 @@ impl std::convert::TryFrom<u64> for VarInt {
     type Error = VarIntBoundsExceeded;
     /// Succeeds iff `x` < 2^62
     fn try_from(x: u64) -> Result<Self, VarIntBoundsExceeded> {
-        VarInt::from_u64(x)
+        Self::from_u64(x)
     }
 }
 
@@ -103,7 +103,7 @@ impl std::convert::TryFrom<u128> for VarInt {
     type Error = VarIntBoundsExceeded;
     /// Succeeds iff `x` < 2^62
     fn try_from(x: u128) -> Result<Self, VarIntBoundsExceeded> {
-        VarInt::from_u64(x.try_into().map_err(|_| VarIntBoundsExceeded)?)
+        Self::from_u64(x.try_into().map_err(|_| VarIntBoundsExceeded)?)
     }
 }
 
@@ -111,7 +111,7 @@ impl std::convert::TryFrom<usize> for VarInt {
     type Error = VarIntBoundsExceeded;
     /// Succeeds iff `x` < 2^62
     fn try_from(x: usize) -> Result<Self, VarIntBoundsExceeded> {
-        VarInt::try_from(x as u64)
+        Self::try_from(x as u64)
     }
 }
 
@@ -130,7 +130,7 @@ impl fmt::Display for VarInt {
 #[cfg(feature = "arbitrary")]
 impl<'arbitrary> Arbitrary<'arbitrary> for VarInt {
     fn arbitrary(u: &mut arbitrary::Unstructured<'arbitrary>) -> arbitrary::Result<Self> {
-        Ok(VarInt(u.int_in_range(0..=VarInt::MAX.0)?))
+        Ok(Self(u.int_in_range(0..=Self::MAX.0)?))
     }
 }
 
@@ -173,7 +173,7 @@ impl Codec for VarInt {
             }
             _ => unreachable!(),
         };
-        Ok(VarInt(x))
+        Ok(Self(x))
     }
 
     fn encode<B: BufMut>(&self, w: &mut B) {

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -1,4 +1,6 @@
 //! Uniform interface to send/recv UDP packets with ECN information.
+#![warn(clippy::use_self)]
+
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
 #[cfg(windows)]

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -44,7 +44,7 @@ impl Connecting {
         conn_events: mpsc::UnboundedReceiver<ConnectionEvent>,
         udp_state: Arc<UdpState>,
         runtime: Arc<dyn Runtime>,
-    ) -> Connecting {
+    ) -> Self {
         let (on_handshake_data_send, on_handshake_data_recv) = oneshot::channel();
         let (on_connected_send, on_connected_recv) = oneshot::channel();
         let conn = ConnectionRef::new(
@@ -60,7 +60,7 @@ impl Connecting {
 
         runtime.spawn(Box::pin(ConnectionDriver(conn.clone())));
 
-        Connecting {
+        Self {
             conn: Some(conn),
             connected: on_connected_recv,
             handshake_data_ready: Some(on_handshake_data_recv),
@@ -1149,6 +1149,6 @@ pub struct UnknownStream {
 
 impl From<proto::UnknownStream> for UnknownStream {
     fn from(_: proto::UnknownStream) -> Self {
-        UnknownStream { _private: () }
+        Self { _private: () }
     }
 }

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -38,6 +38,7 @@
 //! with a domain name--then as with TLS, self-signed certificates can be used to provide
 //! encryption alone.
 #![warn(missing_docs)]
+#![warn(clippy::use_self)]
 
 use std::time::Duration;
 

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -348,8 +348,8 @@ enum ReadStatus<T> {
 impl<T> From<(Option<T>, Option<proto::ReadError>)> for ReadStatus<T> {
     fn from(status: (Option<T>, Option<proto::ReadError>)) -> Self {
         match status {
-            (read, None) => ReadStatus::Finished(read),
-            (read, Some(e)) => ReadStatus::Failed(read, e),
+            (read, None) => Self::Finished(read),
+            (read, Some(e)) => Self::Failed(read, e),
         }
     }
 }
@@ -428,7 +428,7 @@ impl tokio::io::AsyncRead for RecvStream {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        ready!(RecvStream::poll_read(self.get_mut(), cx, buf))?;
+        ready!(Self::poll_read(self.get_mut(), cx, buf))?;
         Poll::Ready(Ok(()))
     }
 }
@@ -484,8 +484,8 @@ pub enum ReadError {
 impl From<ReadableError> for ReadError {
     fn from(e: ReadableError) -> Self {
         match e {
-            ReadableError::UnknownStream => ReadError::UnknownStream,
-            ReadableError::IllegalOrderedRead => ReadError::IllegalOrderedRead,
+            ReadableError::UnknownStream => Self::UnknownStream,
+            ReadableError::IllegalOrderedRead => Self::IllegalOrderedRead,
         }
     }
 }
@@ -498,7 +498,7 @@ impl From<ReadError> for io::Error {
             ConnectionLost(_) | UnknownStream => io::ErrorKind::NotConnected,
             IllegalOrderedRead => io::ErrorKind::InvalidInput,
         };
-        io::Error::new(kind, x)
+        Self::new(kind, x)
     }
 }
 

--- a/quinn/src/runtime/tokio.rs
+++ b/quinn/src/runtime/tokio.rs
@@ -37,7 +37,7 @@ impl Runtime for TokioRuntime {
 
 impl AsyncTimer for Sleep {
     fn reset(self: Pin<&mut Self>, t: Instant) {
-        Sleep::reset(self, t.into())
+        Self::reset(self, t.into())
     }
     fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<()> {
         Future::poll(self, cx)

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -246,7 +246,7 @@ impl tokio::io::AsyncWrite for SendStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        SendStream::execute_poll(self.get_mut(), cx, |stream| stream.write(buf)).map_err(Into::into)
+        Self::execute_poll(self.get_mut(), cx, |stream| stream.write(buf)).map_err(Into::into)
     }
 
     fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<io::Result<()>> {
@@ -471,6 +471,6 @@ impl From<WriteError> for io::Error {
             Stopped(_) | ZeroRttRejected => io::ErrorKind::ConnectionReset,
             ConnectionLost(_) | UnknownStream => io::ErrorKind::NotConnected,
         };
-        io::Error::new(kind, x)
+        Self::new(kind, x)
     }
 }


### PR DESCRIPTION
This is generally more concise and in case of a rename avoids having to change a bunch of extra locations.

(Note that clippy warnings fail our CI's lint job.)