### PR TITLE
Tie up PLPMTUD's loose ends

### DIFF
--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -145,7 +145,7 @@ pub fn transport_config(opt: &Opt) -> quinn::TransportConfig {
     #[cfg(any(windows, os = "linux"))]
     config.mtu_discovery_config(Some(quinn::MtuDiscoveryConfig::default()));
     config.max_concurrent_uni_streams(opt.max_streams.try_into().unwrap());
-    config.initial_max_udp_payload_size(opt.initial_mtu);
+    config.initial_mtu(opt.initial_mtu);
     config
 }
 

--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -65,7 +65,7 @@ struct Opt {
     keylog: bool,
     /// UDP payload size that the network must be capable of carrying
     #[clap(long, default_value = "1200")]
-    initial_max_udp_payload_size: u16,
+    initial_mtu: u16,
     /// Disable packet encryption/decryption (for debugging purpose)
     #[clap(long = "no-protection")]
     no_protection: bool,
@@ -131,7 +131,7 @@ async fn run(opt: Opt) -> Result<()> {
     let mut transport = quinn::TransportConfig::default();
     #[cfg(any(windows, os = "linux"))]
     transport.mtu_discovery_config(Some(quinn::MtuDiscoveryConfig::default()));
-    transport.initial_max_udp_payload_size(opt.initial_max_udp_payload_size);
+    transport.initial_mtu(opt.initial_mtu);
 
     let mut cfg = if opt.no_protection {
         quinn::ClientConfig::new(Arc::new(NoProtectionClientConfig::new(Arc::new(crypto))))

--- a/perf/src/bin/perf_server.rs
+++ b/perf/src/bin/perf_server.rs
@@ -34,7 +34,7 @@ struct Opt {
     keylog: bool,
     /// UDP payload size that the network must be capable of carrying
     #[clap(long, default_value = "1200")]
-    initial_max_udp_payload_size: u16,
+    initial_mtu: u16,
     /// Disable packet encryption/decryption (for debugging purpose)
     #[clap(long = "no-protection")]
     no_protection: bool,
@@ -90,7 +90,7 @@ async fn run(opt: Opt) -> Result<()> {
     let mut transport = quinn::TransportConfig::default();
     #[cfg(any(windows, os = "linux"))]
     transport.mtu_discovery_config(Some(quinn::MtuDiscoveryConfig::default()));
-    transport.initial_max_udp_payload_size(opt.initial_max_udp_payload_size);
+    transport.initial_mtu(opt.initial_mtu);
 
     let mut server_config = if opt.no_protection {
         quinn::ServerConfig::with_crypto(Arc::new(NoProtectionServerConfig::new(Arc::new(crypto))))

--- a/quinn-proto/src/congestion.rs
+++ b/quinn-proto/src/congestion.rs
@@ -58,6 +58,9 @@ pub trait Controller: Send {
         lost_bytes: u64,
     );
 
+    /// The known MTU for the current network path has been updated
+    fn on_mtu_update(&mut self, new_mtu: u16);
+
     /// Number of ack-eliciting bytes that may be in flight
     fn window(&self) -> u64;
 
@@ -74,5 +77,7 @@ pub trait Controller: Send {
 /// Constructs controllers on demand
 pub trait ControllerFactory {
     /// Construct a fresh `Controller`
-    fn build(&self, now: Instant) -> Box<dyn Controller>;
+    fn build(&self, now: Instant, current_mtu: u16) -> Box<dyn Controller>;
 }
+
+const BASE_DATAGRAM_SIZE: u64 = 1200;

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -265,8 +265,9 @@ impl Connection {
                 config.initial_rtt,
                 config
                     .congestion_controller_factory
-                    .build(now, config.initial_max_udp_payload_size),
-                config.initial_max_udp_payload_size,
+                    .build(now, config.get_initial_max_udp_payload_size()),
+                config.get_initial_max_udp_payload_size(),
+                config.max_guaranteed_udp_payload_size,
                 None,
                 config.mtu_discovery_config.clone(),
                 now,
@@ -2738,8 +2739,9 @@ impl Connection {
                 self.config.initial_rtt,
                 self.config
                     .congestion_controller_factory
-                    .build(now, self.config.initial_max_udp_payload_size),
-                self.config.initial_max_udp_payload_size,
+                    .build(now, self.config.get_initial_max_udp_payload_size()),
+                self.config.get_initial_max_udp_payload_size(),
+                self.config.max_guaranteed_udp_payload_size,
                 Some(peer_max_udp_payload_size),
                 self.config.mtu_discovery_config.clone(),
                 now,

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -263,7 +263,9 @@ impl Connection {
             path: PathData::new(
                 remote,
                 config.initial_rtt,
-                config.congestion_controller_factory.build(now),
+                config
+                    .congestion_controller_factory
+                    .build(now, config.initial_max_udp_payload_size),
                 config.initial_max_udp_payload_size,
                 None,
                 config.mtu_discovery_config.clone(),
@@ -1220,7 +1222,13 @@ impl Connection {
                 ack_eliciting_acked |= info.ack_eliciting;
 
                 // Notify MTU discovery that a packet was acked, because it might be an MTU probe
-                self.path.mtud.on_acked(space, packet, info.size);
+                let mtu_updated = self.path.mtud.on_acked(space, packet, info.size);
+                if mtu_updated {
+                    self.path
+                        .congestion
+                        .on_mtu_update(self.path.mtud.current_mtu());
+                }
+
                 self.on_packet_acked(now, space, info);
             }
         }
@@ -2728,7 +2736,9 @@ impl Connection {
             PathData::new(
                 remote,
                 self.config.initial_rtt,
-                self.config.congestion_controller_factory.build(now),
+                self.config
+                    .congestion_controller_factory
+                    .build(now, self.config.initial_max_udp_payload_size),
                 self.config.initial_max_udp_payload_size,
                 Some(peer_max_udp_payload_size),
                 self.config.mtu_discovery_config.clone(),

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -265,9 +265,9 @@ impl Connection {
                 config.initial_rtt,
                 config
                     .congestion_controller_factory
-                    .build(now, config.get_initial_max_udp_payload_size()),
-                config.get_initial_max_udp_payload_size(),
-                config.max_guaranteed_udp_payload_size,
+                    .build(now, config.get_initial_mtu()),
+                config.get_initial_mtu(),
+                config.min_guaranteed_mtu,
                 None,
                 config.mtu_discovery_config.clone(),
                 now,
@@ -2739,9 +2739,9 @@ impl Connection {
                 self.config.initial_rtt,
                 self.config
                     .congestion_controller_factory
-                    .build(now, self.config.get_initial_max_udp_payload_size()),
-                self.config.get_initial_max_udp_payload_size(),
-                self.config.max_guaranteed_udp_payload_size,
+                    .build(now, self.config.get_initial_mtu()),
+                self.config.get_initial_mtu(),
+                self.config.min_guaranteed_mtu,
                 Some(peer_max_udp_payload_size),
                 self.config.mtu_discovery_config.clone(),
                 now,

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1470,6 +1470,7 @@ impl Connection {
                 lost_packets,
                 size_of_lost_packets
             );
+
             for packet in &lost_packets {
                 let info = self.spaces[pn_space].sent_packets.remove(packet).unwrap(); // safe: lost_packets is populated just above
                 self.remove_in_flight(pn_space, &info);
@@ -1477,8 +1478,13 @@ impl Connection {
                     self.streams.retransmit(frame);
                 }
                 self.spaces[pn_space].pending |= info.retransmits;
-                self.path.mtud.on_non_probe_lost(now, *packet, info.size);
+                self.path.mtud.on_non_probe_lost(*packet, info.size);
             }
+
+            if self.path.mtud.black_hole_detected(now) {
+                self.stats.path.black_holes_detected += 1;
+            }
+
             // Don't apply congestion penalty for lost ack-only packets
             let lost_ack_eliciting = old_bytes_in_flight != self.in_flight.bytes;
 

--- a/quinn-proto/src/connection/mtud.rs
+++ b/quinn-proto/src/connection/mtud.rs
@@ -11,11 +11,8 @@ pub(crate) struct MtuDiscovery {
     current_mtu: u16,
     /// The state of the MTU discovery, if enabled
     state: Option<EnabledMtuDiscovery>,
-    /// A count of the number of packets with a size > BASE_UDP_PAYLOAD_SIZE lost since
-    /// the last time a packet with size equal to the current MTU was acknowledged
-    black_hole_counter: u8,
-    /// The largest acked packet of size `current_mtu`
-    largest_acked_mtu_sized_packet: Option<u64>,
+    /// The state of the black hole detector
+    black_hole_detector: BlackHoleDetector,
 }
 
 impl MtuDiscovery {
@@ -50,8 +47,7 @@ impl MtuDiscovery {
         Self {
             current_mtu,
             state,
-            black_hole_counter: 0,
-            largest_acked_mtu_sized_packet: None,
+            black_hole_detector: BlackHoleDetector::new(),
         }
     }
 
@@ -81,10 +77,17 @@ impl MtuDiscovery {
     }
 
     /// Notifies the [`MtuDiscovery`] that a packet has been ACKed
-    pub(crate) fn on_acked(&mut self, space: SpaceId, packet_number: u64, packet_bytes: u16) {
+    ///
+    /// Returns true if the packet was an MTU probe
+    pub(crate) fn on_acked(
+        &mut self,
+        space: SpaceId,
+        packet_number: u64,
+        packet_bytes: u16,
+    ) -> bool {
         // MTU probes are only sent in application data space
         if space != SpaceId::Data {
-            return;
+            return false;
         }
 
         // Update the state of the MTU search
@@ -96,19 +99,15 @@ impl MtuDiscovery {
             self.current_mtu = new_mtu;
             trace!(max_udp_payload_size = self.current_mtu, "new MTU detected");
 
-            // We know for sure the path supports the current MTU
-            self.black_hole_counter = 0;
-        }
-
-        // Reset the black hole counter if a packet the size of the current MTU or larger
-        // has been acknowledged
-        if packet_bytes >= self.current_mtu
-            && self
-                .largest_acked_mtu_sized_packet
-                .map_or(true, |pn| packet_number > pn)
-        {
-            self.black_hole_counter = 0;
-            self.largest_acked_mtu_sized_packet = Some(packet_number);
+            self.black_hole_detector.on_probe_acked();
+            true
+        } else {
+            self.black_hole_detector.on_non_probe_acked(
+                self.current_mtu,
+                packet_number,
+                packet_bytes,
+            );
+            false
         }
     }
 
@@ -131,31 +130,31 @@ impl MtuDiscovery {
     }
 
     /// Notifies the [`MtuDiscovery`] that a non-probe packet was lost
-    pub(crate) fn on_non_probe_lost(&mut self, now: Instant, packet_number: u64, packet_size: u16) {
-        // Ignore packets smaller or equal than the base size
-        if packet_size <= BASE_UDP_PAYLOAD_SIZE {
-            return;
+    ///
+    /// When done notifying of lost packets, [`MtuDiscovery::black_hole_detected`] must be called, to
+    /// ensure the last loss burst is properly processed and to trigger black hole recovery logic if
+    /// necessary.
+    pub(crate) fn on_non_probe_lost(&mut self, packet_number: u64, packet_bytes: u16) {
+        self.black_hole_detector
+            .on_non_probe_lost(packet_number, packet_bytes);
+    }
+
+    /// Returns true if a black hole was detected
+    ///
+    /// Calling this function will close the previous loss burst. If a black hole is detected, the
+    /// current MTU will be reset to `BASE_UDP_PAYLOAD_SIZE`.
+    pub(crate) fn black_hole_detected(&mut self, now: Instant) -> bool {
+        if !self.black_hole_detector.black_hole_detected() {
+            return false;
         }
 
-        // Ignore lost packets if we have received an ACK for a more recent MTU-sized packet
-        if self
-            .largest_acked_mtu_sized_packet
-            .map_or(false, |pn| packet_number < pn)
-        {
-            return;
+        self.current_mtu = BASE_UDP_PAYLOAD_SIZE;
+
+        if let Some(state) = &mut self.state {
+            state.on_black_hole_detected(now);
         }
 
-        // The packet counts towards black hole detection
-        self.black_hole_counter += 1;
-        if self.black_hole_counter > BLACK_HOLE_THRESHOLD {
-            self.black_hole_counter = 0;
-            self.largest_acked_mtu_sized_packet = None;
-            self.current_mtu = BASE_UDP_PAYLOAD_SIZE;
-
-            if let Some(state) = &mut self.state {
-                state.on_black_hole_detected(now);
-            }
-        }
+        true
     }
 }
 
@@ -349,6 +348,127 @@ impl SearchState {
     }
 }
 
+#[derive(Clone)]
+struct BlackHoleDetector {
+    /// Counts suspicious packet loss bursts since a packet with size equal to the current MTU was
+    /// acknowledged (or since a black hole was detected)
+    ///
+    /// A packet loss burst is a group of contiguous packets that are deemed lost at the same time
+    /// (see usages of [`MtuDiscovery::on_non_probe_lost`] for details on how loss detection is
+    /// implemented)
+    ///
+    /// A packet loss burst is considered suspicious when it contains only suspicious packets and no
+    /// MTU-sized packet has been acknowledged since the group's packets were sent
+    suspicious_loss_bursts: u8,
+    /// Indicates whether the current loss burst has any non-suspicious packets
+    ///
+    /// Non-suspicious packets are non-probe packets of size <= `BASE_UDP_PAYLOAD_SIZE`
+    loss_burst_has_non_suspicious_packets: bool,
+    /// The largest suspicious packet that was lost in the current burst
+    ///
+    /// Suspicious packets are non-probe packets of size > `BASE_UDP_PAYLOAD_SIZE`
+    largest_suspicious_packet_lost: Option<u64>,
+    /// The largest non-probe packet that was lost (used to keep track of loss bursts)
+    largest_non_probe_lost: Option<u64>,
+    /// The largest acked packet of size `current_mtu`
+    largest_acked_mtu_sized_packet: Option<u64>,
+}
+
+impl BlackHoleDetector {
+    fn new() -> Self {
+        Self {
+            suspicious_loss_bursts: 0,
+            largest_non_probe_lost: None,
+            loss_burst_has_non_suspicious_packets: false,
+            largest_suspicious_packet_lost: None,
+            largest_acked_mtu_sized_packet: None,
+        }
+    }
+
+    fn on_probe_acked(&mut self) {
+        // We know for sure the path supports the current MTU
+        self.suspicious_loss_bursts = 0;
+    }
+
+    fn on_non_probe_acked(&mut self, current_mtu: u16, packet_number: u64, packet_bytes: u16) {
+        // Reset the black hole counter if a packet the size of the current MTU or larger
+        // has been acknowledged
+        if packet_bytes >= current_mtu
+            && self
+                .largest_acked_mtu_sized_packet
+                .map_or(true, |pn| packet_number > pn)
+        {
+            self.suspicious_loss_bursts = 0;
+            self.largest_acked_mtu_sized_packet = Some(packet_number);
+        }
+    }
+
+    fn on_non_probe_lost(&mut self, packet_number: u64, packet_bytes: u16) {
+        // A loss burst is a group of consecutive packets that are declared lost, so a distance
+        // greater than 1 indicates a new burst
+        let new_loss_burst = self
+            .largest_non_probe_lost
+            .map_or(true, |prev| packet_number - prev != 1);
+
+        if new_loss_burst {
+            self.finish_loss_burst();
+        }
+
+        if packet_bytes <= BASE_UDP_PAYLOAD_SIZE {
+            self.loss_burst_has_non_suspicious_packets = true;
+        } else {
+            self.largest_suspicious_packet_lost = Some(packet_number);
+        }
+
+        self.largest_non_probe_lost = Some(packet_number);
+    }
+
+    fn black_hole_detected(&mut self) -> bool {
+        self.finish_loss_burst();
+
+        if self.suspicious_loss_bursts <= BLACK_HOLE_THRESHOLD {
+            return false;
+        }
+
+        self.suspicious_loss_bursts = 0;
+        self.largest_acked_mtu_sized_packet = None;
+
+        true
+    }
+
+    /// Marks the end of the current loss burst, checking whether it was suspicious
+    fn finish_loss_burst(&mut self) {
+        if self.last_burst_was_suspicious() {
+            self.suspicious_loss_bursts = self.suspicious_loss_bursts.saturating_add(1);
+        }
+
+        self.loss_burst_has_non_suspicious_packets = false;
+        self.largest_suspicious_packet_lost = None;
+        self.largest_non_probe_lost = None;
+    }
+
+    /// Returns true if the burst was suspicious and should count towards black hole detection
+    fn last_burst_was_suspicious(&self) -> bool {
+        // Ignore burst if it contains any non-suspicious packets, because in that case packet loss
+        // was likely caused by congestion (instead of a sudden decrease in the path's MTU)
+        if self.loss_burst_has_non_suspicious_packets {
+            return false;
+        }
+
+        // Ignore burst if we have received an ACK for a more recent MTU-sized packet, because that
+        // proves the network still supports the current MTU
+        let largest_acked = self.largest_acked_mtu_sized_packet.unwrap_or(0);
+        if self
+            .largest_suspicious_packet_lost
+            .map_or(true, |largest_lost| largest_lost < largest_acked)
+        {
+            return false;
+        }
+
+        true
+    }
+}
+
 // Corresponds to the RFC's `MAX_PROBES` constant (see
 // https://www.rfc-editor.org/rfc/rfc8899#section-5.1.2)
 const MAX_PROBE_RETRANSMITS: usize = 3;
@@ -402,6 +522,52 @@ mod tests {
     }
 
     #[test]
+    fn black_hole_detector_ignores_burst_containing_non_suspicious_packet() {
+        let mut mtud = default_mtud();
+        mtud.on_non_probe_lost(2, 1300);
+        mtud.on_non_probe_lost(3, 1300);
+        assert_eq!(
+            mtud.black_hole_detector.largest_suspicious_packet_lost,
+            Some(3)
+        );
+        assert_eq!(mtud.black_hole_detector.suspicious_loss_bursts, 0);
+
+        mtud.on_non_probe_lost(4, 800);
+        assert!(!mtud.black_hole_detected(Instant::now()));
+        assert_eq!(
+            mtud.black_hole_detector.largest_suspicious_packet_lost,
+            None
+        );
+        assert_eq!(mtud.black_hole_detector.suspicious_loss_bursts, 0);
+    }
+
+    #[test]
+    fn black_hole_detector_counts_burst_containing_only_suspicious_packets() {
+        let mut mtud = default_mtud();
+        mtud.on_non_probe_lost(2, 1300);
+        mtud.on_non_probe_lost(3, 1300);
+        assert_eq!(
+            mtud.black_hole_detector.largest_suspicious_packet_lost,
+            Some(3)
+        );
+        assert_eq!(mtud.black_hole_detector.suspicious_loss_bursts, 0);
+
+        assert!(!mtud.black_hole_detected(Instant::now()));
+        assert_eq!(
+            mtud.black_hole_detector.largest_suspicious_packet_lost,
+            None
+        );
+        assert_eq!(mtud.black_hole_detector.suspicious_loss_bursts, 1);
+    }
+
+    #[test]
+    fn black_hole_detector_ignores_empty_burst() {
+        let mut mtud = default_mtud();
+        assert!(!mtud.black_hole_detected(Instant::now()));
+        assert_eq!(mtud.black_hole_detector.suspicious_loss_bursts, 0);
+    }
+
+    #[test]
     fn mtu_discovery_disabled_does_nothing() {
         let mut mtud = MtuDiscovery::disabled(1_200);
         let probe_size = mtud.poll_transmit(Instant::now(), 0);
@@ -409,27 +575,42 @@ mod tests {
     }
 
     #[test]
-    fn mtu_discovery_disabled_lost_four_packets_triggers_black_hole_detection() {
+    fn mtu_discovery_disabled_lost_four_packet_bursts_triggers_black_hole_detection() {
         let mut mtud = MtuDiscovery::disabled(1_400);
         let now = Instant::now();
 
-        for _ in 0..4 {
-            mtud.on_non_probe_lost(now, 0, 1300);
+        for i in 0..4 {
+            // The packets are never contiguous, so each one has its own burst
+            mtud.on_non_probe_lost(i * 2, 1300);
         }
 
+        assert!(mtud.black_hole_detected(now));
         assert_eq!(mtud.current_mtu, 1200);
         assert_matches!(mtud.state, None);
     }
 
     #[test]
-    fn mtu_discovery_lost_four_packets_triggers_black_hole_detection_and_resets_timer() {
+    fn mtu_discovery_lost_two_packet_bursts_does_not_trigger_black_hole_detection() {
         let mut mtud = default_mtud();
         let now = Instant::now();
 
-        for _ in 0..4 {
-            mtud.on_non_probe_lost(now, 0, 1300);
+        for i in 0..2 {
+            mtud.on_non_probe_lost(i, 1300);
+            assert!(!mtud.black_hole_detected(now));
+        }
+    }
+
+    #[test]
+    fn mtu_discovery_lost_four_packet_bursts_triggers_black_hole_detection_and_resets_timer() {
+        let mut mtud = default_mtud();
+        let now = Instant::now();
+
+        for i in 0..4 {
+            // The packets are never contiguous, so each one has its own burst
+            mtud.on_non_probe_lost(i * 2, 1300);
         }
 
+        assert!(mtud.black_hole_detected(now));
         assert_eq!(mtud.current_mtu, 1200);
         if let Phase::Complete(next_mtud_activation) = mtud.state.unwrap().phase {
             assert_eq!(next_mtud_activation, now + Duration::from_secs(60));

--- a/quinn-proto/src/connection/pacing.rs
+++ b/quinn-proto/src/connection/pacing.rs
@@ -22,17 +22,12 @@ pub(super) struct Pacer {
 
 impl Pacer {
     /// Obtains a new [`Pacer`].
-    pub(super) fn new(
-        smoothed_rtt: Duration,
-        window: u64,
-        max_udp_payload_size: u16,
-        now: Instant,
-    ) -> Self {
-        let capacity = optimal_capacity(smoothed_rtt, window, max_udp_payload_size);
+    pub(super) fn new(smoothed_rtt: Duration, window: u64, mtu: u16, now: Instant) -> Self {
+        let capacity = optimal_capacity(smoothed_rtt, window, mtu);
         Self {
             capacity,
             last_window: window,
-            last_mtu: max_udp_payload_size,
+            last_mtu: mtu,
             tokens: capacity,
             prev: now,
         }
@@ -131,17 +126,14 @@ impl Pacer {
 /// tokens for the extra-elapsed time can be stored.
 ///
 /// Too long burst intervals make pacing less effective.
-fn optimal_capacity(smoothed_rtt: Duration, window: u64, max_udp_payload_size: u16) -> u64 {
+fn optimal_capacity(smoothed_rtt: Duration, window: u64, mtu: u16) -> u64 {
     let rtt = smoothed_rtt.as_nanos().max(1);
 
     let capacity = ((window as u128 * BURST_INTERVAL_NANOS) / rtt) as u64;
 
     // Small bursts are less efficient (no GSO), could increase latency and don't effectively
     // use the channel's buffer capacity. Large bursts might block the connection on sending.
-    capacity.clamp(
-        MIN_BURST_SIZE * max_udp_payload_size as u64,
-        MAX_BURST_SIZE * max_udp_payload_size as u64,
-    )
+    capacity.clamp(MIN_BURST_SIZE * mtu as u64, MAX_BURST_SIZE * mtu as u64)
 }
 
 /// The burst interval

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -38,6 +38,7 @@ impl PathData {
         initial_rtt: Duration,
         congestion: Box<dyn congestion::Controller>,
         initial_max_udp_payload_size: u16,
+        max_guaranteed_udp_payload_size: u16,
         peer_max_udp_payload_size: Option<u16>,
         mtud_config: Option<MtuDiscoveryConfig>,
         now: Instant,
@@ -60,10 +61,14 @@ impl PathData {
             total_sent: 0,
             total_recvd: 0,
             mtud: mtud_config.map_or(
-                MtuDiscovery::disabled(initial_max_udp_payload_size),
+                MtuDiscovery::disabled(
+                    initial_max_udp_payload_size,
+                    max_guaranteed_udp_payload_size,
+                ),
                 |config| {
                     MtuDiscovery::new(
                         initial_max_udp_payload_size,
+                        max_guaranteed_udp_payload_size,
                         peer_max_udp_payload_size,
                         config,
                     )

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -37,8 +37,8 @@ impl PathData {
         remote: SocketAddr,
         initial_rtt: Duration,
         congestion: Box<dyn congestion::Controller>,
-        initial_max_udp_payload_size: u16,
-        max_guaranteed_udp_payload_size: u16,
+        initial_mtu: u16,
+        min_guaranteed_mtu: u16,
         peer_max_udp_payload_size: Option<u16>,
         mtud_config: Option<MtuDiscoveryConfig>,
         now: Instant,
@@ -48,12 +48,7 @@ impl PathData {
             remote,
             rtt: RttEstimator::new(initial_rtt),
             sending_ecn: true,
-            pacing: Pacer::new(
-                initial_rtt,
-                congestion.initial_window(),
-                initial_max_udp_payload_size,
-                now,
-            ),
+            pacing: Pacer::new(initial_rtt, congestion.initial_window(), initial_mtu, now),
             congestion,
             challenge: None,
             challenge_pending: false,
@@ -61,14 +56,11 @@ impl PathData {
             total_sent: 0,
             total_recvd: 0,
             mtud: mtud_config.map_or(
-                MtuDiscovery::disabled(
-                    initial_max_udp_payload_size,
-                    max_guaranteed_udp_payload_size,
-                ),
+                MtuDiscovery::disabled(initial_mtu, min_guaranteed_mtu),
                 |config| {
                     MtuDiscovery::new(
-                        initial_max_udp_payload_size,
-                        max_guaranteed_udp_payload_size,
+                        initial_mtu,
+                        min_guaranteed_mtu,
                         peer_max_udp_payload_size,
                         config,
                     )

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -137,6 +137,8 @@ pub struct PathStats {
     /// The amount of PLPMTUD probe packets lost on this path (ignored by `lost_packets` and
     /// `lost_bytes`)
     pub lost_plpmtud_probes: u64,
+    /// The number of times a black hole was detected in the path
+    pub black_holes_detected: u64,
 }
 
 /// Connection statistics

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -28,8 +28,8 @@ use crate::{
         EndpointEventInner, IssuedCid,
     },
     transport_parameters::TransportParameters,
-    ResetToken, RetryToken, Side, Transmit, TransportConfig, TransportError,
-    INITIAL_MAX_UDP_PAYLOAD_SIZE, MAX_CID_SIZE, MIN_INITIAL_SIZE, RESET_TOKEN_SIZE,
+    ResetToken, RetryToken, Side, Transmit, TransportConfig, TransportError, INITIAL_MTU,
+    MAX_CID_SIZE, MIN_INITIAL_SIZE, RESET_TOKEN_SIZE,
 };
 
 /// The main entry point to the library
@@ -679,9 +679,8 @@ impl Endpoint {
 
         let mut buf = Vec::<u8>::new();
         let partial_encode = header.encode(&mut buf);
-        let max_len = INITIAL_MAX_UDP_PAYLOAD_SIZE as usize
-            - partial_encode.header_len
-            - crypto.packet.local.tag_len();
+        let max_len =
+            INITIAL_MTU as usize - partial_encode.header_len - crypto.packet.local.tag_len();
         frame::Close::from(reason).encode(&mut buf, max_len);
         buf.resize(buf.len() + crypto.packet.local.tag_len(), 0);
         partial_encode.finish(

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -65,8 +65,6 @@ pub struct Endpoint {
 
 impl Endpoint {
     /// Create a new endpoint
-    ///
-    /// Returns `Err` if the configuration is invalid.
     pub fn new(config: Arc<EndpointConfig>, server_config: Option<Arc<ServerConfig>>) -> Self {
         Self {
             rng: StdRng::from_entropy(),

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -294,7 +294,7 @@ const RESET_TOKEN_SIZE: usize = 16;
 const MAX_CID_SIZE: usize = 20;
 const MIN_INITIAL_SIZE: u16 = 1200;
 /// <https://www.rfc-editor.org/rfc/rfc9000.html#name-datagram-size>
-const INITIAL_MAX_UDP_PAYLOAD_SIZE: u16 = 1200;
+const INITIAL_MTU: u16 = 1200;
 const MAX_UDP_PAYLOAD: u16 = 65527;
 const TIMER_GRANULARITY: Duration = Duration::from_millis(1);
 /// Maximum number of streams that can be uniquely identified by a stream ID

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -2136,6 +2136,7 @@ fn blackhole_after_mtu_change_repairs_itself() {
     let client_stats = pair.client_conn_mut(client_ch).stats();
     assert!(client_stats.path.lost_packets >= 3);
     assert!(client_stats.path.congestion_events >= 3);
+    assert_eq!(client_stats.path.black_holes_detected, 1);
 }
 
 #[test]


### PR DESCRIPTION
This PR introduces a few self-contained improvements to make PLPMTUD work better.

We will probably want to discuss the API impact of the change to the congestion controller code:

* New `on_mtu_update` function on the `Controller` trait
* Removed `max_datagram_size` from all controller configs (the current MTU is used now instead)
* Removed `minimum_window` from all controller configs (it is now calculated on demand based on the current MTU)

With all this in place, running the top-level `bench` crate with a MTUD upper bound of 9000 results in sending rates of ~900 MiB/s (on my machine ™).