### PR TITLE
Impl Runtime for Box<dyn Runtime>

### DIFF
--- a/quinn/src/runtime.rs
+++ b/quinn/src/runtime.rs
@@ -75,6 +75,18 @@ pub fn default_runtime() -> Option<Arc<dyn Runtime>> {
     None
 }
 
+impl<R: Runtime + ?Sized> Runtime for Box<R> {
+    fn new_timer(&self, i: Instant) -> Pin<Box<dyn AsyncTimer>> {
+        self.as_ref().new_timer(i)
+    }
+    fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) {
+        self.as_ref().spawn(future);
+    }
+    fn wrap_udp_socket(&self, t: std::net::UdpSocket) -> io::Result<Box<dyn AsyncUdpSocket>> {
+        self.as_ref().wrap_udp_socket(t)
+    }
+}
+
 #[cfg(feature = "runtime-tokio")]
 mod tokio;
 #[cfg(feature = "runtime-tokio")]


### PR DESCRIPTION
In order to be able to hide `quinn` types from a user library we need to be able to create Endpoints with a dynamicly typed Runtimes. So far there is `quinn::Endpoint::new` function which is not usable for boxed Runtime's. This PR adds some flexibility to the API allowing a user to pass `Box<dyn Runtime>` into `quinn::Endpoint::new` function.

Please take a look at the discussion: https://github.com/libp2p/rust-libp2p/pull/3454#discussion_r1109515886