### PR TITLE
Duplicate Transmit and EcnCodepoint across -proto and -udp

### DIFF
--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -23,7 +23,6 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 libc = "0.2.69"
-proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.10", default-features = false }
 socket2 = "0.4" # 0.5.1 has an MSRV of 1.63
 tracing = "0.1.10"
 

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -15,7 +15,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use proto::{EcnCodepoint, Transmit};
 use tracing::warn;
 
 #[cfg(unix)]
@@ -121,6 +120,22 @@ impl Default for RecvMeta {
     }
 }
 
+/// An outgoing packet
+#[derive(Debug)]
+pub struct Transmit {
+    /// The socket this datagram should be sent to
+    pub destination: SocketAddr,
+    /// Explicit congestion notification bits to set on the packet
+    pub ecn: Option<EcnCodepoint>,
+    /// Contents of the datagram
+    pub contents: Vec<u8>,
+    /// The segment size if this transmission contains multiple datagrams.
+    /// This is `None` if the transmit only contains a single datagram
+    pub segment_size: Option<usize>,
+    /// Optional source IP address for the datagram
+    pub src_ip: Option<IpAddr>,
+}
+
 /// Log at most 1 IO error per minute
 const IO_ERROR_LOG_INTERVAL: Duration = std::time::Duration::from_secs(60);
 
@@ -167,5 +182,32 @@ where
 {
     fn from(socket: &'s S) -> Self {
         Self(socket.into())
+    }
+}
+
+/// Explicit congestion notification codepoint
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum EcnCodepoint {
+    #[doc(hidden)]
+    Ect0 = 0b10,
+    #[doc(hidden)]
+    Ect1 = 0b01,
+    #[doc(hidden)]
+    Ce = 0b11,
+}
+
+impl EcnCodepoint {
+    /// Create new object from the given bits
+    pub fn from_bits(x: u8) -> Option<Self> {
+        use self::EcnCodepoint::*;
+        Some(match x & 0b11 {
+            0b10 => Ect0,
+            0b01 => Ect1,
+            0b11 => Ce,
+            _ => {
+                return None;
+            }
+        })
     }
 }

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -6,10 +6,12 @@
 use std::os::unix::io::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawSocket;
+#[cfg(not(windows))]
+use std::sync::atomic::AtomicBool;
 use std::{
     net::{IpAddr, Ipv6Addr, SocketAddr},
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicUsize, Ordering},
         Mutex,
     },
     time::{Duration, Instant},
@@ -85,7 +87,7 @@ impl UdpState {
 
     /// Sets the flag indicating we got EINVAL error from `sendmsg` or `sendmmsg` syscall.
     #[inline]
-    #[cfg(not(windows))]
+    #[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
     fn set_sendmsg_einval(&self) {
         self.sendmsg_einval.store(true, Ordering::Relaxed)
     }

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -13,10 +13,12 @@ use std::{
     time::Instant,
 };
 
-use proto::{EcnCodepoint, Transmit};
 use socket2::SockRef;
 
-use super::{cmsg, log_sendmsg_error, RecvMeta, UdpSockRef, UdpState, IO_ERROR_LOG_INTERVAL};
+use super::{
+    cmsg, log_sendmsg_error, EcnCodepoint, RecvMeta, Transmit, UdpSockRef, UdpState,
+    IO_ERROR_LOG_INTERVAL,
+};
 
 #[cfg(target_os = "freebsd")]
 type IpTosTy = libc::c_uchar;

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -6,10 +6,9 @@ use std::{
     time::Instant,
 };
 
-use proto::Transmit;
 use windows_sys::Win32::Networking::WinSock;
 
-use super::{log_sendmsg_error, RecvMeta, UdpSockRef, UdpState, IO_ERROR_LOG_INTERVAL};
+use super::{log_sendmsg_error, RecvMeta, Transmit, UdpSockRef, UdpState, IO_ERROR_LOG_INTERVAL};
 
 /// QUIC-friendly UDP interface for Windows
 #[derive(Debug)]

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -350,7 +350,7 @@ pub(crate) struct State {
     socket: Box<dyn AsyncUdpSocket>,
     udp_state: Arc<UdpState>,
     inner: proto::Endpoint,
-    outgoing: VecDeque<proto::Transmit>,
+    outgoing: VecDeque<udp::Transmit>,
     incoming: VecDeque<Connecting>,
     driver: Option<Waker>,
     ipv6: bool,
@@ -394,10 +394,13 @@ impl State {
                         let mut data: BytesMut = buf[0..meta.len].into();
                         while !data.is_empty() {
                             let buf = data.split_to(meta.stride.min(data.len()));
-                            match self
-                                .inner
-                                .handle(now, meta.addr, meta.dst_ip, meta.ecn, buf)
-                            {
+                            match self.inner.handle(
+                                now,
+                                meta.addr,
+                                meta.dst_ip,
+                                meta.ecn.map(proto_ecn),
+                                buf,
+                            ) {
                                 Some((handle, DatagramEvent::NewConnection(conn))) => {
                                     let conn = self.connections.insert(
                                         handle,
@@ -449,7 +452,7 @@ impl State {
         let result = loop {
             while self.outgoing.len() < BATCH_SIZE {
                 match self.inner.poll_transmit() {
-                    Some(x) => self.outgoing.push_back(x),
+                    Some(t) => self.queue_transmit(t),
                     None => break,
                 }
             }
@@ -508,7 +511,7 @@ impl State {
                                 .send(ConnectionEvent::Proto(event));
                         }
                     }
-                    Transmit(t) => self.outgoing.push_back(t),
+                    Transmit(t) => self.queue_transmit(t),
                 },
                 Poll::Ready(None) => unreachable!("EndpointInner owns one sender"),
                 Poll::Pending => {
@@ -518,6 +521,34 @@ impl State {
         }
 
         true
+    }
+
+    fn queue_transmit(&mut self, t: proto::Transmit) {
+        self.outgoing.push_back(udp::Transmit {
+            destination: t.destination,
+            ecn: t.ecn.map(udp_ecn),
+            contents: t.contents,
+            segment_size: t.segment_size,
+            src_ip: t.src_ip,
+        });
+    }
+}
+
+#[inline]
+fn udp_ecn(ecn: proto::EcnCodepoint) -> udp::EcnCodepoint {
+    match ecn {
+        proto::EcnCodepoint::Ect0 => udp::EcnCodepoint::Ect0,
+        proto::EcnCodepoint::Ect1 => udp::EcnCodepoint::Ect1,
+        proto::EcnCodepoint::Ce => udp::EcnCodepoint::Ce,
+    }
+}
+
+#[inline]
+fn proto_ecn(ecn: udp::EcnCodepoint) -> proto::EcnCodepoint {
+    match ecn {
+        udp::EcnCodepoint::Ect0 => proto::EcnCodepoint::Ect0,
+        udp::EcnCodepoint::Ect1 => proto::EcnCodepoint::Ect1,
+        udp::EcnCodepoint::Ce => proto::EcnCodepoint::Ce,
     }
 }
 

--- a/quinn/src/runtime.rs
+++ b/quinn/src/runtime.rs
@@ -9,8 +9,7 @@ use std::{
     time::Instant,
 };
 
-use proto::Transmit;
-use udp::{RecvMeta, UdpState};
+use udp::{RecvMeta, Transmit, UdpState};
 
 /// Abstracts I/O and timer operations for runtime independence
 pub trait Runtime: Send + Sync + Debug + 'static {

--- a/quinn/src/runtime/async_std.rs
+++ b/quinn/src/runtime/async_std.rs
@@ -53,7 +53,7 @@ impl AsyncUdpSocket for UdpSocket {
         &self,
         state: &udp::UdpState,
         cx: &mut Context,
-        transmits: &[proto::Transmit],
+        transmits: &[udp::Transmit],
     ) -> Poll<io::Result<usize>> {
         loop {
             ready!(self.io.poll_writable(cx))?;

--- a/quinn/src/runtime/tokio.rs
+++ b/quinn/src/runtime/tokio.rs
@@ -55,7 +55,7 @@ impl AsyncUdpSocket for UdpSocket {
         &self,
         state: &udp::UdpState,
         cx: &mut Context,
-        transmits: &[proto::Transmit],
+        transmits: &[udp::Transmit],
     ) -> Poll<io::Result<usize>> {
         let inner = &self.inner;
         let io = &self.io;


### PR DESCRIPTION
To avoid a dependency edge from -udp -> -proto.