### PR TITLE
Implement acknowledgement frequency

### DIFF
--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -39,6 +39,7 @@ pub struct TransportConfig {
     pub(crate) initial_mtu: u16,
     pub(crate) min_guaranteed_mtu: u16,
     pub(crate) mtu_discovery_config: Option<MtuDiscoveryConfig>,
+    pub(crate) ack_frequency_config: Option<AckFrequencyConfig>,
 
     pub(crate) persistent_congestion_threshold: u32,
     pub(crate) keep_alive_interval: Option<Duration>,
@@ -218,6 +219,17 @@ impl TransportConfig {
         self
     }
 
+    /// Specifies the ACK frequency config (see [`AckFrequencyConfig`] for details).
+    ///
+    /// The provided configuration will be ignored if the peer does not support the acknowledgement
+    /// frequency QUIC extension.
+    ///
+    /// Defaults to `None`, which disables the ACK frequency feature.
+    pub fn ack_frequency_config(&mut self, value: Option<AckFrequencyConfig>) -> &mut Self {
+        self.ack_frequency_config = value;
+        self
+    }
+
     /// Number of consecutive PTOs after which network is considered to be experiencing persistent congestion.
     pub fn persistent_congestion_threshold(&mut self, value: u32) -> &mut Self {
         self.persistent_congestion_threshold = value;
@@ -316,6 +328,7 @@ impl Default for TransportConfig {
             initial_mtu: INITIAL_MTU,
             min_guaranteed_mtu: INITIAL_MTU,
             mtu_discovery_config: None,
+            ack_frequency_config: None,
 
             persistent_congestion_threshold: 3,
             keep_alive_interval: None,
@@ -362,6 +375,71 @@ impl fmt::Debug for TransportConfig {
             .field("datagram_send_buffer_size", &self.datagram_send_buffer_size)
             .field("congestion_controller_factory", &"[ opaque ]")
             .finish()
+    }
+}
+
+/// Parameters for controlling the peer's acknowledgement frequency
+///
+/// The parameters provided in this config will be sent to the peer at the beginning of the
+/// connection, so it can take them into account when sending acknowledgements (see each parameter's
+/// description for details on how it influences acknowledgement frequency).
+///
+/// Quinn's implementation follows the fourth draft of the
+/// [QUIC Acknowledgement Frequency extension](https://datatracker.ietf.org/doc/html/draft-ietf-quic-ack-frequency).
+#[derive(Clone, Debug)]
+pub struct AckFrequencyConfig {
+    pub(crate) ack_eliciting_threshold: u64,
+    pub(crate) max_ack_delay: Option<Duration>,
+    pub(crate) reordering_threshold: u64,
+}
+
+impl AckFrequencyConfig {
+    /// The number of ack-eliciting packets the remote peer receives before sending an ACK.
+    ///
+    /// The remote peer should send at least one ACK frame when more than this number of
+    /// ack-eliciting packets have been received. A value of 0 results in a receiver immediately
+    /// acknowledging every ack-eliciting packet.
+    ///
+    /// Defaults to 1, which sends ACK frames for every other ack-eliciting packet.
+    pub fn ack_eliciting_threshold(&mut self, value: u64) -> &mut Self {
+        self.ack_eliciting_threshold = value;
+        self
+    }
+
+    /// The maximum amount of time that the remote peer waits before sending an ACK when the
+    /// ack-eliciting threshold hasn't been reached.
+    ///
+    /// The provided `max_ack_delay` will be clamped to be at least the peer's `min_ack_delay`
+    /// transport parameter.
+    ///
+    /// Defaults to `None`, in which case the peer's original `max_ack_delay` will be used.
+    pub fn max_ack_delay(&mut self, value: Option<Duration>) -> &mut Self {
+        self.max_ack_delay = value;
+        self
+    }
+
+    /// The amount of out-of-order packets that will trigger a peer to send an ACK, without waiting
+    /// for `ack_eliciting_threshold` to be exceeded or for `max_ack_delay` to be elapsed.
+    ///
+    /// A value of 0 indicates out-of-order packets do not elicit an immediate ACK. A value of 1
+    /// immediately acknowledges any packets that are received out of order.
+    ///
+    /// It is recommended to set this value to [`TransportConfig::packet_threshold`] minus one.
+    /// Since the default value for [`TransportConfig::packet_threshold`] is 3, this value defaults
+    /// to 2.
+    pub fn reordering_threshold(&mut self, value: u64) -> &mut Self {
+        self.reordering_threshold = value;
+        self
+    }
+}
+
+impl Default for AckFrequencyConfig {
+    fn default() -> Self {
+        Self {
+            ack_eliciting_threshold: 1,
+            max_ack_delay: None,
+            reordering_threshold: 2,
+        }
     }
 }
 

--- a/quinn-proto/src/connection/ack_frequency.rs
+++ b/quinn-proto/src/connection/ack_frequency.rs
@@ -1,0 +1,65 @@
+use crate::AckFrequencyConfig;
+use std::time::Duration;
+
+pub(super) struct AckFrequencyState {
+    in_flight_ack_frequency_frame: Option<(u64, Duration)>,
+    next_sequence_number: u64,
+    pub(super) peer_max_ack_delay: Duration,
+}
+
+impl AckFrequencyState {
+    pub(super) fn new(peer_max_ack_delay: Duration) -> Self {
+        Self {
+            in_flight_ack_frequency_frame: None,
+            next_sequence_number: 0,
+            peer_max_ack_delay,
+        }
+    }
+
+    /// Returns the `max_ack_delay` that should be requested of the peer when sending an
+    /// ACK_FREQUENCY frame
+    pub(super) fn candidate_max_ack_delay(&self, config: &AckFrequencyConfig) -> Duration {
+        // Use the peer's max_ack_delay if no custom max_ack_delay was provided in the config
+        config.max_ack_delay.unwrap_or(self.peer_max_ack_delay)
+    }
+
+    /// Returns the `max_ack_delay` for the purposes of calculating the PTO, defined as the maximum
+    /// of the peer's current `max_ack_delay` and all in-flight max ack delays.
+    pub(super) fn max_ack_delay_for_pto(&self) -> Duration {
+        if let Some((_, max_ack_delay)) = self.in_flight_ack_frequency_frame {
+            self.peer_max_ack_delay.max(max_ack_delay)
+        } else {
+            self.peer_max_ack_delay
+        }
+    }
+
+    /// Returns the next sequence number for an ACK_FREQUENCY frame
+    pub(super) fn next_sequence_number(&mut self) -> u64 {
+        let seq = self.next_sequence_number;
+        self.next_sequence_number += 1;
+        seq
+    }
+
+    /// Returns true if we should send an ACK_FREQUENCY frame
+    pub(super) fn should_send_ack_frequency(&self) -> bool {
+        // Currently, we only allow sending a single ACK_FREQUENCY frame. There is no need to send
+        // more, because none of the sent values needs to be updated in the course of the connection
+        self.next_sequence_number == 0
+    }
+
+    /// Notifies the [`AckFrequencyState`] that a packet containing an ACK_FREQUENCY frame was sent
+    pub(super) fn ack_frequency_sent(&mut self, pn: u64, requested_max_ack_delay: Duration) {
+        self.in_flight_ack_frequency_frame = Some((pn, requested_max_ack_delay));
+    }
+
+    /// Notifies the [`AckFrequencyState`] that a packet has been ACKed
+    pub(super) fn on_acked(&mut self, pn: u64) {
+        match self.in_flight_ack_frequency_frame {
+            Some((number, requested_max_ack_delay)) if number == pn => {
+                self.in_flight_ack_frequency_frame = None;
+                self.peer_max_ack_delay = requested_max_ack_delay;
+            }
+            _ => {}
+        }
+    }
+}

--- a/quinn-proto/src/connection/packet_crypto.rs
+++ b/quinn-proto/src/connection/packet_crypto.rs
@@ -1,0 +1,173 @@
+use std::time::Instant;
+use tracing::{debug, trace};
+
+use crate::connection::spaces::PacketSpace;
+use crate::crypto::{HeaderKey, KeyPair, PacketKey};
+use crate::packet::{Packet, PartialDecode, SpaceId};
+use crate::token::ResetToken;
+use crate::{TransportError, RESET_TOKEN_SIZE};
+
+pub(super) struct UnprotectHeaderResult {
+    /// The packet with the now unprotected header (`None` in the case of stateless reset packets
+    /// that fail to be decoded)
+    pub(super) packet: Option<Packet>,
+    /// Whether the packet was a stateless reset packet
+    pub(super) stateless_reset: bool,
+}
+
+/// Removes header protection of a packet, or returns `None` if the packet was dropped
+pub(super) fn unprotect_header(
+    partial_decode: PartialDecode,
+    spaces: &[PacketSpace; 3],
+    zero_rtt_crypto: Option<&ZeroRttCrypto>,
+    stateless_reset_token: Option<ResetToken>,
+) -> Option<UnprotectHeaderResult> {
+    let header_crypto = if partial_decode.is_0rtt() {
+        if let Some(crypto) = zero_rtt_crypto {
+            Some(&*crypto.header)
+        } else {
+            debug!("dropping unexpected 0-RTT packet");
+            return None;
+        }
+    } else if let Some(space) = partial_decode.space() {
+        if let Some(ref crypto) = spaces[space].crypto {
+            Some(&*crypto.header.remote)
+        } else {
+            debug!(
+                "discarding unexpected {:?} packet ({} bytes)",
+                space,
+                partial_decode.len(),
+            );
+            return None;
+        }
+    } else {
+        // Unprotected packet
+        None
+    };
+
+    let packet = partial_decode.data();
+    let stateless_reset = packet.len() >= RESET_TOKEN_SIZE + 5
+        && stateless_reset_token.as_deref() == Some(&packet[packet.len() - RESET_TOKEN_SIZE..]);
+
+    match partial_decode.finish(header_crypto) {
+        Ok(packet) => Some(UnprotectHeaderResult {
+            packet: Some(packet),
+            stateless_reset,
+        }),
+        Err(_) if stateless_reset => Some(UnprotectHeaderResult {
+            packet: None,
+            stateless_reset: true,
+        }),
+        Err(e) => {
+            trace!("unable to complete packet decoding: {}", e);
+            None
+        }
+    }
+}
+
+pub(super) struct DecryptPacketResult {
+    /// The packet number
+    pub(super) number: u64,
+    /// Whether a locally initiated key update has been acknowledged by the peer
+    pub(super) outgoing_key_update_acked: bool,
+    /// Whether the peer has initiated a key update
+    pub(super) incoming_key_update: bool,
+}
+
+/// Decrypts a packet's body in-place
+pub(super) fn decrypt_packet_body(
+    packet: &mut Packet,
+    spaces: &[PacketSpace; 3],
+    zero_rtt_crypto: Option<&ZeroRttCrypto>,
+    conn_key_phase: bool,
+    prev_crypto: Option<&PrevCrypto>,
+    next_crypto: Option<&KeyPair<Box<dyn PacketKey>>>,
+) -> Result<Option<DecryptPacketResult>, Option<TransportError>> {
+    if !packet.header.is_protected() {
+        // Unprotected packets also don't have packet numbers
+        return Ok(None);
+    }
+    let space = packet.header.space();
+    let rx_packet = spaces[space].rx_packet;
+    let number = packet.header.number().ok_or(None)?.expand(rx_packet + 1);
+    let packet_key_phase = packet.header.key_phase();
+
+    let mut crypto_update = false;
+    let crypto = if packet.header.is_0rtt() {
+        &zero_rtt_crypto.unwrap().packet
+    } else if packet_key_phase == conn_key_phase || space != SpaceId::Data {
+        &spaces[space].crypto.as_ref().unwrap().packet.remote
+    } else if let Some(prev) = prev_crypto.and_then(|crypto| {
+        // If this packet comes prior to acknowledgment of the key update by the peer,
+        if crypto.end_packet.map_or(true, |(pn, _)| number < pn) {
+            // use the previous keys.
+            Some(crypto)
+        } else {
+            // Otherwise, this must be a remotely-initiated key update, so fall through to the
+            // final case.
+            None
+        }
+    }) {
+        &prev.crypto.remote
+    } else {
+        // We're in the Data space with a key phase mismatch and either there is no locally
+        // initiated key update or the locally initiated key update was acknowledged by a
+        // lower-numbered packet. The key phase mismatch must therefore represent a new
+        // remotely-initiated key update.
+        crypto_update = true;
+        &next_crypto.unwrap().remote
+    };
+
+    crypto
+        .decrypt(number, &packet.header_data, &mut packet.payload)
+        .map_err(|_| {
+            trace!("decryption failed with packet number {}", number);
+            None
+        })?;
+
+    if !packet.reserved_bits_valid() {
+        return Err(Some(TransportError::PROTOCOL_VIOLATION(
+            "reserved bits set",
+        )));
+    }
+
+    let mut outgoing_key_update_acked = false;
+    if let Some(prev) = prev_crypto {
+        if prev.end_packet.is_none() && packet_key_phase == conn_key_phase {
+            outgoing_key_update_acked = true;
+        }
+    }
+
+    if crypto_update {
+        // Validate incoming key update
+        if number <= rx_packet || prev_crypto.map_or(false, |x| x.update_unacked) {
+            return Err(Some(TransportError::KEY_UPDATE_ERROR("")));
+        }
+    }
+
+    Ok(Some(DecryptPacketResult {
+        number,
+        outgoing_key_update_acked,
+        incoming_key_update: crypto_update,
+    }))
+}
+
+pub(super) struct PrevCrypto {
+    /// The keys used for the previous key phase, temporarily retained to decrypt packets sent by
+    /// the peer prior to its own key update.
+    pub(super) crypto: KeyPair<Box<dyn PacketKey>>,
+    /// The incoming packet that ends the interval for which these keys are applicable, and the time
+    /// of its receipt.
+    ///
+    /// Incoming packets should be decrypted using these keys iff this is `None` or their packet
+    /// number is lower. `None` indicates that we have not yet received a packet using newer keys,
+    /// which implies that the update was locally initiated.
+    pub(super) end_packet: Option<(u64, Instant)>,
+    /// Whether the following key phase is from a remotely initiated update that we haven't acked
+    pub(super) update_unacked: bool,
+}
+
+pub(super) struct ZeroRttCrypto {
+    pub(super) header: Box<dyn HeaderKey>,
+    pub(super) packet: Box<dyn PacketKey>,
+}

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -14,7 +14,7 @@ use crate::{
     shared::IssuedCid, Dir, StreamId, VarInt,
 };
 
-pub(super) struct PacketSpace {
+pub(crate) struct PacketSpace {
     pub(super) crypto: Option<Keys>,
     pub(super) dedup: Dedup,
     /// Highest received packet number

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -57,6 +57,7 @@ pub(super) struct PacketSpace {
     /// Number of tail loss probes to send
     pub(super) loss_probes: u32,
     pub(super) ping_pending: bool,
+    pub(super) immediate_ack_pending: bool,
     /// Number of congestion control "in flight" bytes
     pub(super) in_flight: u64,
     /// Number of packets sent in the current key phase
@@ -71,7 +72,7 @@ impl PacketSpace {
             rx_packet: 0,
 
             pending: Retransmits::default(),
-            pending_acks: PendingAcks::default(),
+            pending_acks: PendingAcks::new(),
 
             next_packet_number: 0,
             largest_acked_packet: None,
@@ -87,6 +88,7 @@ impl PacketSpace {
             loss_time: None,
             loss_probes: 0,
             ping_pending: false,
+            immediate_ack_pending: false,
             in_flight: 0,
             sent_with_keys: 0,
         }
@@ -104,9 +106,19 @@ impl PacketSpace {
     /// waiting to be sent, then we retransmit in-flight data to reduce odds of loss. If there's no
     /// in-flight data either, we're probably a client guarding against a handshake
     /// anti-amplification deadlock and we just make something up.
-    pub(super) fn maybe_queue_probe(&mut self, streams: &StreamsState) {
+    pub(super) fn maybe_queue_probe(
+        &mut self,
+        request_immediate_ack: bool,
+        streams: &StreamsState,
+    ) {
         if self.loss_probes == 0 {
             return;
+        }
+
+        if request_immediate_ack {
+            // The probe should be ACKed without delay (should only be used in the Data space and
+            // when the peer supports the acknowledgement frequency extension)
+            self.immediate_ack_pending = true;
         }
 
         // Retransmit the data of the oldest in-flight packet
@@ -141,7 +153,8 @@ impl PacketSpace {
 
     pub(super) fn can_send(&self, streams: &StreamsState) -> SendableFrames {
         let acks = self.pending_acks.can_send();
-        let other = !self.pending.is_empty(streams) || self.ping_pending;
+        let other =
+            !self.pending.is_empty(streams) || self.ping_pending || self.immediate_ack_pending;
 
         SendableFrames { acks, other }
     }
@@ -233,6 +246,7 @@ pub struct Retransmits {
     pub(super) crypto: VecDeque<frame::Crypto>,
     pub(super) new_cids: Vec<IssuedCid>,
     pub(super) retire_cids: Vec<u64>,
+    pub(super) ack_frequency: Option<u64>,
     pub(super) handshake_done: bool,
 }
 
@@ -249,6 +263,7 @@ impl Retransmits {
             && self.crypto.is_empty()
             && self.new_cids.is_empty()
             && self.retire_cids.is_empty()
+            && self.ack_frequency.is_none()
             && !self.handshake_done
     }
 }
@@ -269,6 +284,7 @@ impl ::std::ops::BitOrAssign for Retransmits {
         }
         self.new_cids.extend(&rhs.new_cids);
         self.retire_cids.extend(rhs.retire_cids);
+        self.ack_frequency.or(rhs.ack_frequency);
         self.handshake_done |= rhs.handshake_done;
     }
 }
@@ -390,6 +406,65 @@ impl Dedup {
             true
         }
     }
+
+    /// Returns the packet number of the smallest packet missing between the provided interval, or
+    /// `None` if there are no missing packets
+    fn smallest_missing_in_interval(&self, lower_bound: u64, upper_bound: u64) -> Option<u64> {
+        debug_assert!(lower_bound <= upper_bound);
+        debug_assert!(upper_bound <= self.highest());
+        const BITFIELD_MAX_OFFSET: u64 = 128;
+
+        // Since we already know the packets at the boundaries have been received, we only need to
+        // check those in between them (this removes the necessity of extra logic to deal with the
+        // highest packet)
+        let lower_bound = lower_bound + 1;
+        let upper_bound = upper_bound.saturating_sub(1);
+
+        // Note: the offsets are counted from the right
+        // The highest packet is not included in the bitfield, so we subtract 1 to account for that
+        let start_offset = (self.highest() - upper_bound).max(1) - 1;
+        if start_offset > BITFIELD_MAX_OFFSET {
+            // The start offset is outside of the window. All packets outside of the window are
+            // considered to be received.
+            return None;
+        }
+
+        let end_offset_exclusive = self.highest().saturating_sub(lower_bound);
+
+        // The range is clamped at the edge of the window, because any earlier packets are
+        // considered to be received
+        let range_len = end_offset_exclusive
+            .saturating_sub(start_offset)
+            .min(BITFIELD_MAX_OFFSET);
+        if range_len == 0 {
+            return None;
+        }
+
+        // Since shifting by 128 is not allowed, we need to manually check for the max offset
+        let mask = if range_len == BITFIELD_MAX_OFFSET {
+            u128::MAX
+        } else {
+            ((1u128 << range_len) - 1) << start_offset
+        };
+        let gaps = !self.window & mask;
+
+        let smallest_missing_offset = 128 - gaps.leading_zeros() as u64;
+        let smallest_missing_packet = self.highest() - smallest_missing_offset;
+
+        if smallest_missing_packet <= upper_bound {
+            Some(smallest_missing_packet)
+        } else {
+            None
+        }
+    }
+
+    /// Returns true if there are any missing packets between the provided interval
+    ///
+    /// The provided packet numbers must have been received before calling this function.
+    fn missing_in_interval(&self, lower_bound: u64, upper_bound: u64) -> bool {
+        self.smallest_missing_in_interval(lower_bound, upper_bound)
+            .is_some()
+    }
 }
 
 /// Indicates which data is available for sending
@@ -414,51 +489,183 @@ impl SendableFrames {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(super) struct PendingAcks {
-    permit_ack_only: bool,
-    ranges: ArrayRangeSet,
-    /// This value will be used for calculating ACK delay once it is implemented
+    /// Whether we should send an ACK immediately, even if that means sending an ACK-only packet
     ///
-    /// ACK delay will be the delay between when a packet arrived (`latest_incoming`)
-    /// and between it will be allowed to be acknowledged (`can_send() == true`).
-    latest_incoming: Option<Instant>,
-    ack_delay: Duration,
+    /// When `immediate_ack_required` is false, the normal behavior is to send ACK frames only when
+    /// there is other data to send.
+    immediate_ack_required: bool,
+    /// The number of ack-eliciting packets received since the last ACK frame was sent
+    ///
+    /// Once the count _exceeds_ `ack_eliciting_threshold`, an immediate ACK is required
+    ack_eliciting_since_last_ack_sent: u64,
+    ack_eliciting_threshold: u64,
+    /// The reordering threshold, controlling how we respond to out-of-order ack-eliciting packets
+    ///
+    /// Different values enable different behavior:
+    ///
+    /// * `0`: no special action is taken
+    /// * `1`: an ACK is immediately sent if it is out-of-order according to RFC 9000
+    /// * `>1`: an ACK is immediately sent if it is out-of-order according to the ACK frequency draft
+    reordering_threshold: u64,
+    /// The earliest ack-eliciting packet since the last ACK was sent, used to calculate the moment
+    /// upon which `max_ack_delay` elapses
+    earliest_ack_eliciting_since_last_ack_sent: Option<Instant>,
+    /// The packet number ranges of ack-eliciting packets yet to be ACKed
+    ranges: ArrayRangeSet,
+    /// The packet with the largest packet number, and the time upon which it was received (used to
+    /// calculate ACK delay in [`PendingAcks::ack_delay`])
+    largest_packet: Option<(u64, Instant)>,
+    /// The ack-eliciting packet we have received with the largest packet number
+    largest_ack_eliciting_packet: Option<u64>,
+    /// The largest acknowledged value sent in an ACK frame
+    largest_acked: Option<u64>,
 }
 
 impl PendingAcks {
-    /// Whether any ACK frames can be sent
-    pub(super) fn can_send(&self) -> bool {
-        self.permit_ack_only && !self.ranges.is_empty()
+    fn new() -> Self {
+        Self {
+            immediate_ack_required: false,
+            ack_eliciting_since_last_ack_sent: 0,
+            ack_eliciting_threshold: 1,
+            reordering_threshold: 1,
+            earliest_ack_eliciting_since_last_ack_sent: None,
+            ranges: ArrayRangeSet::default(),
+            largest_packet: None,
+            largest_ack_eliciting_packet: None,
+            largest_acked: None,
+        }
     }
 
-    /// Returns the duration the acknowledgement of the latest incoming packet has been delayed
-    pub(super) fn ack_delay(&self) -> Duration {
-        self.ack_delay
+    pub(super) fn set_ack_eliciting_threshold(&mut self, threshold: u64) {
+        self.ack_eliciting_threshold = threshold;
+    }
+
+    pub(super) fn set_reordering_threshold(&mut self, threshold: u64) {
+        self.reordering_threshold = threshold;
+    }
+
+    pub(super) fn set_immediate_ack_required(&mut self) {
+        self.immediate_ack_required = true;
+    }
+
+    pub(super) fn on_max_ack_delay_timeout(&mut self) {
+        self.immediate_ack_required = self.ack_eliciting_since_last_ack_sent > 0;
+    }
+
+    pub(super) fn max_ack_delay_timeout(&self, max_ack_delay: Duration) -> Option<Instant> {
+        self.earliest_ack_eliciting_since_last_ack_sent
+            .map(|earliest_unacked| earliest_unacked + max_ack_delay)
+    }
+
+    /// Whether any ACK frames can be sent
+    pub(super) fn can_send(&self) -> bool {
+        self.immediate_ack_required && !self.ranges.is_empty()
+    }
+
+    /// Returns the delay since the packet with the largest packet number was received
+    pub(super) fn ack_delay(&self, now: Instant) -> Duration {
+        self.largest_packet
+            .map_or(Duration::default(), |(_, received)| now - received)
     }
 
     /// Handle receipt of a new packet
-    pub(super) fn packet_received(&mut self, ack_eliciting: bool) {
-        self.permit_ack_only |= ack_eliciting;
+    ///
+    /// Returns true if the max ack delay timer should be armed
+    pub(super) fn packet_received(
+        &mut self,
+        now: Instant,
+        packet_number: u64,
+        ack_eliciting: bool,
+        dedup: &Dedup,
+    ) -> bool {
+        if !ack_eliciting {
+            return false;
+        }
+
+        let prev_largest_ack_eliciting = self.largest_ack_eliciting_packet.unwrap_or(0);
+
+        // Track largest ack-eliciting packet
+        self.largest_ack_eliciting_packet = self
+            .largest_ack_eliciting_packet
+            .map(|pn| pn.max(packet_number))
+            .or(Some(packet_number));
+
+        // Handle ack_eliciting_threshold
+        self.ack_eliciting_since_last_ack_sent += 1;
+        self.immediate_ack_required |=
+            self.ack_eliciting_since_last_ack_sent > self.ack_eliciting_threshold;
+
+        // Handle out-of-order packets
+        self.immediate_ack_required |=
+            self.is_out_of_order(packet_number, prev_largest_ack_eliciting, dedup);
+
+        // Arm max_ack_delay timer if necessary
+        if self.earliest_ack_eliciting_since_last_ack_sent.is_none() && !self.can_send() {
+            self.earliest_ack_eliciting_since_last_ack_sent = Some(now);
+            return true;
+        }
+
+        false
+    }
+
+    fn is_out_of_order(
+        &self,
+        packet_number: u64,
+        prev_largest_ack_eliciting: u64,
+        dedup: &Dedup,
+    ) -> bool {
+        match self.reordering_threshold {
+            0 => false,
+            1 => {
+                // From https://www.rfc-editor.org/rfc/rfc9000#section-13.2.1-7
+                packet_number < prev_largest_ack_eliciting
+                    || dedup.missing_in_interval(prev_largest_ack_eliciting, packet_number)
+            }
+            _ => {
+                // From acknowledgement frequency draft, section 6.1
+                if let Some((largest_acked, largest_unacked)) =
+                    self.largest_acked.zip(self.largest_ack_eliciting_packet)
+                {
+                    dedup
+                        .smallest_missing_in_interval(largest_acked, largest_unacked)
+                        .map_or(false, |smallest_missing| {
+                            largest_unacked - smallest_missing >= self.reordering_threshold
+                        })
+                } else {
+                    false
+                }
+            }
+        }
     }
 
     /// Should be called whenever ACKs have been sent
     ///
     /// This will suppress sending further ACKs until additional ACK eliciting frames arrive
     pub(super) fn acks_sent(&mut self) {
-        // If we sent any acks, don't immediately resend them. Setting this even if ack_only is
-        // false needlessly prevents us from ACKing the next packet if it's ACK-only, but saves
-        // the need for subtler logic to avoid double-transmitting acks all the time.
-        // This reset needs to happen before we check whether more data
-        // is available in this space - because otherwise it would return
-        // `true` purely due to the ACKs
-        self.permit_ack_only = false;
+        // It is possible (though unlikely) that the ACKs we just sent do not cover all the
+        // ACK-eliciting packets we have received (e.g. if there is not enough room in the packet to
+        // fit all the ranges). To keep things simple, however, we assume they do. If there are
+        // indeed some ACKs that weren't covered, the packets might be ACKed later anyway, because
+        // they are still contained in `self.ranges`. If we somehow fail to send the ACKs at a later
+        // moment, the peer will assume the packets got lost and will retransmit their frames in a
+        // new packet, which is suboptimal, because we already received them. Our assumption here is
+        // that simplicity results in code that is more performant, even in the presence of
+        // occasional redundant retransmits.
+        self.immediate_ack_required = false;
+        self.ack_eliciting_since_last_ack_sent = 0;
+        self.earliest_ack_eliciting_since_last_ack_sent = None;
+        self.largest_acked = self.largest_ack_eliciting_packet;
     }
 
     /// Insert one packet that needs to be acknowledged
     pub(super) fn insert_one(&mut self, packet: u64, now: Instant) {
         self.ranges.insert_one(packet);
-        self.latest_incoming = Some(now);
+
+        if self.largest_packet.map_or(true, |(pn, _)| packet > pn) {
+            self.largest_packet = Some((packet, now));
+        }
 
         if self.ranges.len() > MAX_ACK_BLOCKS {
             self.ranges.pop_min();
@@ -537,6 +744,130 @@ mod test {
         assert!(!dedup.insert(WINDOW_SIZE + 1));
         assert_eq!(dedup.next, 2 * WINDOW_SIZE + 1);
         assert_eq!(dedup.window, 1 << (WINDOW_SIZE - 2));
+    }
+
+    #[test]
+    fn dedup_has_missing() {
+        let mut dedup = Dedup::new();
+
+        dedup.insert(0);
+        assert!(!dedup.missing_in_interval(0, 0));
+
+        dedup.insert(1);
+        assert!(!dedup.missing_in_interval(0, 1));
+
+        dedup.insert(3);
+        assert!(dedup.missing_in_interval(1, 3));
+
+        dedup.insert(4);
+        assert!(!dedup.missing_in_interval(3, 4));
+        assert!(dedup.missing_in_interval(0, 4));
+
+        dedup.insert(2);
+        assert!(!dedup.missing_in_interval(0, 4));
+    }
+
+    #[test]
+    fn dedup_outside_of_window_has_missing() {
+        let mut dedup = Dedup::new();
+
+        for i in 0..140 {
+            dedup.insert(i);
+        }
+
+        // 0 and 4 are outside of the window
+        assert!(!dedup.missing_in_interval(0, 4));
+        dedup.insert(160);
+        assert!(!dedup.missing_in_interval(0, 4));
+        assert!(!dedup.missing_in_interval(0, 140));
+        assert!(dedup.missing_in_interval(0, 160));
+    }
+
+    #[test]
+    fn dedup_smallest_missing() {
+        let mut dedup = Dedup::new();
+
+        dedup.insert(0);
+        assert_eq!(dedup.smallest_missing_in_interval(0, 0), None);
+
+        dedup.insert(1);
+        assert_eq!(dedup.smallest_missing_in_interval(0, 1), None);
+
+        dedup.insert(5);
+        dedup.insert(7);
+        assert_eq!(dedup.smallest_missing_in_interval(0, 7), Some(2));
+        assert_eq!(dedup.smallest_missing_in_interval(5, 7), Some(6));
+
+        dedup.insert(2);
+        assert_eq!(dedup.smallest_missing_in_interval(1, 7), Some(3));
+
+        dedup.insert(500);
+        assert_eq!(dedup.smallest_missing_in_interval(0, 500), Some(372));
+        assert_eq!(dedup.smallest_missing_in_interval(0, 373), Some(372));
+        assert_eq!(dedup.smallest_missing_in_interval(0, 372), None);
+    }
+
+    #[test]
+    fn pending_acks_first_packet_is_not_considered_reordered() {
+        let mut acks = PendingAcks::new();
+        let mut dedup = Dedup::new();
+        dedup.insert(0);
+        acks.packet_received(Instant::now(), 0, true, &dedup);
+        assert!(!acks.immediate_ack_required);
+    }
+
+    #[test]
+    fn pending_acks_after_immediate_ack_set() {
+        let mut acks = PendingAcks::new();
+        let mut dedup = Dedup::new();
+
+        // Receive ack-eliciting packet
+        dedup.insert(0);
+        let now = Instant::now();
+        acks.insert_one(0, now);
+        acks.packet_received(now, 0, true, &dedup);
+
+        // Sanity check
+        assert!(!acks.ranges.is_empty());
+        assert!(!acks.can_send());
+
+        // Can send ACK after max_ack_delay exceeded
+        acks.set_immediate_ack_required();
+        assert!(acks.can_send());
+    }
+
+    #[test]
+    fn pending_acks_ack_delay() {
+        let mut acks = PendingAcks::new();
+        let mut dedup = Dedup::new();
+
+        let t1 = Instant::now();
+        let t2 = t1 + Duration::from_millis(2);
+        let t3 = t2 + Duration::from_millis(5);
+        assert_eq!(acks.ack_delay(t1), Duration::from_millis(0));
+        assert_eq!(acks.ack_delay(t2), Duration::from_millis(0));
+        assert_eq!(acks.ack_delay(t3), Duration::from_millis(0));
+
+        // In-order packet
+        dedup.insert(0);
+        acks.insert_one(0, t1);
+        acks.packet_received(t1, 0, true, &dedup);
+        assert_eq!(acks.ack_delay(t1), Duration::from_millis(0));
+        assert_eq!(acks.ack_delay(t2), Duration::from_millis(2));
+        assert_eq!(acks.ack_delay(t3), Duration::from_millis(7));
+
+        // Out of order (higher than expected)
+        dedup.insert(3);
+        acks.insert_one(3, t2);
+        acks.packet_received(t2, 3, true, &dedup);
+        assert_eq!(acks.ack_delay(t2), Duration::from_millis(0));
+        assert_eq!(acks.ack_delay(t3), Duration::from_millis(5));
+
+        // Out of order (lower than expected, so previous instant is kept)
+        dedup.insert(2);
+        acks.insert_one(2, t3);
+        acks.packet_received(t3, 2, true, &dedup);
+        assert_eq!(acks.ack_delay(t3), Duration::from_millis(5));
     }
 
     #[test]

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -23,11 +23,13 @@ pub struct UdpStats {
 #[non_exhaustive]
 pub struct FrameStats {
     pub acks: u64,
+    pub ack_frequency: u64,
     pub crypto: u64,
     pub connection_close: u64,
     pub data_blocked: u64,
     pub datagram: u64,
     pub handshake_done: u8,
+    pub immediate_ack: u64,
     pub max_data: u64,
     pub max_stream_data: u64,
     pub max_streams_bidi: u64,
@@ -81,6 +83,8 @@ impl FrameStats {
             Frame::PathChallenge(_) => self.path_challenge += 1,
             Frame::PathResponse(_) => self.path_response += 1,
             Frame::Close(_) => self.connection_close += 1,
+            Frame::AckFrequency(_) => self.ack_frequency += 1,
+            Frame::ImmediateAck => self.immediate_ack += 1,
             Frame::HandshakeDone => self.handshake_done += 1,
             Frame::Invalid { .. } => {}
         }
@@ -91,11 +95,13 @@ impl std::fmt::Debug for FrameStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FrameStats")
             .field("ACK", &self.acks)
+            .field("ACK_FREQUENCY", &self.ack_frequency)
             .field("CONNECTION_CLOSE", &self.connection_close)
             .field("CRYPTO", &self.crypto)
             .field("DATA_BLOCKED", &self.data_blocked)
             .field("DATAGRAM", &self.datagram)
             .field("HANDSHAKE_DONE", &self.handshake_done)
+            .field("IMMEDIATE_ACK", &self.immediate_ack)
             .field("MAX_DATA", &self.max_data)
             .field("MAX_STREAM_DATA", &self.max_stream_data)
             .field("MAX_STREAMS_BIDI", &self.max_streams_bidi)

--- a/quinn-proto/src/connection/timer.rs
+++ b/quinn-proto/src/connection/timer.rs
@@ -18,10 +18,15 @@ pub(crate) enum Timer {
     Pacing = 6,
     /// When to invalidate old CID and proactively push new one via NEW_CONNECTION_ID frame
     PushNewCid = 7,
+    /// When to send an immediate ACK if there are unacked ack-elicited packets of the peer
+    MaxAckDelay = 8,
+    /// When the RTT is elapsed (used to request an immediate ack if there are local unacked
+    /// ack-eliciting packets)
+    Rtt = 9,
 }
 
 impl Timer {
-    pub(crate) const VALUES: [Self; 8] = [
+    pub(crate) const VALUES: [Self; 10] = [
         Self::LossDetection,
         Self::Idle,
         Self::Close,
@@ -30,13 +35,15 @@ impl Timer {
         Self::KeepAlive,
         Self::Pacing,
         Self::PushNewCid,
+        Self::MaxAckDelay,
+        Self::Rtt,
     ];
 }
 
 /// A table of data associated with each distinct kind of `Timer`
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) struct TimerTable {
-    data: [Option<Instant>; 8],
+    data: [Option<Instant>; 10],
 }
 
 impl TimerTable {

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -49,8 +49,8 @@ pub use crate::connection::{
 
 mod config;
 pub use config::{
-    ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig, ServerConfig,
-    TransportConfig,
+    AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig,
+    ServerConfig, TransportConfig,
 };
 
 pub mod crypto;

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -19,7 +19,7 @@ use crate::{
 // to inspect the version and packet type (which depends on the version).
 // This information allows us to fully decode and decrypt the packet.
 #[allow(unreachable_pub)] // fuzzing only
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PartialDecode {
     plain_header: PlainHeader,
     buf: io::Cursor<BytesMut>,
@@ -477,7 +477,7 @@ impl PartialEncode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum PlainHeader {
     Initial {
         dst_cid: ConnectionId,

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -161,6 +161,11 @@ impl EcnCodepoint {
             }
         })
     }
+
+    /// Returns whether the codepoint is a CE, signalling that congestion was experienced
+    pub fn is_ce(self) -> bool {
+        matches!(self, Self::Ce)
+    }
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1,5 +1,6 @@
 use std::{
     convert::TryInto,
+    mem,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
     time::{Duration, Instant},
@@ -1048,6 +1049,10 @@ fn migration() {
     let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
+    pair.drive();
+
+    let client_stats_after_connect = pair.client_conn_mut(client_ch).stats();
+
     pair.client.addr = SocketAddr::new(
         Ipv4Addr::new(127, 0, 0, 1).into(),
         CLIENT_PORTS.lock().unwrap().next().unwrap(),
@@ -1065,6 +1070,19 @@ fn migration() {
     assert_eq!(
         pair.server_conn_mut(server_ch).remote_address(),
         pair.client.addr
+    );
+
+    // Assert that the client's response to the PATH_CHALLENGE was an IMMEDIATE_ACK, instead of a
+    // second ping
+    let client_stats_after_migrate = pair.client_conn_mut(client_ch).stats();
+    assert_eq!(
+        client_stats_after_migrate.frame_tx.ping - client_stats_after_connect.frame_tx.ping,
+        1
+    );
+    assert_eq!(
+        client_stats_after_migrate.frame_tx.immediate_ack
+            - client_stats_after_connect.frame_tx.immediate_ack,
+        1
     );
 }
 
@@ -1913,6 +1931,32 @@ fn malformed_token_len() {
 }
 
 #[test]
+fn loss_probe_requests_immediate_ack() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let (client_ch, _) = pair.connect();
+    pair.drive();
+
+    let stats_after_connect = pair.client_conn_mut(client_ch).stats();
+
+    // Lose a ping
+    let default_mtu = mem::replace(&mut pair.mtu, 0);
+    pair.client_conn_mut(client_ch).ping();
+    pair.drive_client();
+    pair.mtu = default_mtu;
+
+    // Drive the connection further so a loss probe is sent and the ping is recovered
+    pair.drive();
+
+    // Assert that two IMMEDIATE_ACKs were sent (two loss probes)
+    let stats_after_recovery = pair.client_conn_mut(client_ch).stats();
+    assert_eq!(
+        stats_after_recovery.frame_tx.immediate_ack - stats_after_connect.frame_tx.immediate_ack,
+        2
+    );
+}
+
+#[test]
 /// This is mostly a sanity check to ensure our testing code is correctly dropping packets above the
 /// pmtu
 fn connect_too_low_mtu() {
@@ -1931,6 +1975,7 @@ fn connect_too_low_mtu() {
 fn connect_lost_mtu_probes_do_not_trigger_congestion_control() {
     let _guard = subscribe();
     let mut pair = Pair::default();
+    pair.mtu = 1200;
 
     let (client_ch, server_ch) = pair.connect();
     pair.drive();
@@ -1955,7 +2000,6 @@ fn connect_detects_mtu() {
     let max_udp_payload_and_expected_mtu = &[(1200, 1200), (1400, 1389), (1500, 1452)];
 
     for &(pair_max_udp, expected_mtu) in max_udp_payload_and_expected_mtu {
-        println!("Trying {pair_max_udp}");
         let mut pair = Pair::default();
         pair.mtu = pair_max_udp;
         let (client_ch, server_ch) = pair.connect();
@@ -2068,39 +2112,6 @@ fn connect_runs_mtud_again_after_600_seconds() {
 }
 
 #[test]
-fn packet_loss_and_retry_too_low_mtu() {
-    let _guard = subscribe();
-    let mut pair = Pair::default();
-    let (client_ch, server_ch) = pair.connect();
-
-    let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
-
-    pair.client_send(client_ch, s).write(b"hello").unwrap();
-    pair.drive();
-
-    // Nothing will get past this mtu
-    pair.mtu = 10;
-    pair.client_send(client_ch, s).write(b" world").unwrap();
-    pair.drive_client();
-
-    // The packet was dropped
-    assert!(pair.client.outbound.is_empty());
-    assert!(pair.server.inbound.is_empty());
-
-    // Restore the default mtu, so future packets are properly transmitted
-    pair.mtu = DEFAULT_MTU;
-
-    // The lost packet is resent
-    pair.drive();
-    assert!(pair.client.outbound.is_empty());
-
-    let recv = pair.server_recv(server_ch, s);
-    let buf = stream_chunks(recv);
-
-    assert_eq!(buf, b"hello world".as_slice());
-}
-
-#[test]
 fn blackhole_after_mtu_change_repairs_itself() {
     let _guard = subscribe();
     let mut pair = Pair::default();
@@ -2140,6 +2151,21 @@ fn blackhole_after_mtu_change_repairs_itself() {
 }
 
 #[test]
+fn mtud_probes_include_immediate_ack() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let (client_ch, _) = pair.connect();
+    pair.drive();
+
+    let stats = pair.client_conn_mut(client_ch).stats();
+    assert_eq!(stats.path.sent_plpmtud_probes, 4);
+
+    // Each probe contains a ping and an immediate ack
+    assert_eq!(stats.frame_tx.ping, 4);
+    assert_eq!(stats.frame_tx.immediate_ack, 4);
+}
+
+#[test]
 fn packet_splitting_with_default_mtu() {
     let _guard = subscribe();
 
@@ -2147,6 +2173,7 @@ fn packet_splitting_with_default_mtu() {
     let payload = vec![42; 1300];
 
     let mut pair = Pair::default();
+    pair.mtu = 1200;
     let (client_ch, _) = pair.connect();
     pair.drive();
 
@@ -2179,6 +2206,388 @@ fn packet_splitting_not_necessary_after_higher_mtu_discovered() {
 
     pair.drive_client();
     assert_eq!(pair.server.inbound.len(), 1);
+}
+
+#[test]
+fn single_ack_eliciting_packet_triggers_ack_after_delay() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let (client_ch, _) = pair.connect();
+    pair.drive();
+
+    let stats_after_connect = pair.client_conn_mut(client_ch).stats();
+
+    let start = pair.time;
+    pair.client_conn_mut(client_ch).ping();
+    pair.drive_client(); // Send ping
+    pair.drive_server(); // Process ping
+    pair.drive_client(); // Give the client a chance to process an ack, so our assertion can fail
+
+    // Sanity check: the time hasn't advanced in the meantime)
+    assert_eq!(pair.time, start);
+
+    let stats_after_ping = pair.client_conn_mut(client_ch).stats();
+    assert_eq!(
+        stats_after_ping.frame_tx.ping - stats_after_connect.frame_tx.ping,
+        1
+    );
+    assert_eq!(
+        stats_after_ping.frame_rx.acks - stats_after_connect.frame_rx.acks,
+        0
+    );
+
+    pair.drive();
+    let stats_after_drive = pair.client_conn_mut(client_ch).stats();
+    assert_eq!(
+        stats_after_drive.frame_rx.acks - stats_after_ping.frame_rx.acks,
+        1
+    );
+
+    // The time is start + max_ack_delay
+    assert_eq!(pair.time, start + Duration::from_millis(25));
+
+    // Sanity check: no loss probe was sent, because the delayed ACK was received on time
+    assert_eq!(
+        stats_after_drive.frame_tx.ping - stats_after_connect.frame_tx.ping,
+        1
+    );
+}
+
+#[test]
+fn immediate_ack_triggers_ack() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let (client_ch, _) = pair.connect();
+    pair.drive();
+
+    let acks_after_connect = pair.client_conn_mut(client_ch).stats().frame_rx.acks;
+
+    pair.client_conn_mut(client_ch).immediate_ack();
+    pair.drive_client(); // Send ping
+    pair.drive_server(); // Process ping
+    pair.drive_client(); // Give the client a chance to process the ack
+
+    let acks_after_ping = pair.client_conn_mut(client_ch).stats().frame_rx.acks;
+
+    assert_eq!(acks_after_ping - acks_after_connect, 1);
+}
+
+#[test]
+fn out_of_order_ack_eliciting_packet_triggers_ack() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let (client_ch, server_ch) = pair.connect();
+    pair.drive();
+
+    let default_mtu = pair.mtu;
+
+    let client_stats_after_connect = pair.client_conn_mut(client_ch).stats();
+    let server_stats_after_connect = pair.server_conn_mut(server_ch).stats();
+
+    // Send a packet that won't arrive right away (it will be dropped and be re-sent later)
+    pair.mtu = 0;
+    pair.client_conn_mut(client_ch).ping();
+    pair.drive_client();
+
+    // Sanity check (ping sent, no ACK received)
+    let client_stats_after_first_ping = pair.client_conn_mut(client_ch).stats();
+    assert_eq!(
+        client_stats_after_first_ping.frame_tx.ping - client_stats_after_connect.frame_tx.ping,
+        1
+    );
+    assert_eq!(
+        client_stats_after_first_ping.frame_rx.acks - client_stats_after_connect.frame_rx.acks,
+        0
+    );
+
+    // Restore the default MTU and send another ping, which will arrive earlier than the dropped one
+    pair.mtu = default_mtu;
+    pair.client_conn_mut(client_ch).ping();
+    pair.drive_client();
+    pair.drive_server();
+    pair.drive_client();
+
+    // Client sanity check (ping sent, one ACK received)
+    let client_stats_after_second_ping = pair.client_conn_mut(client_ch).stats();
+    assert_eq!(
+        client_stats_after_second_ping.frame_tx.ping - client_stats_after_connect.frame_tx.ping,
+        2
+    );
+    assert_eq!(
+        client_stats_after_second_ping.frame_rx.acks - client_stats_after_connect.frame_rx.acks,
+        1
+    );
+
+    // Server checks (single ping received, ACK sent)
+    let server_stats_after_second_ping = pair.server_conn_mut(server_ch).stats();
+    assert_eq!(
+        server_stats_after_second_ping.frame_rx.ping - server_stats_after_connect.frame_rx.ping,
+        1
+    );
+    assert_eq!(
+        server_stats_after_second_ping.frame_tx.acks - server_stats_after_connect.frame_tx.acks,
+        1
+    );
+}
+
+#[test]
+fn single_ack_eliciting_packet_with_ce_bit_triggers_immediate_ack() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let (client_ch, _) = pair.connect();
+    pair.drive();
+
+    let stats_after_connect = pair.client_conn_mut(client_ch).stats();
+
+    let start = pair.time;
+
+    pair.client_conn_mut(client_ch).ping();
+
+    pair.congestion_experienced = true;
+    pair.drive_client(); // Send ping
+    pair.congestion_experienced = false;
+
+    pair.drive_server(); // Process ping, send ACK in response to congestion
+    pair.drive_client(); // Process ACK
+
+    // Sanity check: the time hasn't advanced in the meantime)
+    assert_eq!(pair.time, start);
+
+    let stats_after_ping = pair.client_conn_mut(client_ch).stats();
+    assert_eq!(
+        stats_after_ping.frame_tx.ping - stats_after_connect.frame_tx.ping,
+        1
+    );
+    assert_eq!(
+        stats_after_ping.frame_rx.acks - stats_after_connect.frame_rx.acks,
+        1
+    );
+    assert_eq!(
+        stats_after_ping.path.congestion_events - stats_after_connect.path.congestion_events,
+        1
+    );
+}
+
+#[test]
+fn ack_frequency() {
+    let _guard = subscribe();
+
+    // ---
+    // Config and initialization
+    // ---
+
+    let mut client_config = client_config();
+    let mut ack_freq_config = AckFrequencyConfig::default();
+    ack_freq_config.ack_eliciting_threshold(10);
+    Arc::get_mut(&mut client_config.transport)
+        .unwrap()
+        .ack_frequency_config(Some(ack_freq_config))
+        .mtu_discovery_config(None); // To keep traffic cleaner
+
+    let mut pair = Pair::default();
+    pair.latency = Duration::from_millis(10); // Need latency to avoid an RTT = 0
+    let (client_ch, server_ch) = pair.connect_with(client_config);
+    pair.drive();
+
+    assert_eq!(
+        pair.client_conn_mut(client_ch)
+            .stats()
+            .frame_tx
+            .ack_frequency,
+        1
+    );
+    assert_eq!(pair.client_conn_mut(client_ch).stats().frame_tx.ping, 0);
+
+    // ---
+    // Check: three ack-eliciting packets trigger no ACK, and an immediate ACK is requested by the
+    // client after RTT elapses
+    // ---
+
+    // We manually drive to prevent the clock from advancing and triggering the RTT timer
+    for _ in 0..3 {
+        pair.client_conn_mut(client_ch).ping();
+        pair.drive_client();
+    }
+
+    let server_stats_before = pair.server_conn_mut(server_ch).stats();
+
+    pair.time += Duration::from_millis(10); // account for latency
+    pair.drive_server();
+    let server_stats_after = pair.server_conn_mut(server_ch).stats();
+
+    // 3 pings received, no ack sent
+    assert_eq!(
+        server_stats_after.frame_rx.ping - server_stats_before.frame_rx.ping,
+        3
+    );
+    assert_eq!(
+        server_stats_after.frame_tx.acks - server_stats_before.frame_tx.acks,
+        0
+    );
+
+    // RTT elapsed, immediate ack will be requested by the client and everything will be acked
+    let client_stats_before = pair.client_conn_mut(client_ch).stats();
+    pair.drive();
+    let client_stats_after = pair.client_conn_mut(client_ch).stats();
+
+    assert_eq!(
+        client_stats_after.frame_tx.immediate_ack - client_stats_before.frame_tx.immediate_ack,
+        1
+    );
+    assert_eq!(
+        client_stats_after.frame_rx.acks - client_stats_before.frame_rx.acks,
+        1
+    );
+
+    // ---
+    // Check: three ack-eliciting packets do not trigger an ACK, but an ACK is sent anyway after
+    // max_ack_delay
+    // ---
+
+    for _ in 0..3 {
+        pair.client_conn_mut(client_ch).ping();
+        pair.drive_client();
+    }
+
+    let server_stats_before = pair.server_conn_mut(server_ch).stats();
+    pair.time += Duration::from_millis(10); // account for latency
+    pair.drive_server();
+    let server_stats_after = pair.server_conn_mut(server_ch).stats();
+
+    // 3 pings received, no ack sent
+    assert_eq!(
+        server_stats_after.frame_rx.ping - server_stats_before.frame_rx.ping,
+        3
+    );
+    assert_eq!(
+        server_stats_after.frame_tx.acks - server_stats_before.frame_tx.acks,
+        0
+    );
+
+    let server_stats_before = pair.server_conn_mut(server_ch).stats();
+    pair.time += Duration::from_millis(30); // > max_ack_delay
+    pair.drive_server();
+    let server_stats_after = pair.server_conn_mut(server_ch).stats();
+
+    // max_ack_delay elapsed, so ack sent
+    assert_eq!(
+        server_stats_after.frame_tx.acks - server_stats_before.frame_tx.acks,
+        1
+    );
+
+    // RTT has elapsed before the server's ACK is received, so an immediate ack will be requested
+    let client_stats_before = pair.client_conn_mut(client_ch).stats();
+    pair.drive();
+    let client_stats_after = pair.client_conn_mut(client_ch).stats();
+
+    assert_eq!(
+        client_stats_after.frame_tx.immediate_ack - client_stats_before.frame_tx.immediate_ack,
+        1
+    );
+
+    // ---
+    // Check: eleven ack-eliciting packets trigger an ACK, and no immediate ACK is requested by the
+    // client after RTT elapses
+    // ---
+
+    for _ in 0..11 {
+        pair.client_conn_mut(client_ch).ping();
+        pair.drive_client();
+    }
+
+    let server_stats_before = pair.server_conn_mut(server_ch).stats();
+    pair.time += Duration::from_millis(10); // account for latency
+    pair.drive_server();
+    let server_stats_after = pair.server_conn_mut(server_ch).stats();
+
+    // 11 pings received, ack sent
+    assert_eq!(
+        server_stats_after.frame_rx.ping - server_stats_before.frame_rx.ping,
+        11
+    );
+    assert_eq!(
+        server_stats_after.frame_tx.acks - server_stats_before.frame_tx.acks,
+        1
+    );
+
+    // RTT elapsed, but immediate ack won't be requested
+    let client_stats_before = pair.client_conn_mut(client_ch).stats();
+    pair.drive();
+    let client_stats_after = pair.client_conn_mut(client_ch).stats();
+
+    assert_eq!(
+        client_stats_after.frame_tx.immediate_ack - client_stats_before.frame_tx.immediate_ack,
+        0
+    );
+
+    // ---
+    // Check: one reordered packet does not trigger an ACK, and an immediate ack is requested
+    // after RTT elapses
+    // ---
+
+    // Send and lose an ack-eliciting packet
+    pair.mtu = 0;
+    pair.client_conn_mut(client_ch).ping();
+    pair.drive_client();
+
+    // Restore the default MTU and send another ping, which will arrive earlier than the dropped one
+    pair.mtu = DEFAULT_MTU;
+    pair.client_conn_mut(client_ch).ping();
+    pair.drive_client();
+
+    let server_stats_before = pair.server_conn_mut(server_ch).stats();
+    pair.time += Duration::from_millis(10); // account for latency
+    pair.drive_server();
+    let server_stats_after = pair.server_conn_mut(server_ch).stats();
+
+    assert_eq!(
+        server_stats_after.frame_rx.ping - server_stats_before.frame_rx.ping,
+        1
+    );
+    assert_eq!(
+        server_stats_after.frame_tx.acks - server_stats_before.frame_tx.acks,
+        0
+    );
+
+    // RTT elapsed
+    let client_stats_before = pair.client_conn_mut(client_ch).stats();
+    pair.drive();
+    let client_stats_after = pair.client_conn_mut(client_ch).stats();
+
+    assert_eq!(
+        client_stats_after.frame_tx.immediate_ack - client_stats_before.frame_tx.immediate_ack,
+        1
+    );
+
+    // ---
+    // Check: two reordered packets trigger an ACK
+    // ---
+
+    // Send and lose an ack-eliciting packet
+    pair.mtu = 0;
+    for _ in 0..2 {
+        pair.client_conn_mut(client_ch).ping();
+        pair.drive_client();
+    }
+
+    // Restore the default MTU and send another ping, which will arrive earlier than the dropped ones
+    pair.mtu = DEFAULT_MTU;
+    pair.client_conn_mut(client_ch).ping();
+    pair.drive_client();
+
+    let server_stats_before = pair.server_conn_mut(server_ch).stats();
+    pair.time += Duration::from_millis(10); // account for latency
+    pair.drive_server();
+    let server_stats_after = pair.server_conn_mut(server_ch).stats();
+
+    assert_eq!(
+        server_stats_after.frame_rx.ping - server_stats_before.frame_rx.ping,
+        1
+    );
+    assert_eq!(
+        server_stats_after.frame_tx.acks - server_stats_before.frame_tx.acks,
+        1
+    );
 }
 
 fn stream_chunks(mut recv: RecvStream) -> Vec<u8> {

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -18,6 +18,7 @@ use super::*;
 use crate::{
     cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator},
     frame::FrameStruct,
+    transport_parameters::TransportParameters,
 };
 mod util;
 use util::*;
@@ -2236,6 +2237,7 @@ fn single_ack_eliciting_packet_triggers_ack_after_delay() {
         0
     );
 
+    pair.client.capture_inbound_packets = true;
     pair.drive();
     let stats_after_drive = pair.client_conn_mut(client_ch).stats();
     assert_eq!(
@@ -2245,6 +2247,19 @@ fn single_ack_eliciting_packet_triggers_ack_after_delay() {
 
     // The time is start + max_ack_delay
     assert_eq!(pair.time, start + Duration::from_millis(25));
+
+    // The ACK delay is properly calculated
+    assert_eq!(pair.client.captured_packets.len(), 1);
+    let mut frames =
+        frame::Iter::new(pair.client.captured_packets.remove(0).into()).collect::<Vec<_>>();
+    assert_eq!(frames.len(), 1);
+    if let Frame::Ack(ack) = frames.remove(0) {
+        let ack_delay_exp = TransportParameters::default().ack_delay_exponent;
+        let delay = ack.delay << ack_delay_exp.into_inner();
+        assert_eq!(delay, 25_000);
+    } else {
+        panic!("Expected ACK frame");
+    }
 
     // Sanity check: no loss probe was sent, because the delayed ACK was received on time
     assert_eq!(

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -271,6 +271,8 @@ pub(super) struct TestEndpoint {
     accepted: Option<ConnectionHandle>,
     pub(super) connections: HashMap<ConnectionHandle, Connection>,
     conn_events: HashMap<ConnectionHandle, VecDeque<ConnectionEvent>>,
+    pub(super) captured_packets: Vec<Vec<u8>>,
+    pub(super) capture_inbound_packets: bool,
 }
 
 impl TestEndpoint {
@@ -295,6 +297,8 @@ impl TestEndpoint {
             accepted: None,
             connections: HashMap::default(),
             conn_events: HashMap::default(),
+            captured_packets: Vec::new(),
+            capture_inbound_packets: false,
         }
     }
 
@@ -320,6 +324,11 @@ impl TestEndpoint {
                         self.accepted = Some(ch);
                     }
                     DatagramEvent::ConnectionEvent(event) => {
+                        if self.capture_inbound_packets {
+                            let packet = self.connections[&ch].decode_packet(&event);
+                            self.captured_packets.extend(packet);
+                        }
+
                         self.conn_events
                             .entry(ch)
                             .or_insert_with(VecDeque::new)


### PR DESCRIPTION
_Note: this PR is no longer a draft, but I've left the text below untouched so people can trace how the PR was developed. You will probably want to jump to [this comment](https://github.com/quinn-rs/quinn/pull/1543#issuecomment-1531658463) for an overview of what this PR actually achieves._

---

This is a draft PR for now, because it is missing the following stuff:

* Regularly sending `ACK_FREQUENCY` frames to actively control the ACK frequency of the peer (I'm waiting for #1529 to be merged to avoid conflicts around the congestion control code)
* Polishing out-of-order packet detection (more on that below, but the current code to handle out-of-order ack-eliciting packets is probably wrong)
* Adding a few more tests

As to the things that _are_ properly implemented:

* `min_ack_delay` transport parameter
* `ACK_FREQUENCY` and `IMMEDIATE_ACK` frames
* Logic around delaying ACKs up to `max_ack_delay`, properly tweaked upon receiving an `ACK_FREQUENCY` frame
* Receiving an `IMMEDIATE_ACK` causes an ACK to be sent in the next `poll_transmit` call, even if that results in an ACK-only packet.
* If the remote peer supports it, we send an `IMMEDIATE_ACK` in the following cases:
    * When a PMTU probe is sent (see section 8.3 of the draft)
    * When a client wants to validate the path after connection migration (see section 8.4 of the draft)
    * When a loss probe is sent (see section 5 of the draft)

That being said, here are a few questions:

1. What do you think of the general direction of the PR? Do you see anything that seems out of place?
2. Is there a way to access unencrypted packet frames in tests that simulate a connection (`quinn-proto/src/test/mod.rs`)? It would be useful to ensure the ACK delay value in ACK frames is being properly set. Unit tests don’t give the same degree of confidence and have a higher maintenance cost. If this doesn't exist yet, would you welcome a commit adding it?
3. I'm confused about the way out-of-order packets are detected in the ACK frequency draft, which seems different than in RFC 9000. The draft gives an example that, to my understanding, is wrong (which probably means my understanding is wrong). I posted a detailed question in the [quicdev slack](https://quicdev.slack.com/archives/C68J3KSH3/p1681895302006479) to get more clarity, so please have a look if you think you can help.
