### PR TITLE
Fragmentation handling improvements

### DIFF
--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -142,8 +142,6 @@ pub fn transport_config(opt: &Opt) -> quinn::TransportConfig {
     // High stream windows are chosen because the amount of concurrent streams
     // is configurable as a parameter.
     let mut config = quinn::TransportConfig::default();
-    #[cfg(any(windows, os = "linux"))]
-    config.mtu_discovery_config(Some(quinn::MtuDiscoveryConfig::default()));
     config.max_concurrent_uni_streams(opt.max_streams.try_into().unwrap());
     config.initial_mtu(opt.initial_mtu);
     config

--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -129,8 +129,6 @@ async fn run(opt: Opt) -> Result<()> {
     }
 
     let mut transport = quinn::TransportConfig::default();
-    #[cfg(any(windows, os = "linux"))]
-    transport.mtu_discovery_config(Some(quinn::MtuDiscoveryConfig::default()));
     transport.initial_mtu(opt.initial_mtu);
 
     let mut cfg = if opt.no_protection {

--- a/perf/src/bin/perf_server.rs
+++ b/perf/src/bin/perf_server.rs
@@ -88,8 +88,6 @@ async fn run(opt: Opt) -> Result<()> {
     }
 
     let mut transport = quinn::TransportConfig::default();
-    #[cfg(any(windows, os = "linux"))]
-    transport.mtu_discovery_config(Some(quinn::MtuDiscoveryConfig::default()));
     transport.initial_mtu(opt.initial_mtu);
 
     let mut server_config = if opt.no_protection {

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -315,7 +315,7 @@ impl Default for TransportConfig {
             initial_rtt: Duration::from_millis(333), // per spec, intentionally distinct from EXPECTED_RTT
             initial_mtu: INITIAL_MTU,
             min_mtu: INITIAL_MTU,
-            mtu_discovery_config: None,
+            mtu_discovery_config: Some(MtuDiscoveryConfig::default()),
 
             persistent_congestion_threshold: 3,
             keep_alive_interval: None,

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -212,7 +212,7 @@ impl TransportConfig {
     /// to disable UDP packet fragmentation (this is strongly recommended by [RFC
     /// 9000](https://www.rfc-editor.org/rfc/rfc9000.html#section-14-7), regardless of MTU
     /// discovery). They can build on top of the `quinn-udp` crate, used by `quinn` itself, which
-    /// provides Linux and Windows support for disabling packet fragmentation.
+    /// provides Linux, Windows, macOS, and FreeBSD support for disabling packet fragmentation.
     pub fn mtu_discovery_config(&mut self, value: Option<MtuDiscoveryConfig>) -> &mut Self {
         self.mtu_discovery_config = value;
         self

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -236,6 +236,7 @@ impl Connection {
         cid_gen: &dyn ConnectionIdGenerator,
         now: Instant,
         version: u32,
+        allow_mtud: bool,
     ) -> Self {
         let side = if server_config.is_some() {
             Side::Server
@@ -269,7 +270,10 @@ impl Connection {
                 config.get_initial_mtu(),
                 config.min_mtu,
                 None,
-                config.mtu_discovery_config.clone(),
+                match allow_mtud {
+                    true => config.mtu_discovery_config.clone(),
+                    false => None,
+                },
                 now,
                 path_validated,
             ),

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -35,8 +35,8 @@ pub(super) struct Pair {
 
 impl Pair {
     pub(super) fn new(endpoint_config: Arc<EndpointConfig>, server_config: ServerConfig) -> Self {
-        let server = Endpoint::new(endpoint_config.clone(), Some(Arc::new(server_config)));
-        let client = Endpoint::new(endpoint_config, None);
+        let server = Endpoint::new(endpoint_config.clone(), Some(Arc::new(server_config)), true);
+        let client = Endpoint::new(endpoint_config, None, true);
 
         Self::new_from_endpoint(client, server)
     }
@@ -430,11 +430,7 @@ impl Write for TestWriter {
 }
 
 pub(super) fn server_config() -> ServerConfig {
-    let mut config = ServerConfig::with_crypto(Arc::new(server_crypto()));
-    Arc::get_mut(&mut config.transport)
-        .unwrap()
-        .mtu_discovery_config(Some(MtuDiscoveryConfig::default()));
-    config
+    ServerConfig::with_crypto(Arc::new(server_crypto()))
 }
 
 pub(super) fn server_config_with_cert(cert: Certificate, key: PrivateKey) -> ServerConfig {
@@ -452,11 +448,7 @@ pub(super) fn server_crypto_with_cert(cert: Certificate, key: PrivateKey) -> rus
 }
 
 pub(super) fn client_config() -> ClientConfig {
-    let mut config = ClientConfig::new(Arc::new(client_crypto()));
-    Arc::get_mut(&mut config.transport)
-        .unwrap()
-        .mtu_discovery_config(Some(MtuDiscoveryConfig::default()));
-    config
+    ClientConfig::new(Arc::new(client_crypto()))
 }
 
 pub(super) fn client_config_with_certs(certs: Vec<rustls::Certificate>) -> ClientConfig {

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -22,7 +22,7 @@ log = ["tracing/log"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-libc = "0.2.69"
+libc = "0.2.113"
 socket2 = "0.4" # 0.5.1 has an MSRV of 1.63
 tracing = "0.1.10"
 

--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -106,4 +106,9 @@ pub fn udp_state() -> super::UdpState {
     }
 }
 
+#[inline]
+pub(crate) fn may_fragment() -> bool {
+    true
+}
+
 pub const BATCH_SIZE: usize = 1;

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -36,6 +36,14 @@ mod imp;
 
 pub use imp::UdpSocketState;
 
+/// Whether transmitted datagrams might get fragmented by the IP layer
+///
+/// Returns `false` on targets which employ e.g. the `IPV6_DONTFRAG` socket option.
+#[inline]
+pub fn may_fragment() -> bool {
+    imp::may_fragment()
+}
+
 /// Number of UDP packets to send/receive at a time
 pub const BATCH_SIZE: usize = imp::BATCH_SIZE;
 

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -151,10 +151,6 @@ fn init(io: SockRef<'_>) -> io::Result<()> {
         set_socket_option(&*io, libc::IPPROTO_IPV6, libc::IPV6_DONTFRAG, OPTION_ON)?;
     }
 
-    if !is_ipv4 {
-        set_socket_option(&*io, libc::IPPROTO_IPV6, libc::IPV6_RECVTCLASS, OPTION_ON)?;
-    }
-
     Ok(())
 }
 

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -125,6 +125,12 @@ fn init(io: SockRef<'_>) -> io::Result<()> {
             )?;
         }
     }
+    #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "ios"))]
+    {
+        if is_ipv4 {
+            set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_DONTFRAG, OPTION_ON)?;
+        }
+    }
     #[cfg(any(target_os = "freebsd", target_os = "macos"))]
     // IP_RECVDSTADDR == IP_SENDSRCADDR on FreeBSD
     // macOS uses only IP_RECVDSTADDR, no IP_SENDSRCADDR on macOS
@@ -135,10 +141,14 @@ fn init(io: SockRef<'_>) -> io::Result<()> {
         }
     }
 
-    // IPV6_RECVPKTINFO is standardized
+    // Options standardized in RFC 3542
     if !is_ipv4 {
         set_socket_option(&*io, libc::IPPROTO_IPV6, libc::IPV6_RECVPKTINFO, OPTION_ON)?;
         set_socket_option(&*io, libc::IPPROTO_IPV6, libc::IPV6_RECVTCLASS, OPTION_ON)?;
+        // Linux's IP_PMTUDISC_PROBE allows us to operate under interface MTU rather than the
+        // kernel's path MTU guess, but actually disabling fragmentation requires this too. See
+        // __ip6_append_data in ip6_output.c.
+        set_socket_option(&*io, libc::IPPROTO_IPV6, libc::IPV6_DONTFRAG, OPTION_ON)?;
     }
 
     if !is_ipv4 {

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -677,6 +677,11 @@ pub(crate) const BATCH_SIZE: usize = 32;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 pub(crate) const BATCH_SIZE: usize = 1;
 
+#[inline]
+pub(crate) fn may_fragment() -> bool {
+    false
+}
+
 #[cfg(target_os = "linux")]
 mod gso {
     use super::*;

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -154,3 +154,8 @@ pub fn udp_state() -> super::UdpState {
 }
 
 pub const BATCH_SIZE: usize = 1;
+
+#[inline]
+pub(crate) fn may_fragment() -> bool {
+    false
+}

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -95,9 +95,7 @@ async fn run(options: Opt) -> Result<()> {
         client_crypto.key_log = Arc::new(rustls::KeyLogFile::new());
     }
 
-    let mut client_config = quinn::ClientConfig::new(Arc::new(client_crypto));
-    common::enable_mtud_if_supported(&mut client_config);
-
+    let client_config = quinn::ClientConfig::new(Arc::new(client_crypto));
     let mut endpoint = quinn::Endpoint::client("[::]:0".parse().unwrap())?;
     endpoint.set_default_client_config(client_config);
 

--- a/quinn/examples/common/mod.rs
+++ b/quinn/examples/common/mod.rs
@@ -45,23 +45,9 @@ fn configure_client(server_certs: &[&[u8]]) -> Result<ClientConfig, Box<dyn Erro
         certs.add(&rustls::Certificate(cert.to_vec()))?;
     }
 
-    let mut client_config = ClientConfig::with_root_certificates(certs);
-    enable_mtud_if_supported(&mut client_config);
-
+    let client_config = ClientConfig::with_root_certificates(certs);
     Ok(client_config)
 }
-
-/// Enables MTUD if supported by the operating system
-#[cfg(any(windows, os = "linux"))]
-pub fn enable_mtud_if_supported(client_config: &mut ClientConfig) {
-    let mut transport_config = quinn::TransportConfig::default();
-    transport_config.mtu_discovery_config(Some(quinn::MtuDiscoveryConfig::default()));
-    client_config.transport_config(Arc::new(transport_config));
-}
-
-/// Enables MTUD if supported by the operating system
-#[cfg(not(any(windows, os = "linux")))]
-pub fn enable_mtud_if_supported(_client_config: &mut ClientConfig) {}
 
 /// Returns default server configuration along with its certificate.
 fn configure_server() -> Result<(ServerConfig, Vec<u8>), Box<dyn Error>> {
@@ -74,8 +60,6 @@ fn configure_server() -> Result<(ServerConfig, Vec<u8>), Box<dyn Error>> {
     let mut server_config = ServerConfig::with_single_cert(cert_chain, priv_key)?;
     let transport_config = Arc::get_mut(&mut server_config.transport).unwrap();
     transport_config.max_concurrent_uni_streams(0_u8.into());
-    #[cfg(any(windows, os = "linux"))]
-    transport_config.mtu_discovery_config(Some(quinn::MtuDiscoveryConfig::default()));
 
     Ok((server_config, cert_der))
 }

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -31,10 +31,8 @@ async fn run_server(addr: SocketAddr) {
 }
 
 async fn run_client(server_addr: SocketAddr) -> Result<(), Box<dyn Error>> {
-    let mut client_cfg = configure_client();
-    common::enable_mtud_if_supported(&mut client_cfg);
     let mut endpoint = Endpoint::client("127.0.0.1:0".parse().unwrap())?;
-    endpoint.set_default_client_config(client_cfg);
+    endpoint.set_default_client_config(configure_client());
 
     // connect to server
     let connection = endpoint

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -133,8 +133,6 @@ async fn run(options: Opt) -> Result<()> {
     let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(server_crypto));
     let transport_config = Arc::get_mut(&mut server_config.transport).unwrap();
     transport_config.max_concurrent_uni_streams(0_u8.into());
-    #[cfg(any(windows, os = "linux"))]
-    transport_config.mtu_discovery_config(Some(quinn::MtuDiscoveryConfig::default()));
     if options.stateless_retry {
         server_config.use_retry(true);
     }

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -114,9 +114,10 @@ impl Endpoint {
         runtime: Arc<dyn Runtime>,
     ) -> io::Result<Self> {
         let addr = socket.local_addr()?;
+        let allow_mtud = !socket.may_fragment();
         let rc = EndpointRef::new(
             socket,
-            proto::Endpoint::new(Arc::new(config), server_config.map(Arc::new)),
+            proto::Endpoint::new(Arc::new(config), server_config.map(Arc::new), allow_mtud),
             addr.is_ipv6(),
             runtime.clone(),
         );

--- a/quinn/src/runtime.rs
+++ b/quinn/src/runtime.rs
@@ -50,6 +50,14 @@ pub trait AsyncUdpSocket: Send + Debug + 'static {
 
     /// Look up the local IP address and port used by this socket
     fn local_addr(&self) -> io::Result<SocketAddr>;
+
+    /// Whether datagrams might get fragmented into multiple parts
+    ///
+    /// Sockets should prevent this for best performance. See e.g. the `IPV6_DONTFRAG` socket
+    /// option.
+    fn may_fragment(&self) -> bool {
+        true
+    }
 }
 
 /// Automatically select an appropriate runtime from those enabled at compile time

--- a/quinn/src/runtime/async_std.rs
+++ b/quinn/src/runtime/async_std.rs
@@ -80,4 +80,8 @@ impl AsyncUdpSocket for UdpSocket {
     fn local_addr(&self) -> io::Result<std::net::SocketAddr> {
         self.io.as_ref().local_addr()
     }
+
+    fn may_fragment(&self) -> bool {
+        udp::may_fragment()
+    }
 }

--- a/quinn/src/runtime/tokio.rs
+++ b/quinn/src/runtime/tokio.rs
@@ -88,4 +88,8 @@ impl AsyncUdpSocket for UdpSocket {
     fn local_addr(&self) -> io::Result<std::net::SocketAddr> {
         self.io.local_addr()
     }
+
+    fn may_fragment(&self) -> bool {
+        udp::may_fragment()
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/quinn-rs/quinn/issues/664.

Some questions following from this work:
- Should MTU discovery configuration be on the endpoint, rather than the connection? It's hard to imagine a case where a user might want to vary this per-connection, and usually the main concern is whether the common socket has DONTFRAG set. On the other hand, the reduction in complexity from moving it to the endpoint seems slight. I guess you could use a single endpoint to communicate both on a jumbo-frame-capable LAN and also the internet...
- Setting IP_DONTFRAG might fail pre-Big Sur (version 11). As written, this PR will make endpoint creation fail if this occurs, probably with `EINVAL`. Are older macOS builds worth supporting?
- ~Can we reduce the amount of work required from users to create a endpoint or connection with the recommended configuration for their platform?~