### PR TITLE
Implement acknowledgement frequency

### DIFF
--- a/quinn-proto/src/connection/ack_frequency.rs
+++ b/quinn-proto/src/connection/ack_frequency.rs
@@ -1,0 +1,124 @@
+use crate::connection::spaces::PendingAcks;
+use crate::frame::AckFrequency;
+use crate::{AckFrequencyConfig, TransportError, VarInt, TIMER_GRANULARITY};
+use std::time::Duration;
+
+/// State associated to ACK frequency
+pub(super) struct AckFrequencyState {
+    //
+    // Sending ACK_FREQUENCY frames
+    //
+    in_flight_ack_frequency_frame: Option<(u64, Duration)>,
+    next_outgoing_sequence_number: VarInt,
+    pub(super) peer_max_ack_delay: Duration,
+
+    //
+    // Receiving ACK_FREQUENCY frames
+    //
+    last_ack_frequency_frame: Option<u64>,
+    pub(super) max_ack_delay: Duration,
+}
+
+impl AckFrequencyState {
+    pub(super) fn new(default_max_ack_delay: Duration) -> Self {
+        Self {
+            in_flight_ack_frequency_frame: None,
+            next_outgoing_sequence_number: VarInt(0),
+            peer_max_ack_delay: default_max_ack_delay,
+
+            last_ack_frequency_frame: None,
+            max_ack_delay: default_max_ack_delay,
+        }
+    }
+
+    /// Returns the `max_ack_delay` that should be requested of the peer when sending an
+    /// ACK_FREQUENCY frame
+    pub(super) fn candidate_max_ack_delay(&self, config: &AckFrequencyConfig) -> Duration {
+        // Use the peer's max_ack_delay if no custom max_ack_delay was provided in the config
+        config.max_ack_delay.unwrap_or(self.peer_max_ack_delay)
+    }
+
+    /// Returns the `max_ack_delay` for the purposes of calculating the PTO
+    ///
+    /// This `max_ack_delay` is defined as the maximum of the peer's current `max_ack_delay` and all
+    /// in-flight `max_ack_delay`s (i.e. proposed values that haven't been acknowledged yet, but
+    /// might be already in use by the peer).
+    pub(super) fn max_ack_delay_for_pto(&self) -> Duration {
+        // Note: we have at most one in-flight ACK_FREQUENCY frame
+        if let Some((_, max_ack_delay)) = self.in_flight_ack_frequency_frame {
+            self.peer_max_ack_delay.max(max_ack_delay)
+        } else {
+            self.peer_max_ack_delay
+        }
+    }
+
+    /// Returns the next sequence number for an ACK_FREQUENCY frame
+    pub(super) fn next_sequence_number(&mut self) -> VarInt {
+        assert!(self.next_outgoing_sequence_number <= VarInt::MAX);
+
+        let seq = self.next_outgoing_sequence_number;
+        self.next_outgoing_sequence_number.0 += 1;
+        seq
+    }
+
+    /// Returns true if we should send an ACK_FREQUENCY frame
+    pub(super) fn should_send_ack_frequency(&self) -> bool {
+        // Currently, we only allow sending a single ACK_FREQUENCY frame. There is no need to send
+        // more, because none of the sent values needs to be updated in the course of the connection
+        self.next_outgoing_sequence_number.0 == 0
+    }
+
+    /// Notifies the [`AckFrequencyState`] that a packet containing an ACK_FREQUENCY frame was sent
+    pub(super) fn ack_frequency_sent(&mut self, pn: u64, requested_max_ack_delay: Duration) {
+        self.in_flight_ack_frequency_frame = Some((pn, requested_max_ack_delay));
+    }
+
+    /// Notifies the [`AckFrequencyState`] that a packet has been ACKed
+    pub(super) fn on_acked(&mut self, pn: u64) {
+        match self.in_flight_ack_frequency_frame {
+            Some((number, requested_max_ack_delay)) if number == pn => {
+                self.in_flight_ack_frequency_frame = None;
+                self.peer_max_ack_delay = requested_max_ack_delay;
+            }
+            _ => {}
+        }
+    }
+
+    /// Notifies the [`AckFrequencyState`] that an ACK_FREQUENCY frame was received
+    ///
+    /// Updates the endpoint's params according to the payload of the ACK_FREQUENCY frame, or
+    /// returns an error in case the requested `max_ack_delay` is invalid.
+    ///
+    /// Returns `true` if the frame was processed and `false` if it was ignored because of being
+    /// stale.
+    pub(super) fn ack_frequency_received(
+        &mut self,
+        frame: &AckFrequency,
+        pending_acks: &mut PendingAcks,
+    ) -> Result<bool, TransportError> {
+        if self
+            .last_ack_frequency_frame
+            .map_or(false, |highest_sequence_nr| {
+                frame.sequence.into_inner() <= highest_sequence_nr
+            })
+        {
+            return Ok(false);
+        }
+
+        self.last_ack_frequency_frame = Some(frame.sequence.into_inner());
+
+        // Update max_ack_delay
+        let max_ack_delay = Duration::from_micros(frame.request_max_ack_delay.into_inner());
+        if max_ack_delay < TIMER_GRANULARITY {
+            return Err(TransportError::PROTOCOL_VIOLATION(
+                "Requested Max Ack Delay in ACK_FREQUENCY frame is less than min_ack_delay",
+            ));
+        }
+        self.max_ack_delay = max_ack_delay;
+
+        // Update the rest of the params
+        pending_acks.set_ack_frequency_params(frame);
+
+        Ok(true)
+    }
+}

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3293,6 +3293,43 @@ impl Connection {
         self.spaces[self.highest_space].immediate_ack_pending = true;
     }
 
+    /// Decodes a packet, returning its decrypted payload, so it can be inspected in tests
+    #[cfg(test)]
+    pub(crate) fn decode_packet(&self, event: &ConnectionEvent) -> Option<Vec<u8>> {
+        let (first_decode, remaining) = match &event.0 {
+            ConnectionEventInner::Datagram {
+                first_decode,
+                remaining,
+                ..
+            } => (first_decode, remaining),
+            _ => return None,
+        };
+
+        if remaining.is_some() {
+            panic!("Packets should never be coalesced in tests");
+        }
+
+        let decrypted_header = packet_crypto::unprotect_header(
+            first_decode.clone(),
+            &self.spaces,
+            self.zero_rtt_crypto.as_ref(),
+            self.peer_params.stateless_reset_token,
+        )?;
+
+        let mut packet = decrypted_header.packet?;
+        packet_crypto::decrypt_packet_body(
+            &mut packet,
+            &self.spaces,
+            self.zero_rtt_crypto.as_ref(),
+            self.key_phase,
+            self.prev_crypto.as_ref(),
+            self.next_crypto.as_ref(),
+        )
+        .ok()?;
+
+        Some(packet.payload.to_vec())
+    }
+
     /// The number of bytes of packets containing retransmittable frames that have not been
     /// acknowledged or declared lost.
     #[cfg(test)]

--- a/quinn-proto/src/connection/packet_crypto.rs
+++ b/quinn-proto/src/connection/packet_crypto.rs
@@ -1,0 +1,70 @@
+use tracing::{debug, trace};
+
+use crate::connection::spaces::PacketSpace;
+use crate::crypto::{HeaderKey, PacketKey};
+use crate::packet::{Packet, PartialDecode};
+use crate::token::ResetToken;
+use crate::RESET_TOKEN_SIZE;
+
+/// Removes header protection of a packet, or returns `None` if the packet was dropped
+pub(super) fn unprotect_header(
+    partial_decode: PartialDecode,
+    spaces: &[PacketSpace; 3],
+    zero_rtt_crypto: Option<&ZeroRttCrypto>,
+    stateless_reset_token: Option<ResetToken>,
+) -> Option<UnprotectHeaderResult> {
+    let header_crypto = if partial_decode.is_0rtt() {
+        if let Some(crypto) = zero_rtt_crypto {
+            Some(&*crypto.header)
+        } else {
+            debug!("dropping unexpected 0-RTT packet");
+            return None;
+        }
+    } else if let Some(space) = partial_decode.space() {
+        if let Some(ref crypto) = spaces[space].crypto {
+            Some(&*crypto.header.remote)
+        } else {
+            debug!(
+                "discarding unexpected {:?} packet ({} bytes)",
+                space,
+                partial_decode.len(),
+            );
+            return None;
+        }
+    } else {
+        // Unprotected packet
+        None
+    };
+
+    let packet = partial_decode.data();
+    let stateless_reset = packet.len() >= RESET_TOKEN_SIZE + 5
+        && stateless_reset_token.as_deref() == Some(&packet[packet.len() - RESET_TOKEN_SIZE..]);
+
+    match partial_decode.finish(header_crypto) {
+        Ok(packet) => Some(UnprotectHeaderResult {
+            packet: Some(packet),
+            stateless_reset,
+        }),
+        Err(_) if stateless_reset => Some(UnprotectHeaderResult {
+            packet: None,
+            stateless_reset: true,
+        }),
+        Err(e) => {
+            trace!("unable to complete packet decoding: {}", e);
+            None
+        }
+    }
+}
+
+pub(super) struct UnprotectHeaderResult {
+    /// The packet with the now unprotected header (`None` in the case of stateless reset packets
+    /// that fail to be decoded)
+    pub(super) packet: Option<Packet>,
+    /// Whether the packet was a stateless reset packet
+    pub(super) stateless_reset: bool,
+}
+
+pub(super) struct ZeroRttCrypto {
+    pub(super) header: Box<dyn HeaderKey>,
+    pub(super) packet: Box<dyn PacketKey>,
+}

--- a/quinn-proto/src/connection/packet_crypto.rs
+++ b/quinn-proto/src/connection/packet_crypto.rs
@@ -1,10 +1,11 @@
+use std::time::Instant;
 use tracing::{debug, trace};
 
 use crate::connection::spaces::PacketSpace;
-use crate::crypto::{HeaderKey, PacketKey};
-use crate::packet::{Packet, PartialDecode};
+use crate::crypto::{HeaderKey, KeyPair, PacketKey};
+use crate::packet::{Packet, PartialDecode, SpaceId};
 use crate::token::ResetToken;
-use crate::RESET_TOKEN_SIZE;
+use crate::{TransportError, RESET_TOKEN_SIZE};
 
 /// Removes header protection of a packet, or returns `None` if the packet was dropped
 pub(super) fn unprotect_header(
@@ -62,6 +63,108 @@ pub(super) struct UnprotectHeaderResult {
     pub(super) packet: Option<Packet>,
     /// Whether the packet was a stateless reset packet
     pub(super) stateless_reset: bool,
+}
+
+/// Decrypts a packet's body in-place
+pub(super) fn decrypt_packet_body(
+    packet: &mut Packet,
+    spaces: &[PacketSpace; 3],
+    zero_rtt_crypto: Option<&ZeroRttCrypto>,
+    conn_key_phase: bool,
+    prev_crypto: Option<&PrevCrypto>,
+    next_crypto: Option<&KeyPair<Box<dyn PacketKey>>>,
+) -> Result<Option<DecryptPacketResult>, Option<TransportError>> {
+    if !packet.header.is_protected() {
+        // Unprotected packets also don't have packet numbers
+        return Ok(None);
+    }
+    let space = packet.header.space();
+    let rx_packet = spaces[space].rx_packet;
+    let number = packet.header.number().ok_or(None)?.expand(rx_packet + 1);
+    let packet_key_phase = packet.header.key_phase();
+
+    let mut crypto_update = false;
+    let crypto = if packet.header.is_0rtt() {
+        &zero_rtt_crypto.unwrap().packet
+    } else if packet_key_phase == conn_key_phase || space != SpaceId::Data {
+        &spaces[space].crypto.as_ref().unwrap().packet.remote
+    } else if let Some(prev) = prev_crypto.and_then(|crypto| {
+        // If this packet comes prior to acknowledgment of the key update by the peer,
+        if crypto.end_packet.map_or(true, |(pn, _)| number < pn) {
+            // use the previous keys.
+            Some(crypto)
+        } else {
+            // Otherwise, this must be a remotely-initiated key update, so fall through to the
+            // final case.
+            None
+        }
+    }) {
+        &prev.crypto.remote
+    } else {
+        // We're in the Data space with a key phase mismatch and either there is no locally
+        // initiated key update or the locally initiated key update was acknowledged by a
+        // lower-numbered packet. The key phase mismatch must therefore represent a new
+        // remotely-initiated key update.
+        crypto_update = true;
+        &next_crypto.unwrap().remote
+    };
+
+    crypto
+        .decrypt(number, &packet.header_data, &mut packet.payload)
+        .map_err(|_| {
+            trace!("decryption failed with packet number {}", number);
+            None
+        })?;
+
+    if !packet.reserved_bits_valid() {
+        return Err(Some(TransportError::PROTOCOL_VIOLATION(
+            "reserved bits set",
+        )));
+    }
+
+    let mut outgoing_key_update_acked = false;
+    if let Some(prev) = prev_crypto {
+        if prev.end_packet.is_none() && packet_key_phase == conn_key_phase {
+            outgoing_key_update_acked = true;
+        }
+    }
+
+    if crypto_update {
+        // Validate incoming key update
+        if number <= rx_packet || prev_crypto.map_or(false, |x| x.update_unacked) {
+            return Err(Some(TransportError::KEY_UPDATE_ERROR("")));
+        }
+    }
+
+    Ok(Some(DecryptPacketResult {
+        number,
+        outgoing_key_update_acked,
+        incoming_key_update: crypto_update,
+    }))
+}
+
+pub(super) struct DecryptPacketResult {
+    /// The packet number
+    pub(super) number: u64,
+    /// Whether a locally initiated key update has been acknowledged by the peer
+    pub(super) outgoing_key_update_acked: bool,
+    /// Whether the peer has initiated a key update
+    pub(super) incoming_key_update: bool,
+}
+
+pub(super) struct PrevCrypto {
+    /// The keys used for the previous key phase, temporarily retained to decrypt packets sent by
+    /// the peer prior to its own key update.
+    pub(super) crypto: KeyPair<Box<dyn PacketKey>>,
+    /// The incoming packet that ends the interval for which these keys are applicable, and the time
+    /// of its receipt.
+    ///
+    /// Incoming packets should be decrypted using these keys iff this is `None` or their packet
+    /// number is lower. `None` indicates that we have not yet received a packet using newer keys,
+    /// which implies that the update was locally initiated.
+    pub(super) end_packet: Option<(u64, Instant)>,
+    /// Whether the following key phase is from a remotely initiated update that we haven't acked
+    pub(super) update_unacked: bool,
 }
 
 pub(super) struct ZeroRttCrypto {

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -24,11 +24,13 @@ pub struct UdpStats {
 #[allow(missing_docs)]
 pub struct FrameStats {
     pub acks: u64,
+    pub ack_frequency: u64,
     pub crypto: u64,
     pub connection_close: u64,
     pub data_blocked: u64,
     pub datagram: u64,
     pub handshake_done: u8,
+    pub immediate_ack: u64,
     pub max_data: u64,
     pub max_stream_data: u64,
     pub max_streams_bidi: u64,
@@ -82,6 +84,8 @@ impl FrameStats {
             Frame::PathChallenge(_) => self.path_challenge += 1,
             Frame::PathResponse(_) => self.path_response += 1,
             Frame::Close(_) => self.connection_close += 1,
+            Frame::AckFrequency(_) => self.ack_frequency += 1,
+            Frame::ImmediateAck => self.immediate_ack += 1,
             Frame::HandshakeDone => self.handshake_done += 1,
             Frame::Invalid { .. } => {}
         }
@@ -92,11 +96,13 @@ impl std::fmt::Debug for FrameStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FrameStats")
             .field("ACK", &self.acks)
+            .field("ACK_FREQUENCY", &self.ack_frequency)
             .field("CONNECTION_CLOSE", &self.connection_close)
             .field("CRYPTO", &self.crypto)
             .field("DATA_BLOCKED", &self.data_blocked)
             .field("DATAGRAM", &self.datagram)
             .field("HANDSHAKE_DONE", &self.handshake_done)
+            .field("IMMEDIATE_ACK", &self.immediate_ack)
             .field("MAX_DATA", &self.max_data)
             .field("MAX_STREAM_DATA", &self.max_stream_data)
             .field("MAX_STREAMS_BIDI", &self.max_streams_bidi)

--- a/quinn-proto/src/connection/timer.rs
+++ b/quinn-proto/src/connection/timer.rs
@@ -18,10 +18,15 @@ pub(crate) enum Timer {
     Pacing = 6,
     /// When to invalidate old CID and proactively push new one via NEW_CONNECTION_ID frame
     PushNewCid = 7,
+    /// When to send an immediate ACK if there are unacked ack-eliciting packets of the peer
+    MaxAckDelay = 8,
+    /// When the RTT is elapsed (used to request an immediate ack if there are local unacked
+    /// ack-eliciting packets)
+    Rtt = 9,
 }
 
 impl Timer {
-    pub(crate) const VALUES: [Self; 8] = [
+    pub(crate) const VALUES: [Self; 10] = [
         Self::LossDetection,
         Self::Idle,
         Self::Close,
@@ -30,13 +35,15 @@ impl Timer {
         Self::KeepAlive,
         Self::Pacing,
         Self::PushNewCid,
+        Self::MaxAckDelay,
+        Self::Rtt,
     ];
 }
 
 /// A table of data associated with each distinct kind of `Timer`
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) struct TimerTable {
-    data: [Option<Instant>; 8],
+    data: [Option<Instant>; 10],
 }
 
 impl TimerTable {

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -51,8 +51,8 @@ pub use crate::connection::{
 
 mod config;
 pub use config::{
-    ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig, ServerConfig,
-    TransportConfig,
+    AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig,
+    ServerConfig, TransportConfig,
 };
 
 pub mod crypto;

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -19,6 +19,7 @@ use crate::{
 // to inspect the version and packet type (which depends on the version).
 // This information allows us to fully decode and decrypt the packet.
 #[allow(unreachable_pub)] // fuzzing only
+#[cfg_attr(test, derive(Clone))]
 #[derive(Debug)]
 pub struct PartialDecode {
     plain_header: PlainHeader,
@@ -234,7 +235,8 @@ impl Packet {
     }
 }
 
-#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(Clone))]
+#[derive(Debug)]
 pub(crate) enum Header {
     Initial {
         dst_cid: ConnectionId,
@@ -477,7 +479,7 @@ impl PartialEncode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum PlainHeader {
     Initial {
         dst_cid: ConnectionId,

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -161,6 +161,11 @@ impl EcnCodepoint {
             }
         })
     }
+
+    /// Returns whether the codepoint is a CE, signalling that congestion was experienced
+    pub fn is_ce(self) -> bool {
+        matches!(self, Self::Ce)
+    }
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -21,7 +21,7 @@ use crate::{
     config::{EndpointConfig, ServerConfig, TransportConfig},
     shared::ConnectionId,
     ResetToken, Side, TransportError, VarInt, LOC_CID_COUNT, MAX_CID_SIZE, MAX_STREAM_COUNT,
-    RESET_TOKEN_SIZE,
+    RESET_TOKEN_SIZE, TIMER_GRANULARITY,
 };
 
 // Apply a given macro to a list of all the transport parameters having integer types, along with
@@ -81,6 +81,13 @@ macro_rules! make_struct {
             /// bit
             pub(crate) grease_quic_bit: bool,
 
+            /// Minimum amount of time in microseconds by which the endpoint is able to delay
+            /// sending acknowledgments
+            ///
+            /// If a value is provided, it implies that the endpoint supports QUIC Acknowledgement
+            /// Frequency
+            pub(crate) min_ack_delay: Option<VarInt>,
+
             // Server-only
             /// The value of the Destination Connection ID field from the first Initial packet sent
             /// by the client
@@ -104,6 +111,7 @@ macro_rules! make_struct {
                     max_datagram_frame_size: None,
                     initial_src_cid: None,
                     grease_quic_bit: false,
+                    min_ack_delay: None,
 
                     original_dst_cid: None,
                     retry_src_cid: None,
@@ -146,6 +154,9 @@ impl TransportParameters {
                 .datagram_receive_buffer_size
                 .map(|x| (x.min(u16::max_value().into()) as u16).into()),
             grease_quic_bit: endpoint_config.grease_quic_bit,
+            min_ack_delay: Some(
+                VarInt::from_u64(u64::try_from(TIMER_GRANULARITY.as_micros()).unwrap()).unwrap(),
+            ),
             ..Self::default()
         }
     }
@@ -329,6 +340,12 @@ impl TransportParameters {
             w.write_var(0x2ab2);
             w.write_var(0);
         }
+
+        if let Some(x) = self.min_ack_delay {
+            w.write_var(0xff04de1a);
+            w.write_var(x.size() as u64);
+            w.write(x);
+        }
     }
 
     /// Decode `TransportParameters` from buffer
@@ -392,6 +409,7 @@ impl TransportParameters {
                     0 => params.grease_quic_bit = true,
                     _ => return Err(Error::Malformed),
                 },
+                0xff04de1a => params.min_ack_delay = Some(r.get().unwrap()),
                 _ => {
                     macro_rules! parse {
                         {$($(#[$doc:meta])* $name:ident ($code:expr) = $default:expr,)*} => {
@@ -418,6 +436,10 @@ impl TransportParameters {
             || params.max_udp_payload_size.0 < 1200
             || params.initial_max_streams_bidi.0 > MAX_STREAM_COUNT
             || params.initial_max_streams_uni.0 > MAX_STREAM_COUNT
+            || params.min_ack_delay.map_or(false, |min_ack_delay| {
+                // min_ack_delay uses microseconds, whereas max_ack_delay uses milliseconds
+                min_ack_delay.0 > params.max_ack_delay.0 * 1_000
+            })
             || (side.is_server()
                 && (params.stateless_reset_token.is_some() || params.preferred_address.is_some()))
         {
@@ -458,6 +480,7 @@ mod test {
                 stateless_reset_token: [0xab; RESET_TOKEN_SIZE].into(),
             }),
             grease_quic_bit: true,
+            min_ack_delay: Some(2_000u32.into()),
             ..TransportParameters::default()
         };
         params.write(&mut buf);
@@ -465,6 +488,40 @@ mod test {
             TransportParameters::read(Side::Client, &mut buf.as_slice()).unwrap(),
             params
         );
+    }
+
+    #[test]
+    fn read_semantic_validation() {
+        #[allow(clippy::type_complexity)]
+        let illegal_params_builders: Vec<Box<dyn FnMut(&mut TransportParameters)>> = vec![
+            Box::new(|t| {
+                // This min_ack_delay is bigger than max_ack_delay!
+                let min_ack_delay = t.max_ack_delay.0 * 1_000 + 1;
+                t.min_ack_delay = Some(VarInt::from_u64(min_ack_delay).unwrap())
+            }),
+            Box::new(|t| {
+                // Preferred address can only be sent by senders (and we are reading the transport
+                // params as a client)
+                t.preferred_address = Some(PreferredAddress {
+                    address_v4: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 42)),
+                    address_v6: None,
+                    connection_id: ConnectionId::new(&[]),
+                    stateless_reset_token: [0xab; RESET_TOKEN_SIZE].into(),
+                })
+            }),
+        ];
+
+        for mut builder in illegal_params_builders {
+            let mut buf = Vec::new();
+            let mut params = TransportParameters::default();
+            builder(&mut params);
+            params.write(&mut buf);
+
+            assert_eq!(
+                TransportParameters::read(Side::Server, &mut buf.as_slice()),
+                Err(Error::IllegalValue)
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Overview of the feature:

* The ack frequency extension allows one to control the ACK frequency of the remote peer.
* Quinn provides an `AckFrequencyConfig` to control the parameters, which are sent to the peer in an `ACK_FREQUENCY` frame at the beginning of the connection (technically, the extension allows modifying the ack frequency parameters multiple times during a connection, but then you would need to come up with an algorithm to automatically tune the parameters, which IMO is out of scope for this first implementation).
* On the other side of the connection, Quinn will receive and process the `ACK_FREQUENCY` frame, updating the local ack frequency parameters based on the new parameters sent by the peer.
* If the local peer has requested a custom ack frequency from the remote peer, Quinn will send an `IMMEDIATE_ACK` frame every RTT if there are any unacked ack-eliciting packets (this is a new kind of frame to immediately elicit an ACK). This is recommended by the draft as a way to ensure congestion control and loss detection work properly.
* The draft is ambiguous when it comes to out-of-order packet detection. I wrote the specific details in [this issue](https://github.com/quicwg/ack-frequency/issues/183), hoping it gets clarified. In the meantime, I am sticking to the text of the draft and ignoring the parts in the examples that deviate from the draft's definitions.

I have a bunch of questions / comments:

1. I introduced two timers, one to be notified when `max_ack_delay` is elapsed, and one to be notified when an RTT is elapsed. I tried to come up with an approach that wouldn't require additional timers, but I'm not sure it is possible. It would be nice if you can double-check that, given your knowledge of the codebase.
1. I introduced a `reset_rtt_timer` function that arms the `Timer::Rtt` for the first time. I wanted to arm it right after we have reached the Data space and have an RTT estimate. I ended up calling it inside `process_payload`. Please let me know if there is a more suitable place.
1. I rewrote a long comment inside `PendingAcks::acks_sent`, which I found difficult to understand. Hopefully the new version says the same in clearer terms (otherwise let me know and I'll update it)