### PR TITLE
Fail FreeBSD CI if any step fails

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,11 +27,11 @@ jobs:
             sh rustup.sh -y --profile minimal --default-toolchain stable
             echo "~~~~ rustc --version ~~~~"
             $HOME/.cargo/bin/rustc --version
-          run: |
+            echo "~~~~ freebsd-version ~~~~"
             freebsd-version
+          run: |
             $HOME/.cargo/bin/cargo build --all-targets
             $HOME/.cargo/bin/cargo test
-            $HOME/.cargo/bin/cargo test --manifest-path fuzz/Cargo.toml
   test:
     strategy:
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,9 +29,7 @@ jobs:
             $HOME/.cargo/bin/rustc --version
             echo "~~~~ freebsd-version ~~~~"
             freebsd-version
-          run: |
-            $HOME/.cargo/bin/cargo build --all-targets
-            $HOME/.cargo/bin/cargo test
+          run: $HOME/.cargo/bin/cargo build --all-targets && $HOME/.cargo/bin/cargo test && $HOME/.cargo/bin/cargo test --manifest-path fuzz/Cargo.toml
   test:
     strategy:
       matrix:


### PR DESCRIPTION
FreeBSD CI Action gives false success results. Here is possible explanation: [#1556](https://github.com/quinn-rs/quinn/issues/1556)

Removing fuzz tests is not ideal, but better than getting false success CI check results on every run