### PR TITLE
Overhaul bench

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.22"
 bytes = "1"
 hdrhistogram = { version = "7.2", default-features = false }
 quinn = { path = "../quinn" }
+quinn-proto = { path = "../quinn-proto" }
 rcgen = "0.10.0"
 rustls = { version = "0.21.0", default-features = false, features = ["quic"] }
 clap = { version = "3.2", features = ["derive"] }

--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -169,6 +169,10 @@ pub fn transport_config(opt: &Opt) -> quinn::TransportConfig {
     let mut config = quinn::TransportConfig::default();
     config.max_concurrent_uni_streams(opt.max_streams.try_into().unwrap());
     config.initial_mtu(opt.initial_mtu);
+    config.min_mtu(opt.min_mtu);
+    if opt.disable_mtud {
+        config.mtu_discovery_config(None);
+    }
     config
 }
 
@@ -250,6 +254,12 @@ pub struct Opt {
     /// Starting guess for maximum UDP payload size
     #[clap(long, default_value = "1200")]
     pub initial_mtu: u16,
+    /// The MTU that is guaranteed to be supported by the network
+    #[clap(long, default_value = "1200")]
+    min_mtu: u16,
+    /// Disable MTU discovery, to make the output more predictable
+    #[clap(long)]
+    disable_mtud: bool,
     /// Disable packet encryption/decryption
     #[clap(long)]
     no_protection: bool,

--- a/bench/src/noprotection.rs
+++ b/bench/src/noprotection.rs
@@ -1,0 +1,222 @@
+use std::sync::Arc;
+
+use bytes::BytesMut;
+
+use quinn_proto::{
+    crypto::{self, CryptoError},
+    transport_parameters, ConnectionId, Side, TransportError,
+};
+
+/// A TLS session which does not perform packet encryption/decryption (for benchmarking purposes)
+struct NoProtectionSession {
+    inner: Box<dyn crypto::Session>,
+}
+
+impl NoProtectionSession {
+    fn new(tls: Box<dyn crypto::Session>) -> Self {
+        Self { inner: tls }
+    }
+}
+
+struct NoProtectionHeaderKey {
+    inner: Box<dyn crypto::HeaderKey>,
+}
+
+impl NoProtectionHeaderKey {
+    fn new(key: Box<dyn crypto::HeaderKey>) -> Self {
+        Self { inner: key }
+    }
+}
+
+struct NoProtectionPacketKey {
+    inner: Box<dyn crypto::PacketKey>,
+}
+
+impl NoProtectionPacketKey {
+    fn new(key: Box<dyn crypto::PacketKey>) -> Self {
+        Self { inner: key }
+    }
+}
+
+pub struct NoProtectionClientConfig {
+    inner: Arc<rustls::ClientConfig>,
+}
+
+impl NoProtectionClientConfig {
+    pub fn new(config: Arc<rustls::ClientConfig>) -> Self {
+        Self { inner: config }
+    }
+}
+
+pub struct NoProtectionServerConfig {
+    inner: Arc<rustls::ServerConfig>,
+}
+
+impl NoProtectionServerConfig {
+    pub fn new(config: Arc<rustls::ServerConfig>) -> Self {
+        Self { inner: config }
+    }
+}
+
+// Forward all calls to inner except those related to packet encryption/decryption
+impl crypto::Session for NoProtectionSession {
+    fn initial_keys(&self, dst_cid: &ConnectionId, side: Side) -> crypto::Keys {
+        self.inner.initial_keys(dst_cid, side)
+    }
+
+    fn handshake_data(&self) -> Option<Box<dyn std::any::Any>> {
+        self.inner.handshake_data()
+    }
+
+    fn peer_identity(&self) -> Option<Box<dyn std::any::Any>> {
+        self.inner.peer_identity()
+    }
+
+    fn early_crypto(&self) -> Option<(Box<dyn crypto::HeaderKey>, Box<dyn crypto::PacketKey>)> {
+        let (hkey, pkey) = self.inner.early_crypto()?;
+
+        // use wrapper type to disable packet encryption/decryption
+        Some((hkey, Box::new(NoProtectionPacketKey::new(pkey))))
+    }
+
+    fn early_data_accepted(&self) -> Option<bool> {
+        self.inner.early_data_accepted()
+    }
+
+    fn is_handshaking(&self) -> bool {
+        self.inner.is_handshaking()
+    }
+
+    fn read_handshake(&mut self, buf: &[u8]) -> Result<bool, TransportError> {
+        self.inner.read_handshake(buf)
+    }
+
+    fn transport_parameters(
+        &self,
+    ) -> Result<Option<transport_parameters::TransportParameters>, TransportError> {
+        self.inner.transport_parameters()
+    }
+
+    fn write_handshake(&mut self, buf: &mut Vec<u8>) -> Option<crypto::Keys> {
+        let keys = self.inner.write_handshake(buf)?;
+
+        // use wrapper type to disable packet encryption/decryption
+        Some(crypto::Keys {
+            header: crypto::KeyPair {
+                local: Box::new(NoProtectionHeaderKey::new(keys.header.local)),
+                remote: Box::new(NoProtectionHeaderKey::new(keys.header.remote)),
+            },
+            packet: crypto::KeyPair {
+                local: Box::new(NoProtectionPacketKey::new(keys.packet.local)),
+                remote: Box::new(NoProtectionPacketKey::new(keys.packet.remote)),
+            },
+        })
+    }
+
+    fn next_1rtt_keys(&mut self) -> Option<crypto::KeyPair<Box<dyn crypto::PacketKey>>> {
+        let keys = self.inner.next_1rtt_keys()?;
+
+        // use wrapper type to disable packet encryption/decryption
+        Some(crypto::KeyPair {
+            local: Box::new(NoProtectionPacketKey::new(keys.local)),
+            remote: Box::new(NoProtectionPacketKey::new(keys.remote)),
+        })
+    }
+
+    fn is_valid_retry(&self, orig_dst_cid: &ConnectionId, header: &[u8], payload: &[u8]) -> bool {
+        self.inner.is_valid_retry(orig_dst_cid, header, payload)
+    }
+
+    fn export_keying_material(
+        &self,
+        output: &mut [u8],
+        label: &[u8],
+        context: &[u8],
+    ) -> Result<(), crypto::ExportKeyingMaterialError> {
+        self.inner.export_keying_material(output, label, context)
+    }
+}
+
+impl crypto::ClientConfig for NoProtectionClientConfig {
+    fn start_session(
+        self: Arc<Self>,
+        version: u32,
+        server_name: &str,
+        params: &transport_parameters::TransportParameters,
+    ) -> Result<Box<dyn crypto::Session>, quinn::ConnectError> {
+        let tls = self
+            .inner
+            .clone()
+            .start_session(version, server_name, params)?;
+
+        Ok(Box::new(NoProtectionSession::new(tls)))
+    }
+}
+
+impl crypto::ServerConfig for NoProtectionServerConfig {
+    fn initial_keys(
+        &self,
+        version: u32,
+        dst_cid: &ConnectionId,
+        side: Side,
+    ) -> Result<crypto::Keys, crypto::UnsupportedVersion> {
+        self.inner.initial_keys(version, dst_cid, side)
+    }
+
+    fn retry_tag(&self, version: u32, orig_dst_cid: &ConnectionId, packet: &[u8]) -> [u8; 16] {
+        self.inner.retry_tag(version, orig_dst_cid, packet)
+    }
+
+    fn start_session(
+        self: Arc<Self>,
+        version: u32,
+        params: &transport_parameters::TransportParameters,
+    ) -> Box<dyn crypto::Session> {
+        let tls = self.inner.clone().start_session(version, params);
+
+        Box::new(NoProtectionSession::new(tls))
+    }
+}
+
+impl crypto::HeaderKey for NoProtectionHeaderKey {
+    fn decrypt(&self, _pn_offset: usize, _packet: &mut [u8]) {}
+
+    fn encrypt(&self, _pn_offset: usize, _packet: &mut [u8]) {}
+
+    fn sample_size(&self) -> usize {
+        self.inner.sample_size()
+    }
+}
+
+// Forward all calls to inner except those related to packet encryption/decryption
+impl crypto::PacketKey for NoProtectionPacketKey {
+    fn encrypt(&self, _packet: u64, buf: &mut [u8], header_len: usize) {
+        let (_header, payload_tag) = buf.split_at_mut(header_len);
+        let (_payload, tag_storage) =
+            payload_tag.split_at_mut(payload_tag.len() - self.inner.tag_len());
+        tag_storage.fill(42);
+    }
+
+    fn decrypt(
+        &self,
+        _packet: u64,
+        _header: &[u8],
+        payload: &mut BytesMut,
+    ) -> Result<(), CryptoError> {
+        let plain_len = payload.len() - self.inner.tag_len();
+        payload.truncate(plain_len);
+        Ok(())
+    }
+
+    fn tag_len(&self) -> usize {
+        self.inner.tag_len()
+    }
+
+    fn confidentiality_limit(&self) -> u64 {
+        self.inner.confidentiality_limit()
+    }
+
+    fn integrity_limit(&self) -> u64 {
+        self.inner.integrity_limit()
+    }
+}

--- a/bench/src/simulated_network.rs
+++ b/bench/src/simulated_network.rs
@@ -1,0 +1,250 @@
+use std::collections::VecDeque;
+use std::io::{Error, IoSliceMut};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::sync::{Arc, Mutex};
+use std::task::{Poll, Waker};
+use std::time::{Duration, Instant};
+
+use quinn::udp::{RecvMeta, Transmit, UdpState};
+use quinn::AsyncUdpSocket;
+
+use queue::InboundQueue;
+
+#[derive(Debug)]
+pub struct InMemorySocketHandle {
+    pub network: Arc<InMemoryNetwork>,
+    pub addr: SocketAddr,
+}
+
+impl AsyncUdpSocket for InMemorySocketHandle {
+    fn poll_send(
+        &self,
+        _state: &UdpState,
+        _cx: &mut std::task::Context,
+        transmits: &[Transmit],
+    ) -> Poll<Result<usize, Error>> {
+        let now = Instant::now();
+        for transmit in transmits {
+            let transmit = Transmit {
+                destination: transmit.destination,
+                ecn: transmit.ecn,
+                contents: transmit.contents.clone(),
+                src_ip: Some(self.addr.ip()),
+                segment_size: transmit.segment_size,
+            };
+
+            self.network.send(now, self.addr, transmit);
+        }
+
+        if transmits.is_empty() {
+            Poll::Pending
+        } else {
+            Poll::Ready(Ok(transmits.len()))
+        }
+    }
+
+    fn poll_recv(
+        &self,
+        cx: &mut std::task::Context,
+        bufs: &mut [IoSliceMut<'_>],
+        meta: &mut [RecvMeta],
+    ) -> Poll<std::io::Result<usize>> {
+        let socket = self.network.socket(self.addr);
+        let mut inbound = socket.inbound.lock().unwrap();
+
+        let max_transmits = meta.len();
+        let mut received = 0;
+
+        let out = meta.iter_mut().zip(bufs);
+        for (in_transit, (meta, buf)) in inbound.receive(max_transmits).zip(out) {
+            received += 1;
+            let transmit = in_transit.transmit;
+
+            // Meta
+            meta.addr = in_transit.source_addr;
+            meta.ecn = transmit.ecn;
+            meta.dst_ip = Some(transmit.destination.ip());
+            meta.len = transmit.contents.len();
+            meta.stride = transmit.segment_size.unwrap_or(meta.len);
+
+            // Buffer
+            buf[..transmit.contents.len()].copy_from_slice(&transmit.contents);
+        }
+
+        if received == 0 {
+            if inbound.is_empty() {
+                // Store the waker so we can be notified of new transmits
+                let mut waker = socket.waker.lock().unwrap();
+                if waker.is_none() {
+                    *waker = Some(cx.waker().clone())
+                }
+            } else {
+                // Wake up next time we can read
+                let next_read = inbound.time_of_next_receive();
+                let waker = cx.waker().clone();
+                tokio::task::spawn(async move {
+                    tokio::time::sleep_until(next_read.into()).await;
+                    waker.wake();
+                });
+            }
+
+            Poll::Pending
+        } else {
+            Poll::Ready(Ok(received))
+        }
+    }
+
+    fn local_addr(&self) -> std::io::Result<SocketAddr> {
+        Ok(self.addr)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct InMemorySocket {
+    addr: SocketAddr,
+    inbound: Arc<Mutex<InboundQueue>>,
+    waker: Arc<Mutex<Option<Waker>>>,
+}
+
+impl InMemorySocket {
+    pub fn new(addr: SocketAddr, link_delay: Duration, link_capacity: usize) -> InMemorySocket {
+        InMemorySocket {
+            addr,
+            inbound: Arc::new(Mutex::new(InboundQueue::new(link_delay, link_capacity))),
+            waker: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+// This mod is meant to enforce encapsulation of InboundQueue's private fields
+mod queue {
+    use super::*;
+
+    #[derive(Debug)]
+    pub struct InboundQueue {
+        queue: VecDeque<InTransitData>,
+        bytes_in_transit: usize,
+        link_delay: Duration,
+        link_capacity: usize,
+    }
+
+    impl InboundQueue {
+        pub(super) fn new(link_delay: Duration, link_capacity: usize) -> Self {
+            Self {
+                queue: VecDeque::new(),
+                bytes_in_transit: 0,
+                link_delay,
+                link_capacity,
+            }
+        }
+
+        pub(super) fn send(&mut self, data: InTransitData) -> bool {
+            if self.bytes_in_transit + data.transmit.contents.len() <= self.link_capacity {
+                self.bytes_in_transit += data.transmit.contents.len();
+                self.queue.push_back(data);
+                true
+            } else {
+                false
+            }
+        }
+
+        pub(super) fn is_empty(&self) -> bool {
+            self.queue.is_empty()
+        }
+
+        pub(super) fn receive(
+            &mut self,
+            max_transmits: usize,
+        ) -> impl Iterator<Item = InTransitData> + '_ {
+            let now = Instant::now();
+            let transmits_to_read = self
+                .queue
+                .iter()
+                .take(max_transmits)
+                .take_while(|t| t.sent + self.link_delay <= now)
+                .count();
+
+            for data in self.queue.iter().take(transmits_to_read) {
+                self.bytes_in_transit -= data.transmit.contents.len();
+            }
+
+            self.queue.drain(..transmits_to_read)
+        }
+
+        pub(super) fn time_of_next_receive(&self) -> Instant {
+            self.queue[0].sent + self.link_delay
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InMemoryNetwork {
+    pub sockets: Vec<InMemorySocket>,
+}
+
+impl InMemoryNetwork {
+    /// Initializes a new [`InMemoryNetwork`] with one socket for the server and one for the client
+    ///
+    /// The link capacity is measured in bytes per `link_delay`
+    pub fn initialize(link_delay: Duration, link_capacity: usize) -> Self {
+        let server_addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080);
+        let client_addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8081);
+
+        Self {
+            sockets: vec![
+                InMemorySocket::new(server_addr, link_delay, link_capacity),
+                InMemorySocket::new(client_addr, link_delay, link_capacity),
+            ],
+        }
+    }
+
+    /// Returns a handle to the server's socket
+    pub fn server_socket(self: Arc<InMemoryNetwork>) -> InMemorySocketHandle {
+        InMemorySocketHandle {
+            addr: self.sockets[0].addr,
+            network: self.clone(),
+        }
+    }
+
+    /// Returns a handle to the client's socket
+    pub fn client_socket(self: Arc<InMemoryNetwork>) -> InMemorySocketHandle {
+        InMemorySocketHandle {
+            addr: self.sockets[1].addr,
+            network: self.clone(),
+        }
+    }
+
+    /// Returns the socket bound to the provided address
+    fn socket(&self, addr: SocketAddr) -> InMemorySocket {
+        self.sockets
+            .iter()
+            .find(|s| s.addr == addr)
+            .cloned()
+            .expect("socket does not exist")
+    }
+
+    /// Sends a [`Transmit`] to its destination
+    fn send(&self, now: Instant, source_addr: SocketAddr, transmit: Transmit) {
+        let socket = self.socket(transmit.destination);
+        let sent = socket.inbound.lock().unwrap().send(InTransitData {
+            source_addr,
+            transmit,
+            sent: now,
+        });
+
+        if sent {
+            // Wake the receiver if it is waiting for incoming transmits
+            let mut opt_waker = socket.waker.lock().unwrap();
+            if let Some(waker) = opt_waker.take() {
+                waker.wake();
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct InTransitData {
+    source_addr: SocketAddr,
+    transmit: Transmit,
+    sent: Instant,
+}


### PR DESCRIPTION
This PR introduces a few options to benchmark more effectively:

- Disable encryption (using the `--no-protection` flag, similar to the `perf` crate).
- Run on a simulated in-memory network, instead of going through the networking stack of the operating system (using the `--simulate-network` together with the `--simulated-link-latency` and `--simulated-link-capacity` options). This makes it trivial to benchmark for different latencies and link capacities out-of-the-box (instead of relying on platform-specific utilities like `tc`).
- Disable MTUD (using `--disable-mtud`) and set the minimum MTU (using `--min-mtu`), to make runs more deterministic