### PR TITLE
Add perf_datagram_{server, client}

### DIFF
--- a/perf/src/bin/perf_datagram_client.rs
+++ b/perf/src/bin/perf_datagram_client.rs
@@ -1,0 +1,204 @@
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use clap::Parser;
+use quinn::{RecvStream, TokioRuntime};
+
+use tracing::{debug, error, info};
+
+use perf::{
+    bind_socket, get_client_config, get_client_crypto, get_local_addr, get_transport_config,
+    lookup_host,
+};
+
+/// Connects to a QUIC perf datagram server and maintains a specified pattern of requests until interrupted
+#[derive(Parser)]
+#[clap(name = "datagram_client")]
+struct Opt {
+    /// Host to connect to
+    #[clap(default_value = "localhost:4433")]
+    host: String,
+    /// Override DNS resolution for host
+    #[clap(long)]
+    ip: Option<IpAddr>,
+    /// Send buffer size in bytes
+    #[clap(long, default_value = "2097152")]
+    send_buffer_size: usize,
+    /// Receive buffer size in bytes
+    #[clap(long, default_value = "2097152")]
+    recv_buffer_size: usize,
+    /// Transfer the data using a stream instead of datagrams (useful to compare performance between
+    /// the two)
+    #[clap(long)]
+    use_stream: bool,
+    /// Specify the local socket address
+    #[clap(long)]
+    local_addr: Option<SocketAddr>,
+    /// Perform NSS-compatible TLS key logging to the file specified in `SSLKEYLOGFILE`.
+    #[clap(long = "keylog")]
+    keylog: bool,
+    /// UDP payload size that the network must be capable of carrying
+    #[clap(long, default_value = "1200")]
+    initial_mtu: u16,
+    /// Disable packet encryption/decryption (for debugging purpose)
+    #[clap(long = "no-protection")]
+    no_protection: bool,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let opt = Opt::parse();
+
+    tracing_subscriber::fmt::init();
+
+    if let Err(e) = run(opt).await {
+        error!("{:#}", e);
+    }
+}
+
+async fn run(opt: Opt) -> Result<()> {
+    let (host_name, addr) = lookup_host(&opt.host, opt.ip).await?;
+    info!("connecting to {} at {}", host_name, addr);
+
+    let bind_addr = get_local_addr(addr, opt.local_addr);
+    info!("local addr {:?}", bind_addr);
+
+    let socket = bind_socket(bind_addr, opt.send_buffer_size, opt.recv_buffer_size)?;
+
+    let endpoint = quinn::Endpoint::new(Default::default(), None, socket, Arc::new(TokioRuntime))?;
+
+    let crypto = get_client_crypto(opt.keylog)?;
+    let mut transport = get_transport_config(opt.initial_mtu);
+
+    transport.datagram_send_buffer_size(1024 * 1024 * 100);
+
+    let cfg = get_client_config(transport, crypto, opt.no_protection);
+
+    let connection = endpoint
+        .connect_with(cfg, addr, host_name)?
+        .await
+        .context("connecting")?;
+
+    info!("established");
+
+    let data_len = 1024 * 1024 * 1024 * 2; // 2 GiB
+    let data_len_buf = u64::to_le_bytes(data_len);
+
+    let datagram_size = connection.max_datagram_size().unwrap();
+
+    // The length of the data to send
+    let (mut data_len_send, recv_done) = connection.open_bi().await?;
+    data_len_send.write_all(&data_len_buf).await?;
+
+    let start = Instant::now();
+
+    let total_received_by_server = if opt.use_stream {
+        send_stream(&connection, data_len as usize).await?;
+        receive_total_bytes_read(recv_done).await?
+    } else {
+        tokio::select! {
+            Ok(()) = send_datagrams(&connection, datagram_size) => {
+                unreachable!("send_datagrams never stops by itself")
+            }
+            Ok(total_received) = receive_total_bytes_read(recv_done) => {
+                total_received
+            }
+        }
+    };
+
+    assert!(total_received_by_server >= data_len);
+
+    let finish = Instant::now();
+    let diff = finish - start;
+
+    println!(
+        "Transferred {total_received_by_server} bytes in {} ms ({:.2} MiB/s)",
+        diff.as_millis(),
+        total_received_by_server as f64 / 1024.0 / 1024.0 / diff.as_secs_f64()
+    );
+
+    let bytes_lost = if opt.use_stream {
+        connection.stats().path.lost_bytes
+    } else {
+        let total_sent = connection.stats().frame_tx.datagram * datagram_size as u64;
+        total_sent - total_received_by_server
+    };
+
+    println!(
+        "Bytes lost {bytes_lost} ({:.2} MiB)",
+        bytes_lost as f64 / 1024.0 / 1024.0
+    );
+
+    println!(
+        "Congestion events: {}",
+        connection.stats().path.congestion_events
+    );
+    println!("Congestion window: {}", connection.stats().path.cwnd);
+
+    endpoint.wait_idle().await;
+
+    Ok(())
+}
+
+async fn send_stream(connection: &quinn::Connection, data_len: usize) -> Result<()> {
+    const DATA: [u8; 1024 * 1024] = [42; 1024 * 1024];
+
+    let mut send = connection.open_uni().await?;
+    let mut upload = data_len;
+
+    while upload > 0 {
+        let chunk_len = upload.min(DATA.len());
+        send.write_chunk(Bytes::from_static(&DATA[..chunk_len]))
+            .await
+            .context("sending stream chunk")?;
+        upload -= chunk_len;
+    }
+
+    send.finish().await?;
+
+    debug!("upload finished on {}", send.id());
+    Ok(())
+}
+
+async fn send_datagrams(connection: &quinn::Connection, datagram_size: usize) -> Result<()> {
+    // Since all datagrams contain the same data, they can all use the same shared buffer
+    let data = Bytes::from(vec![42; datagram_size]);
+    let total_buffer_space = connection.datagram_send_buffer_space();
+    let mut first_iteration = true;
+
+    loop {
+        // Make sure the outgoing datagram buffer is always full, so we are sending at the maximum
+        // possible rate allowed by congestion control
+        let buffer_space = connection.datagram_send_buffer_space();
+        if !first_iteration && buffer_space == total_buffer_space {
+            anyhow::bail!("No datagrams were pending! Increase datagram send buffer space so the connection is always busy");
+        }
+
+        if first_iteration {
+            first_iteration = false;
+        }
+
+        let mut sent = 0;
+        while sent + datagram_size <= buffer_space {
+            sent += datagram_size;
+            connection
+                .send_datagram(data.clone())
+                .context("send_datagram")?;
+        }
+
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn receive_total_bytes_read(mut recv: RecvStream) -> Result<u64> {
+    let mut buf = [0; 8];
+    recv.read_exact(&mut buf)
+        .await
+        .context("receive_total_bytes_read")?;
+    Ok(u64::from_le_bytes(buf))
+}

--- a/perf/src/bin/perf_datagram_server.rs
+++ b/perf/src/bin/perf_datagram_server.rs
@@ -1,0 +1,140 @@
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use quinn::TokioRuntime;
+use tracing::{debug, error, info};
+
+use perf::{bind_socket, drain_stream, get_server_config, get_server_crypto, get_transport_config};
+
+#[derive(Parser)]
+#[clap(name = "datagram_server")]
+struct Opt {
+    /// Address to listen on
+    #[clap(long = "listen", default_value = "[::]:4433")]
+    listen: SocketAddr,
+    /// TLS private key in DER format
+    #[clap(parse(from_os_str), short = 'k', long = "key", requires = "cert")]
+    key: Option<PathBuf>,
+    /// TLS certificate in PEM format
+    #[clap(parse(from_os_str), short = 'c', long = "cert", requires = "key")]
+    cert: Option<PathBuf>,
+    /// Send buffer size in bytes
+    #[clap(long, default_value = "2097152")]
+    send_buffer_size: usize,
+    /// Receive buffer size in bytes
+    #[clap(long, default_value = "2097152")]
+    recv_buffer_size: usize,
+    /// Transfer the data using a stream instead of datagrams (useful to compare performance between
+    /// the two)
+    #[clap(long)]
+    use_stream: bool,
+    /// Perform NSS-compatible TLS key logging to the file specified in `SSLKEYLOGFILE`.
+    #[clap(long = "keylog")]
+    keylog: bool,
+    /// UDP payload size that the network must be capable of carrying
+    #[clap(long, default_value = "1200")]
+    initial_mtu: u16,
+    /// Disable packet encryption/decryption (for debugging purpose)
+    #[clap(long = "no-protection")]
+    no_protection: bool,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let opt = Opt::parse();
+
+    tracing_subscriber::fmt::init();
+
+    if let Err(e) = run(opt).await {
+        error!("{:#}", e);
+    }
+}
+
+async fn run(opt: Opt) -> Result<()> {
+    let crypto = get_server_crypto(opt.key.as_deref(), opt.cert.as_deref(), opt.keylog)?;
+    let mut transport_config = get_transport_config(opt.initial_mtu);
+    transport_config.datagram_receive_buffer_size(Some(1024 * 1024 * 10));
+    let server_config = get_server_config(transport_config, crypto, opt.no_protection);
+    let socket = bind_socket(opt.listen, opt.send_buffer_size, opt.recv_buffer_size)?;
+
+    let endpoint = quinn::Endpoint::new(
+        Default::default(),
+        Some(server_config),
+        socket,
+        Arc::new(TokioRuntime),
+    )
+    .context("creating endpoint")?;
+
+    info!("listening on {}", endpoint.local_addr().unwrap());
+
+    let use_stream = opt.use_stream;
+    while let Some(handshake) = endpoint.accept().await {
+        tokio::spawn(async move {
+            if let Err(e) = handle(handshake, use_stream).await {
+                error!("connection lost: {:#}", e);
+            }
+        });
+    }
+
+    Ok(())
+}
+
+async fn handle(handshake: quinn::Connecting, use_stream: bool) -> Result<()> {
+    let connection = handshake.await.context("handshake failed")?;
+    debug!("{} connected", connection.remote_address());
+
+    // The first 8 bytes represent the amount of data that we want to transfer
+    let (mut send_stream, mut recv_stream) =
+        connection.accept_bi().await.context("accept_bi failed")?;
+    let mut buf = [0; 8];
+    recv_stream
+        .read_exact(&mut buf)
+        .await
+        .context("unable to read data length")?;
+    let data_length = u64::from_le_bytes(buf);
+
+    let received = if use_stream {
+        // The data will be transferred in an unidirectional stream
+        receive_stream(connection).await.context("receive_stream")?;
+        data_length
+    } else {
+        // The data will be transferred in datagrams
+        receive_datagrams(connection, data_length as usize)
+            .await
+            .context("receive_datagrams")?
+    };
+
+    // We are done! Now let the client know
+    send_stream
+        .write_all(&u64::to_le_bytes(received))
+        .await
+        .context("unable to write to signal we are done")?;
+    send_stream.finish().await?;
+
+    Ok(())
+}
+
+async fn receive_stream(connection: quinn::Connection) -> Result<()> {
+    // No need to explicitly keep track of received bytes, because streams are reliable
+    let stream = connection
+        .accept_uni()
+        .await
+        .context("unable to receive data through stream")?;
+    drain_stream(stream).await?;
+    Ok(())
+}
+
+async fn receive_datagrams(connection: quinn::Connection, data_length: usize) -> Result<u64> {
+    // Need to explicitly keep track of received bytes, because datagrams are unreliable
+    let mut received = 0;
+    while received < data_length {
+        let datagram = connection
+            .read_datagram()
+            .await
+            .context("unable to read datagram")?;
+        received += datagram.len();
+    }
+
+    Ok(received as u64)
+}

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -1,13 +1,166 @@
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use bytes::Bytes;
 use socket2::{Domain, Protocol, Socket, Type};
-use tracing::warn;
+use tracing::{debug, warn};
+
+use noprotection::{NoProtectionClientConfig, NoProtectionServerConfig};
 
 #[cfg_attr(not(feature = "json-output"), allow(dead_code))]
 pub mod stats;
 
 pub mod noprotection;
+
+pub fn get_cert(
+    key_path: Option<&Path>,
+    cert_path: Option<&Path>,
+) -> Result<(rustls::PrivateKey, Vec<rustls::Certificate>)> {
+    match (key_path, cert_path) {
+        (Some(key), Some(cert)) => {
+            let key = std::fs::read(key).context("reading key")?;
+            let cert = std::fs::read(cert).expect("reading cert");
+
+            let mut certs = Vec::new();
+            for cert in rustls_pemfile::certs(&mut cert.as_ref()).context("parsing cert")? {
+                certs.push(rustls::Certificate(cert));
+            }
+
+            Ok((rustls::PrivateKey(key), certs))
+        }
+        _ => {
+            let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+            Ok((
+                rustls::PrivateKey(cert.serialize_private_key_der()),
+                vec![rustls::Certificate(cert.serialize_der().unwrap())],
+            ))
+        }
+    }
+}
+
+pub fn get_server_crypto(
+    key_path: Option<&Path>,
+    cert_path: Option<&Path>,
+    keylog: bool,
+) -> Result<rustls::ServerConfig> {
+    let (key, cert) = get_cert(key_path, cert_path)?;
+
+    let mut crypto = rustls::ServerConfig::builder()
+        .with_cipher_suites(PERF_CIPHER_SUITES)
+        .with_safe_default_kx_groups()
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap()
+        .with_no_client_auth()
+        .with_single_cert(cert, key)
+        .unwrap();
+    crypto.alpn_protocols = vec![b"perf".to_vec()];
+
+    if keylog {
+        crypto.key_log = Arc::new(rustls::KeyLogFile::new());
+    }
+
+    Ok(crypto)
+}
+
+pub fn get_client_crypto(keylog: bool) -> Result<rustls::ClientConfig> {
+    let mut crypto = rustls::ClientConfig::builder()
+        .with_cipher_suites(PERF_CIPHER_SUITES)
+        .with_safe_default_kx_groups()
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap()
+        .with_custom_certificate_verifier(SkipServerVerification::new())
+        .with_no_client_auth();
+    crypto.alpn_protocols = vec![b"perf".to_vec()];
+
+    if keylog {
+        crypto.key_log = Arc::new(rustls::KeyLogFile::new());
+    }
+
+    Ok(crypto)
+}
+
+pub fn get_transport_config(initial_mtu: u16) -> quinn::TransportConfig {
+    let mut transport = quinn::TransportConfig::default();
+    transport.initial_mtu(initial_mtu);
+    transport
+}
+
+pub fn get_server_config(
+    transport: quinn::TransportConfig,
+    crypto: rustls::ServerConfig,
+    no_protection: bool,
+) -> quinn::ServerConfig {
+    let mut server_config = if no_protection {
+        quinn::ServerConfig::with_crypto(Arc::new(NoProtectionServerConfig::new(Arc::new(crypto))))
+    } else {
+        quinn::ServerConfig::with_crypto(Arc::new(crypto))
+    };
+    server_config.transport_config(Arc::new(transport));
+    server_config
+}
+
+pub fn get_client_config(
+    transport: quinn::TransportConfig,
+    crypto: rustls::ClientConfig,
+    no_protection: bool,
+) -> quinn::ClientConfig {
+    let mut client_config = if no_protection {
+        quinn::ClientConfig::new(Arc::new(NoProtectionClientConfig::new(Arc::new(crypto))))
+    } else {
+        quinn::ClientConfig::new(Arc::new(crypto))
+    };
+    client_config.transport_config(Arc::new(transport));
+    client_config
+}
+
+pub fn get_local_addr(remote_addr: SocketAddr, local_addr: Option<SocketAddr>) -> SocketAddr {
+    local_addr.unwrap_or_else(|| {
+        let unspec = if remote_addr.is_ipv4() {
+            Ipv4Addr::UNSPECIFIED.into()
+        } else {
+            Ipv6Addr::UNSPECIFIED.into()
+        };
+        SocketAddr::new(unspec, 0)
+    })
+}
+
+pub async fn drain_stream(mut stream: quinn::RecvStream) -> Result<()> {
+    #[rustfmt::skip]
+        let mut bufs = [
+        Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+        Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+        Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+        Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+        Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+        Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+        Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+        Bytes::new(), Bytes::new(), Bytes::new(), Bytes::new(),
+    ];
+    while stream.read_chunks(&mut bufs[..]).await?.is_some() {}
+    debug!("finished reading {}", stream.id());
+    Ok(())
+}
+
+pub async fn lookup_host(host: &str, resolved_host: Option<IpAddr>) -> Result<(&str, SocketAddr)> {
+    let mut host_parts = host.split(':');
+    let host_name = host_parts.next().unwrap();
+    let host_port = host_parts
+        .next()
+        .map_or(Ok(443), |x| x.parse())
+        .context("parsing port")?;
+    let addr = match resolved_host {
+        None => tokio::net::lookup_host(host)
+            .await
+            .context("resolving host")?
+            .next()
+            .unwrap(),
+        Some(ip) => SocketAddr::new(ip, host_port),
+    };
+
+    Ok((host_name, addr))
+}
 
 pub fn bind_socket(
     addr: SocketAddr,
@@ -55,3 +208,25 @@ pub static PERF_CIPHER_SUITES: &[rustls::SupportedCipherSuite] = &[
     rustls::cipher_suite::TLS13_AES_256_GCM_SHA384,
     rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
 ];
+
+struct SkipServerVerification;
+
+impl SkipServerVerification {
+    fn new() -> Arc<Self> {
+        Arc::new(Self)
+    }
+}
+
+impl rustls::client::ServerCertVerifier for SkipServerVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
+        _server_name: &rustls::ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: std::time::SystemTime,
+    ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::ServerCertVerified::assertion())
+    }
+}


### PR DESCRIPTION
This PR adds a `perf_datagram_server` and `perf_datagram_client` to benchmark datagram transmit performance. There are two modes of operation: sending all the data through datagrams, or sending all the data in a single stream. That makes it possible to compare performance between the two. I dedided to add them as separate binaries because they differ too much from the existing `perf_{client, server}`, but I reused the code where possible.

Interestingly, there is a huge discrepancy in performance between datagrams and streams. Somehow the throughput when using datagrams is much lower! Below follows a comparison. I won't have time to investigate the reason of the difference, but as far as I can see the benchmarking code is correct.

### Using datagrams

Server: `cargo run --release --bin perf_datagram_server -- --no-protection`

Client: `cargo run --release --bin perf_datagram_client -- --no-protection`

Output:

```
Transferred 2147484066 bytes in 6670 ms (307.04 MiB/s)
Bytes lost 2561048 (2.44 MiB)
Congestion events: 23
Congestion window: 454043
```

### Using a stream

Server: `cargo run --release --bin perf_datagram_server -- --no-protection --use-stream`

Client: `cargo run --release --bin perf_datagram_client -- --no-protection --use-stream`

Output:

```
Transferred 2147483648 bytes in 1185 ms (1727.60 MiB/s)
Bytes lost 627092 (0.60 MiB)
Congestion events: 7
Congestion window: 4069176
```