### PR TITLE
deps: remove webpki dependency.

### DIFF
--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -22,7 +22,6 @@ rustls-pemfile = "1.0.0"
 serde = { version = "1.0", features = ["derive"], optional = true  }
 serde_json = { version = "1.0", optional = true }
 socket2 = "0.5"
-webpki = "0.22"
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["rt", "macros", "signal", "net", "sync"] }
 tracing = "0.1.10"

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 
 [features]
 default = ["tls-rustls", "log"]
-tls-rustls = ["rustls", "webpki", "ring"]
+tls-rustls = ["rustls", "ring"]
 # Provides `ClientConfig::with_native_roots()` convenience method
 native-certs = ["rustls-native-certs"]
 # Write logs via the `log` crate when no `tracing` subscriber exists
@@ -36,7 +36,6 @@ slab = "0.4"
 thiserror = "1.0.21"
 tinyvec = { version = "1.1", features = ["alloc"] }
 tracing = "0.1.10"
-webpki = { version = "0.22", default-features = false, optional = true }
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-proto"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.63"
 license = "MIT OR Apache-2.0"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn"
-version = "0.10.0"
+version = "0.10.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/quinn-rs/quinn"
 description = "Versatile QUIC transport protocol implementation"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -20,7 +20,7 @@ default = ["native-certs", "tls-rustls", "runtime-tokio", "log"]
 lock_tracking = []
 # Provides `ClientConfig::with_native_roots()` convenience method
 native-certs = ["proto/native-certs"]
-tls-rustls = ["rustls", "webpki", "proto/tls-rustls", "ring"]
+tls-rustls = ["rustls", "proto/tls-rustls", "ring"]
 # Enables `Endpoint::client` and `Endpoint::server` conveniences
 ring = ["proto/ring"]
 runtime-tokio = ["tokio/time", "tokio/rt", "tokio/net"]
@@ -46,7 +46,6 @@ thiserror = "1.0.21"
 tracing = "0.1.10"
 tokio = { version = "1.28.1", features = ["sync"] }
 udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.4", default-features = false }
-webpki = { version = "0.22", default-features = false, optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.22"


### PR DESCRIPTION
This commit updates the existing Quinn sub-crate dependencies to remove the explicit `webpki` v0.22 dependency. It's not used by directly anywhere and can be a transitive dependency through rustls as required.