### PR TITLE
Allow compilation with `--cfg fuzzing` but not `--features=arbitrary`

### DIFF
--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -88,10 +88,12 @@ pub mod fuzzing {
     pub use crate::frame::ResetStream;
     pub use crate::packet::PartialDecode;
     pub use crate::transport_parameters::TransportParameters;
-    use crate::MAX_CID_SIZE;
-    use arbitrary::{Arbitrary, Result, Unstructured};
     pub use bytes::{BufMut, BytesMut};
 
+    #[cfg(feature = "arbitrary")]
+    use arbitrary::{Arbitrary, Result, Unstructured};
+
+    #[cfg(feature = "arbitrary")]
     impl<'arbitrary> Arbitrary<'arbitrary> for TransportParameters {
         fn arbitrary(u: &mut Unstructured<'arbitrary>) -> Result<Self> {
             Ok(Self {
@@ -111,9 +113,10 @@ pub mod fuzzing {
         pub grease_quic_bit: bool,
     }
 
+    #[cfg(feature = "arbitrary")]
     impl<'arbitrary> Arbitrary<'arbitrary> for PacketParams {
         fn arbitrary(u: &mut Unstructured<'arbitrary>) -> Result<Self> {
-            let local_cid_len: usize = u.int_in_range(0..=MAX_CID_SIZE)?;
+            let local_cid_len: usize = u.int_in_range(0..=crate::MAX_CID_SIZE)?;
             let bytes: Vec<u8> = Vec::arbitrary(u)?;
             let mut buf = BytesMut::new();
             buf.put_slice(&bytes[..]);


### PR DESCRIPTION
Right now, if `quinn-proto` is built without `--features=arbitrary`, one gets an error about an unresolved import. The `compile_error` helps to clarify why.

An alternative would be to try and disentangle `--cfg fuzzing` and `--features=arbitrary`. But this change is less invasive.