### PR TITLE
Extend Dependabot configuration to keep GitHub Actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
   schedule:
     interval: weekly
     time: "13:00"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Extend Dependabot configuration to automatically open PRs for outdated actions.

Inspired by @djc's request in <https://github.com/quinn-rs/quinn/pull/1579#pullrequestreview-1456906747>.