### PR TITLE
Added Endpoint::reject_new_connections

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -653,7 +653,12 @@ impl Endpoint {
         }
     }
 
-    /// Rejects new connections without affecting existing connections.
+    /// Reject new incoming connections without affecting existing connections
+    ///
+    /// Convenience short-hand for using
+    /// [`set_server_config`](Self::set_server_config) to update
+    /// [`concurrent_connections`](ServerConfig::concurrent_connections) to
+    /// zero.
     pub fn reject_new_connections(&mut self) {
         if let Some(config) = self.server_config.as_mut() {
             Arc::make_mut(config).concurrent_connections(0);

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -653,6 +653,13 @@ impl Endpoint {
         }
     }
 
+    /// Rejects new connections without affecting existing connections.
+    pub fn reject_new_connections(&mut self) {
+        if let Some(config) = self.server_config.as_mut() {
+            Arc::make_mut(config).concurrent_connections(0);
+        }
+    }
+
     /// Access the configuration used by this endpoint
     pub fn config(&self) -> &EndpointConfig {
         &self.config

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -2193,3 +2193,11 @@ fn stream_chunks(mut recv: RecvStream) -> Vec<u8> {
 
     buf
 }
+
+#[test]
+fn reject_new_connections() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    pair.server.reject_new_connections();
+    pair.assert_connection_refused();
+}

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -2199,5 +2199,10 @@ fn reject_new_connections() {
     let _guard = subscribe();
     let mut pair = Pair::default();
     pair.server.reject_new_connections();
-    pair.assert_connection_refused();
+
+    // The server should now reject incoming connections.
+    let client_ch = pair.begin_connect(client_config());
+    pair.drive();
+    pair.server.assert_no_accept();
+    assert!(pair.client.connections.get(&client_ch).unwrap().is_closed());
 }

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -166,15 +166,6 @@ impl Pair {
         }
     }
 
-    /// Attempts to connect, asserting that the server doesn't accept the
-    /// connection and the client marks the connection as closed.
-    pub(super) fn assert_connection_refused(&mut self) {
-        let client_ch = self.begin_connect(client_config());
-        self.drive();
-        self.server.assert_no_accept();
-        assert!(self.client.connections.get(&client_ch).unwrap().is_closed());
-    }
-
     pub(super) fn connect(&mut self) -> (ConnectionHandle, ConnectionHandle) {
         self.connect_with(client_config())
     }

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -166,6 +166,15 @@ impl Pair {
         }
     }
 
+    /// Attempts to connect, asserting that the server doesn't accept the
+    /// connection and the client marks the connection as closed.
+    pub(super) fn assert_connection_refused(&mut self) {
+        let client_ch = self.begin_connect(client_config());
+        self.drive();
+        self.server.assert_no_accept();
+        assert!(self.client.connections.get(&client_ch).unwrap().is_closed());
+    }
+
     pub(super) fn connect(&mut self) -> (ConnectionHandle, ConnectionHandle) {
         self.connect_with(client_config())
     }

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -236,6 +236,16 @@ impl Endpoint {
         self.inner.state.lock().unwrap().socket.local_addr()
     }
 
+    /// Rejects new connections without affecting existing connections.
+    pub fn reject_new_connections(&self) {
+        self.inner
+            .state
+            .lock()
+            .unwrap()
+            .inner
+            .reject_new_connections();
+    }
+
     /// Close all of this endpoint's connections immediately and cease accepting new connections.
     ///
     /// See [`Connection::close()`] for details.

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -236,7 +236,12 @@ impl Endpoint {
         self.inner.state.lock().unwrap().socket.local_addr()
     }
 
-    /// Rejects new connections without affecting existing connections.
+    /// Reject new incoming connections without affecting existing connections
+    ///
+    /// Convenience short-hand for using
+    /// [`set_server_config`](Self::set_server_config) to update
+    /// [`concurrent_connections`](ServerConfig::concurrent_connections) to
+    /// zero.
     pub fn reject_new_connections(&self) {
         self.inner
             .state


### PR DESCRIPTION
Closes #1584

This commit adds a new function that refuses new connections without impacting existing connections. Internally, this just sets the connection limit to 0, which causes incoming connections to be rejected. This is the same approach that was taken in 0.8.5 when `Incoming` was dropped.

Let me know if I should also add a unit test to the `quinn` crate. Since it's a simple pass-through, I elected not to initially.