### PR TITLE
0.10 backports

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -8,7 +8,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,11 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-llvm-cov
       - run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     name: test on freebsd
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: test on freebsd
         uses: vmactions/freebsd-vm@v0
         with:
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -67,7 +67,7 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -82,7 +82,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -116,5 +116,5 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,64 +45,35 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
       - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all-targets
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-      - uses: actions-rs/cargo@v1
+      - run: cargo build --all-targets
+      - run: cargo test
+      - run: cargo test --manifest-path fuzz/Cargo.toml
         if: ${{ matrix.rust }} == "stable"
-        with:
-          command: test
-          args: --manifest-path fuzz/Cargo.toml
 
   msrv:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.63.0
-          override: true
+      - uses: dtolnay/rust-toolchain@1.63.0
       - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --lib --all-features -p quinn-udp -p quinn-proto -p quinn
+      - run: cargo check --lib --all-features -p quinn-udp -p quinn-proto -p quinn
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets -- -D warnings
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          command: fmt
-          args: --all -- --check
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets -- -D warnings
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: clippy
       - name: doc
         run: cargo doc --no-deps --document-private-items

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -709,6 +709,18 @@ impl Endpoint {
         })
     }
 
+    /// Reject new incoming connections without affecting existing connections
+    ///
+    /// Convenience short-hand for using
+    /// [`set_server_config`](Self::set_server_config) to update
+    /// [`concurrent_connections`](ServerConfig::concurrent_connections) to
+    /// zero.
+    pub fn reject_new_connections(&mut self) {
+        if let Some(config) = self.server_config.as_mut() {
+            Arc::make_mut(config).concurrent_connections(0);
+        }
+    }
+
     /// Access the configuration used by this endpoint
     pub fn config(&self) -> &EndpointConfig {
         &self.config

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -709,13 +709,6 @@ impl Endpoint {
         })
     }
 
-    /// Unconditionally reject future incoming connections
-    pub fn reject_new_connections(&mut self) {
-        if let Some(config) = self.server_config.as_mut() {
-            Arc::make_mut(config).concurrent_connections(0);
-        }
-    }
-
     /// Access the configuration used by this endpoint
     pub fn config(&self) -> &EndpointConfig {
         &self.config

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -2196,3 +2196,16 @@ fn stream_chunks(mut recv: RecvStream) -> Vec<u8> {
 
     buf
 }
+
+#[test]
+fn reject_new_connections() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    pair.server.reject_new_connections();
+
+    // The server should now reject incoming connections.
+    let client_ch = pair.begin_connect(client_config());
+    pair.drive();
+    pair.server.assert_no_accept();
+    assert!(pair.client.connections.get(&client_ch).unwrap().is_closed());
+}

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -157,6 +157,14 @@ impl Connecting {
 
         inner.inner.local_ip()
     }
+
+    /// The peer's UDP address.
+    ///
+    /// Will panic if called after `poll` has returned `Ready`.
+    pub fn remote_address(&self) -> SocketAddr {
+        let conn_ref: &ConnectionRef = self.conn.as_ref().expect("used after yielding Ready");
+        conn_ref.state.lock("remote_address").inner.remote_address()
+    }
 }
 
 impl Future for Connecting {
@@ -175,16 +183,6 @@ impl Future for Connecting {
                     .expect("connected signaled without connection success or error"))
             }
         })
-    }
-}
-
-impl Connecting {
-    /// The peer's UDP address.
-    ///
-    /// Will panic if called after `poll` has returned `Ready`.
-    pub fn remote_address(&self) -> SocketAddr {
-        let conn_ref: &ConnectionRef = self.conn.as_ref().expect("used after yielding Ready");
-        conn_ref.state.lock("remote_address").inner.remote_address()
     }
 }
 

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -236,6 +236,21 @@ impl Endpoint {
         self.inner.state.lock().unwrap().socket.local_addr()
     }
 
+    /// Reject new incoming connections without affecting existing connections
+    ///
+    /// Convenience short-hand for using
+    /// [`set_server_config`](Self::set_server_config) to update
+    /// [`concurrent_connections`](ServerConfig::concurrent_connections) to
+    /// zero.
+    pub fn reject_new_connections(&self) {
+        self.inner
+            .state
+            .lock()
+            .unwrap()
+            .inner
+            .reject_new_connections();
+    }
+
     /// Close all of this endpoint's connections immediately and cease accepting new connections.
     ///
     /// See [`Connection::close()`] for details.

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -144,8 +144,10 @@ impl SendStream {
             .poll(cx)
             .map(|x| x.unwrap())
         {
-            Poll::Ready(None) => Poll::Ready(Ok(())),
-            Poll::Ready(Some(e)) => Poll::Ready(Err(e)),
+            Poll::Ready(x) => {
+                self.finishing = None;
+                Poll::Ready(x.map_or(Ok(()), Err))
+            }
             Poll::Pending => {
                 // To ensure that finished streams can be detected even after the connection is
                 // closed, we must only check for connection errors after determining that the


### PR DESCRIPTION
Started a branch from the 0.10.1 tag and backported:

* #1588
* #1585
* #1581 (only the commit that removed `Endpoint::reject_new_connections()`)
* #1579
* #1571 