### PR TITLE
fix: Make new_with_abstract public again

### DIFF
--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -98,7 +98,7 @@ impl Endpoint {
     ///
     /// Useful when `socket` has additional state (e.g. sidechannels) attached for which shared
     /// ownership is needed.
-    fn new_with_abstract_socket(
+    pub fn new_with_abstract_socket(
         config: EndpointConfig,
         server_config: Option<ServerConfig>,
         socket: Box<dyn AsyncUdpSocket>,


### PR DESCRIPTION
In my previous [MR](https://github.com/quinn-rs/quinn/pull/1534/files) I accidentally made the constructor private. This MR fixes this.