### PR TITLE
Replace `.rev().next()` with `.next_back()`

### DIFF
--- a/quinn-proto/src/range_set/array_range_set.rs
+++ b/quinn-proto/src/range_set/array_range_set.rs
@@ -204,6 +204,6 @@ impl ArrayRangeSet {
     }
 
     pub fn max(&self) -> Option<u64> {
-        self.iter().rev().next().map(|x| x.end - 1)
+        self.iter().next_back().map(|x| x.end - 1)
     }
 }

--- a/quinn-proto/src/range_set/btree_range_set.rs
+++ b/quinn-proto/src/range_set/btree_range_set.rs
@@ -85,8 +85,7 @@ impl RangeSet {
     fn pred(&self, x: u64) -> Option<(u64, u64)> {
         self.0
             .range((Included(0), Included(x)))
-            .rev()
-            .next()
+            .next_back()
             .map(|(&x, &y)| (x, y))
     }
 
@@ -181,7 +180,7 @@ impl RangeSet {
         self.iter().next().map(|x| x.start)
     }
     pub fn max(&self) -> Option<u64> {
-        self.iter().rev().next().map(|x| x.end - 1)
+        self.iter().next_back().map(|x| x.end - 1)
     }
 
     pub fn len(&self) -> usize {


### PR DESCRIPTION
Cherry pick lint fixes from main to 0.10.x