### PR TITLE
Fold UdpState into AsyncUdpSocket

### DIFF
--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.63"
 license = "MIT OR Apache-2.0"

--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -90,6 +90,16 @@ impl UdpSocketState {
         };
         Ok(1)
     }
+
+    #[inline]
+    pub fn max_gso_segments(&self) -> usize {
+        1
+    }
+
+    #[inline]
+    pub fn gro_segments(&self) -> usize {
+        1
+    }
 }
 
 impl Default for UdpSocketState {

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -6,14 +6,9 @@
 use std::os::unix::io::AsFd;
 #[cfg(windows)]
 use std::os::windows::io::AsSocket;
-#[cfg(not(windows))]
-use std::sync::atomic::AtomicBool;
 use std::{
     net::{IpAddr, Ipv6Addr, SocketAddr},
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Mutex,
-    },
+    sync::Mutex,
     time::{Duration, Instant},
 };
 
@@ -47,66 +42,6 @@ pub fn may_fragment() -> bool {
 
 /// Number of UDP packets to send/receive at a time
 pub const BATCH_SIZE: usize = imp::BATCH_SIZE;
-
-/// The capabilities a UDP socket supports on a certain platform
-#[derive(Debug)]
-pub struct UdpState {
-    max_gso_segments: AtomicUsize,
-    gro_segments: usize,
-
-    /// True if we have received EINVAL error from `sendmsg` or `sendmmsg` system call at least once.
-    ///
-    /// If enabled, we assume that old kernel is used and switch to fallback mode.
-    /// In particular, we do not use IP_TOS cmsg_type in this case,
-    /// which is not supported on Linux <3.13 and results in not sending the UDP packet at all.
-    #[cfg(not(windows))]
-    sendmsg_einval: AtomicBool,
-}
-
-impl UdpState {
-    pub fn new() -> Self {
-        imp::udp_state()
-    }
-
-    /// The maximum amount of segments which can be transmitted if a platform
-    /// supports Generic Send Offload (GSO).
-    ///
-    /// This is 1 if the platform doesn't support GSO. Subject to change if errors are detected
-    /// while using GSO.
-    #[inline]
-    pub fn max_gso_segments(&self) -> usize {
-        self.max_gso_segments.load(Ordering::Relaxed)
-    }
-
-    /// The number of segments to read when GRO is enabled. Used as a factor to
-    /// compute the receive buffer size.
-    ///
-    /// Returns 1 if the platform doesn't support GRO.
-    #[inline]
-    pub fn gro_segments(&self) -> usize {
-        self.gro_segments
-    }
-
-    /// Returns true if we previously got an EINVAL error from `sendmsg` or `sendmmsg` syscall.
-    #[inline]
-    #[cfg(not(windows))]
-    fn sendmsg_einval(&self) -> bool {
-        self.sendmsg_einval.load(Ordering::Relaxed)
-    }
-
-    /// Sets the flag indicating we got EINVAL error from `sendmsg` or `sendmmsg` syscall.
-    #[inline]
-    #[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
-    fn set_sendmsg_einval(&self) {
-        self.sendmsg_einval.store(true, Ordering::Relaxed)
-    }
-}
-
-impl Default for UdpState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 #[derive(Debug, Copy, Clone)]
 pub struct RecvMeta {

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -45,7 +45,7 @@ rustls = { version = "0.21.0", default-features = false, features = ["quic"], op
 thiserror = "1.0.21"
 tracing = "0.1.10"
 tokio = { version = "1.28.1", features = ["sync"] }
-udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.4", default-features = false }
+udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.5", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.22"


### PR DESCRIPTION
Allows knowledge of UdpState to be isolated entirely within AsyncUdpSocket implementations, simplifying quinn::Endpoint and the poll_send API, and exposing more control over UDP feature checks to implementers.

Fixes #1609.