### PR TITLE
set may_fragment based on whether setting IP_DONTFRAG fails with ENOPROTOOPT.

### DIFF
--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -32,14 +32,6 @@ mod imp;
 
 pub use imp::UdpSocketState;
 
-/// Whether transmitted datagrams might get fragmented by the IP layer
-///
-/// Returns `false` on targets which employ e.g. the `IPV6_DONTFRAG` socket option.
-#[inline]
-pub fn may_fragment() -> bool {
-    imp::may_fragment()
-}
-
 /// Number of UDP packets to send/receive at a time
 pub const BATCH_SIZE: usize = imp::BATCH_SIZE;
 

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -32,6 +32,7 @@ pub struct UdpSocketState {
     last_send_error: Mutex<Instant>,
     max_gso_segments: AtomicUsize,
     gro_segments: usize,
+    may_fragment: bool,
 
     /// True if we have received EINVAL error from `sendmsg` or `sendmmsg` system call at least once.
     ///
@@ -74,34 +75,39 @@ impl UdpSocketState {
             }
         }
 
+        let mut may_fragment = false;
         #[cfg(target_os = "linux")]
         {
             // opportunistically try to enable GRO. See gro::gro_segments().
             let _ = set_socket_option(&*io, libc::SOL_UDP, libc::UDP_GRO, OPTION_ON);
 
             // Forbid IPv4 fragmentation. Set even for IPv6 to account for IPv6 mapped IPv4 addresses.
-            set_socket_option(
+            let result = set_socket_option(
                 &*io,
                 libc::IPPROTO_IP,
                 libc::IP_MTU_DISCOVER,
                 libc::IP_PMTUDISC_PROBE,
-            )?;
+            );
+            may_fragment = is_result_noprotoopt_err(result) || may_fragment;
 
             if is_ipv4 {
                 set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_PKTINFO, OPTION_ON)?;
             } else {
-                set_socket_option(
+                let result = set_socket_option(
                     &*io,
                     libc::IPPROTO_IPV6,
                     libc::IPV6_MTU_DISCOVER,
                     libc::IP_PMTUDISC_PROBE,
-                )?;
+                );
+                may_fragment = is_result_noprotoopt_err(result) || may_fragment;
             }
         }
         #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "ios"))]
         {
             if is_ipv4 {
-                set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_DONTFRAG, OPTION_ON)?;
+                let result =
+                    set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_DONTFRAG, OPTION_ON);
+                may_fragment = is_result_noprotoopt_err(result) || may_fragment;
             }
         }
         #[cfg(any(target_os = "freebsd", target_os = "macos"))]
@@ -121,7 +127,9 @@ impl UdpSocketState {
             // Linux's IP_PMTUDISC_PROBE allows us to operate under interface MTU rather than the
             // kernel's path MTU guess, but actually disabling fragmentation requires this too. See
             // __ip6_append_data in ip6_output.c.
-            set_socket_option(&*io, libc::IPPROTO_IPV6, libc::IPV6_DONTFRAG, OPTION_ON)?;
+            let result =
+                set_socket_option(&*io, libc::IPPROTO_IPV6, libc::IPV6_DONTFRAG, OPTION_ON);
+            may_fragment = is_result_noprotoopt_err(result) || may_fragment;
         }
 
         let now = Instant::now();
@@ -129,6 +137,7 @@ impl UdpSocketState {
             last_send_error: Mutex::new(now.checked_sub(2 * IO_ERROR_LOG_INTERVAL).unwrap_or(now)),
             max_gso_segments: AtomicUsize::new(gso::max_gso_segments()),
             gro_segments: gro::gro_segments(),
+            may_fragment,
             sendmsg_einval: AtomicBool::new(false),
         })
     }
@@ -170,7 +179,7 @@ impl UdpSocketState {
     /// Returns `false` on targets which employ e.g. the `IPV6_DONTFRAG` socket option.
     #[inline]
     pub fn may_fragment(&self) -> bool {
-        false
+        self.may_fragment
     }
 
     /// Returns true if we previously got an EINVAL error from `sendmsg` or `sendmmsg` syscall.
@@ -808,6 +817,17 @@ fn set_socket_option(
     match rc == 0 {
         true => Ok(()),
         false => Err(io::Error::last_os_error()),
+    }
+}
+
+#[inline]
+fn is_result_noprotoopt_err(result: Result<(), io::Error>) -> bool {
+    match result {
+        Err(error) => match error.raw_os_error() {
+            Some(raw_os_error) => raw_os_error == libc::ENOPROTOOPT,
+            None => false,
+        },
+        Ok(_) => false,
     }
 }
 

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -165,6 +165,14 @@ impl UdpSocketState {
         self.gro_segments
     }
 
+    /// Whether transmitted datagrams might get fragmented by the IP layer
+    ///
+    /// Returns `false` on targets which employ e.g. the `IPV6_DONTFRAG` socket option.
+    #[inline]
+    pub fn may_fragment(&self) -> bool {
+        false
+    }
+
     /// Returns true if we previously got an EINVAL error from `sendmsg` or `sendmmsg` syscall.
     fn sendmsg_einval(&self) -> bool {
         self.sendmsg_einval.load(Ordering::Relaxed)
@@ -712,11 +720,6 @@ pub(crate) const BATCH_SIZE: usize = 32;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 pub(crate) const BATCH_SIZE: usize = 1;
-
-#[inline]
-pub(crate) fn may_fragment() -> bool {
-    false
-}
 
 #[cfg(target_os = "linux")]
 mod gso {

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -147,11 +147,11 @@ impl UdpSocketState {
     pub fn gro_segments(&self) -> usize {
         1
     }
+
+    #[inline]
+    pub fn may_fragment(&self) -> bool {
+        false
+    }
 }
 
 pub(crate) const BATCH_SIZE: usize = 1;
-
-#[inline]
-pub(crate) fn may_fragment() -> bool {
-    false
-}

--- a/quinn/src/runtime/async_std.rs
+++ b/quinn/src/runtime/async_std.rs
@@ -77,7 +77,7 @@ impl AsyncUdpSocket for UdpSocket {
     }
 
     fn may_fragment(&self) -> bool {
-        udp::may_fragment()
+        self.inner.may_fragment()
     }
 
     fn max_transmit_segments(&self) -> usize {

--- a/quinn/src/runtime/tokio.rs
+++ b/quinn/src/runtime/tokio.rs
@@ -83,7 +83,7 @@ impl AsyncUdpSocket for UdpSocket {
     }
 
     fn may_fragment(&self) -> bool {
-        udp::may_fragment()
+        self.inner.may_fragment()
     }
 
     fn max_transmit_segments(&self) -> usize {


### PR DESCRIPTION
[fix issue](https://github.com/quinn-rs/quinn/issues/1624)