### PR TITLE
Require explicit timestamp for Endpoint::connect(), Rust 1.72

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["quinn", "quinn-proto", "quinn-udp", "bench", "perf", "fuzz"]
 default-members = ["quinn", "quinn-proto", "quinn-udp", "bench", "perf"]
+resolver = "2"
 
 [profile.bench]
 debug = true

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -312,6 +312,7 @@ impl Endpoint {
     /// Initiate a connection
     pub fn connect(
         &mut self,
+        now: Instant,
         config: ClientConfig,
         remote: SocketAddr,
         server_name: &str,
@@ -352,7 +353,7 @@ impl Endpoint {
                 remote,
                 local_ip: None,
             },
-            Instant::now(),
+            now,
             tls,
             None,
             config.transport,

--- a/quinn-proto/src/range_set/btree_range_set.rs
+++ b/quinn-proto/src/range_set/btree_range_set.rs
@@ -321,6 +321,7 @@ impl Drop for Replace<'_> {
 /// Tests which apply for all implementations can be found in the `tests.rs` module
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::single_range_in_vec_init)] // https://github.com/rust-lang/rust-clippy/issues/11086
     use super::*;
 
     #[test]

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -37,7 +37,9 @@ fn version_negotiate_server() {
         // Long-header packet with reserved version number
         hex!("80 0a1a2a3a 04 00000000 04 00000000 00")[..].into(),
     );
-    let Some(DatagramEvent::Response(Transmit { contents, .. })) = event else { panic!("expected a response"); };
+    let Some(DatagramEvent::Response(Transmit { contents, .. })) = event else {
+        panic!("expected a response");
+    };
 
     assert_ne!(contents[0] & 0x80, 0);
     assert_eq!(&contents[1..15], hex!("00000000 04 00000000 04 00000000"));

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -65,7 +65,7 @@ fn version_negotiate_client() {
         true,
     );
     let (_, mut client_ch) = client
-        .connect(client_config(), server_addr, "localhost")
+        .connect(Instant::now(), client_config(), server_addr, "localhost")
         .unwrap();
     let now = Instant::now();
     let opt_event = client.handle(

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -201,7 +201,7 @@ impl Pair {
         let _guard = span.enter();
         let (client_ch, client_conn) = self
             .client
-            .connect(config, self.server.addr, "localhost")
+            .connect(Instant::now(), config, self.server.addr, "localhost")
             .unwrap();
         self.client.connections.insert(client_ch, client_conn);
         client_ch

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -186,7 +186,11 @@ impl Endpoint {
         } else {
             addr
         };
-        let (ch, conn) = endpoint.inner.connect(config, addr, server_name)?;
+
+        let (ch, conn) = endpoint
+            .inner
+            .connect(Instant::now(), config, addr, server_name)?;
+
         let socket = endpoint.socket.clone();
         Ok(endpoint
             .connections


### PR DESCRIPTION
Fixes #1648 and cleans up new warnings from Rust 1.72.