### PR TITLE
Communicate endpoint events in -proto w/ an intrusive queue

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.63.0
+      - uses: dtolnay/rust-toolchain@1.67.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --lib --all-features -p quinn-udp -p quinn-proto -p quinn
 

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bench"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "perf"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quinn-proto"
 version = "0.11.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/quinn-rs/quinn"
 description = "State machine for the QUIC transport protocol"

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -4,7 +4,7 @@ use std::{
     convert::TryFrom,
     fmt, io, mem,
     net::{IpAddr, SocketAddr},
-    sync::Arc,
+    sync::{atomic::Ordering, Arc},
     time::{Duration, Instant},
 };
 
@@ -24,10 +24,7 @@ use crate::{
     frame::{Close, Datagram, FrameStruct},
     packet::{Header, LongType, Packet, PartialDecode, SpaceId},
     range_set::ArrayRangeSet,
-    shared::{
-        ConnectionEvent, ConnectionEventInner, ConnectionId, EcnCodepoint, EndpointEvent,
-        EndpointEventInner,
-    },
+    shared::{ConnectionEvent, ConnectionEventInner, ConnectionId, EcnCodepoint, EndpointEvents},
     token::ResetToken,
     transport_parameters::TransportParameters,
     Dir, EndpointConfig, Frame, Side, StreamId, Transmit, TransportError, TransportErrorCode,
@@ -89,10 +86,10 @@ use timer::{Timer, TimerTable};
 
 /// Protocol state and logic for a single QUIC connection
 ///
-/// Objects of this type receive [`ConnectionEvent`]s and emit [`EndpointEvent`]s and application
-/// [`Event`]s to make progress. To handle timeouts, a `Connection` returns timer updates and
-/// expects timeouts through various methods. A number of simple getter methods are exposed
-/// to allow callers to inspect some of the connection state.
+/// Objects of this type receive [`ConnectionEvent`]s and emit application [`Event`]s to make
+/// progress. To handle timeouts, a `Connection` returns timer updates and expects timeouts through
+/// various methods. A number of simple getter methods are exposed to allow callers to inspect some
+/// of the connection state.
 ///
 /// `Connection` has roughly 4 types of methods:
 ///
@@ -130,6 +127,7 @@ pub struct Connection {
     endpoint_config: Arc<EndpointConfig>,
     server_config: Option<Arc<ServerConfig>>,
     config: Arc<TransportConfig>,
+    endpoint_events: Arc<EndpointEvents>,
     rng: StdRng,
     crypto: Box<dyn crypto::Session>,
     /// The CID we initially chose, for use during the handshake
@@ -162,7 +160,6 @@ pub struct Connection {
     /// Total number of outgoing packets that have been deemed lost
     lost_packets: u64,
     events: VecDeque<Event>,
-    endpoint_events: VecDeque<EndpointEventInner>,
     /// Whether the spin bit is in use for this connection
     spin_enabled: bool,
     /// Outgoing spin bit state
@@ -242,6 +239,7 @@ impl Connection {
         endpoint_config: Arc<EndpointConfig>,
         server_config: Option<Arc<ServerConfig>>,
         config: Arc<TransportConfig>,
+        endpoint_events: Arc<EndpointEvents>,
         init_cid: ConnectionId,
         loc_cid: ConnectionId,
         rem_cid: ConnectionId,
@@ -272,6 +270,7 @@ impl Connection {
         let mut this = Self {
             endpoint_config,
             server_config,
+            endpoint_events,
             crypto,
             handshake_cid: loc_cid,
             rem_handshake_cid: rem_cid,
@@ -313,7 +312,6 @@ impl Connection {
             retry_src_cid: None,
             lost_packets: 0,
             events: VecDeque::new(),
-            endpoint_events: VecDeque::new(),
             spin_enabled: config.allow_spin && rng.gen_ratio(7, 8),
             spin: false,
             spaces: [initial_space, PacketSpace::new(now), PacketSpace::new(now)],
@@ -404,12 +402,6 @@ impl Connection {
         }
 
         None
-    }
-
-    /// Return endpoint-facing events
-    #[must_use]
-    pub fn poll_endpoint_events(&mut self) -> Option<EndpointEvent> {
-        self.endpoint_events.pop_front().map(EndpointEvent)
     }
 
     /// Provide control over streams
@@ -1017,13 +1009,7 @@ impl Connection {
                     self.spaces[SpaceId::Data].pending.new_cids.push(frame);
                 });
                 // Update Timer::PushNewCid
-                if self
-                    .timers
-                    .get(Timer::PushNewCid)
-                    .map_or(true, |x| x <= now)
-                {
-                    self.reset_cid_retirement();
-                }
+                self.reset_cid_retirement();
             }
         }
     }
@@ -1047,7 +1033,7 @@ impl Connection {
             match timer {
                 Timer::Close => {
                     self.state = State::Drained;
-                    self.endpoint_events.push_back(EndpointEventInner::Drained);
+                    self.endpoint_events.drained.store(true, Ordering::Relaxed);
                 }
                 Timer::Idle => {
                     self.kill(ConnectionError::TimedOut);
@@ -1081,7 +1067,8 @@ impl Connection {
                             self.local_cid_state.retire_prior_to()
                         );
                         self.endpoint_events
-                            .push_back(EndpointEventInner::NeedIdentifiers(num_new_cid));
+                            .need_identifiers
+                            .fetch_add(num_new_cid, Ordering::Relaxed);
                     }
                 }
                 Timer::MaxAckDelay => {
@@ -2199,7 +2186,7 @@ impl Connection {
             }
         }
         if !was_drained && self.state.is_drained() {
-            self.endpoint_events.push_back(EndpointEventInner::Drained);
+            self.endpoint_events.drained.store(true, Ordering::Relaxed);
             // Close timer may have been started previously, e.g. if we sent a close and got a
             // stateless reset in response
             self.timers.stop(Timer::Close);
@@ -2375,8 +2362,8 @@ impl Connection {
                         }
                     }
                     if let Some(token) = params.stateless_reset_token {
-                        self.endpoint_events
-                            .push_back(EndpointEventInner::ResetToken(self.path.remote, token));
+                        *self.endpoint_events.reset_token.lock().unwrap() =
+                            Some((self.path.remote, token));
                     }
                     self.handle_peer_params(params)?;
                     self.issue_first_cids();
@@ -2693,11 +2680,16 @@ impl Connection {
                     let allow_more_cids = self
                         .local_cid_state
                         .on_cid_retirement(sequence, self.peer_params.issue_cids_limit())?;
+                    if allow_more_cids {
+                        self.endpoint_events
+                            .need_identifiers
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
                     self.endpoint_events
-                        .push_back(EndpointEventInner::RetireConnectionId(
-                            sequence,
-                            allow_more_cids,
-                        ));
+                        .retire_cids
+                        .lock()
+                        .unwrap()
+                        .push(sequence);
                 }
                 Frame::NewConnectionId(frame) => {
                     trace!(
@@ -2912,11 +2904,7 @@ impl Connection {
     }
 
     fn set_reset_token(&mut self, reset_token: ResetToken) {
-        self.endpoint_events
-            .push_back(EndpointEventInner::ResetToken(
-                self.path.remote,
-                reset_token,
-            ));
+        *self.endpoint_events.reset_token.lock().unwrap() = Some((self.path.remote, reset_token));
         self.peer_params.stateless_reset_token = Some(reset_token);
     }
 
@@ -2929,7 +2917,8 @@ impl Connection {
         // Subtract 1 to account for the CID we supplied while handshaking
         let n = self.peer_params.issue_cids_limit() - 1;
         self.endpoint_events
-            .push_back(EndpointEventInner::NeedIdentifiers(n));
+            .need_identifiers
+            .fetch_add(n, Ordering::Relaxed);
     }
 
     fn populate_packet(
@@ -3409,7 +3398,8 @@ impl Connection {
     pub(crate) fn rotate_local_cid(&mut self, v: u64) {
         let n = self.local_cid_state.assign_retire_seq(v);
         self.endpoint_events
-            .push_back(EndpointEventInner::NeedIdentifiers(n));
+            .need_identifiers
+            .fetch_add(n, Ordering::Relaxed);
     }
 
     /// Check the current active remote CID sequence
@@ -3450,7 +3440,7 @@ impl Connection {
         self.close_common();
         self.error = Some(reason);
         self.state = State::Drained;
-        self.endpoint_events.push_back(EndpointEventInner::Drained);
+        self.endpoint_events.drained.store(true, Ordering::Relaxed);
     }
 }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -966,7 +966,7 @@ impl Connection {
     /// Will execute protocol logic upon receipt of a connection event, in turn preparing signals
     /// (including application `Event`s, `EndpointEvent`s and outgoing datagrams) that should be
     /// extracted through the relevant methods.
-    pub fn handle_event(&mut self, event: ConnectionEvent) {
+    pub fn handle_event(&mut self, event: ConnectionEvent, now: Instant) {
         use self::ConnectionEventInner::*;
         match event.0 {
             Datagram {
@@ -1011,7 +1011,7 @@ impl Connection {
                     self.set_loss_detection_timer(now);
                 }
             }
-            NewIdentifiers(ids, now) => {
+            NewIdentifiers(ids) => {
                 self.local_cid_state.new_cids(&ids, now);
                 ids.into_iter().rev().for_each(|frame| {
                     self.spaces[SpaceId::Data].pending.new_cids.push(frame);
@@ -1081,7 +1081,7 @@ impl Connection {
                             self.local_cid_state.retire_prior_to()
                         );
                         self.endpoint_events
-                            .push_back(EndpointEventInner::NeedIdentifiers(now, num_new_cid));
+                            .push_back(EndpointEventInner::NeedIdentifiers(num_new_cid));
                     }
                 }
                 Timer::MaxAckDelay => {
@@ -2379,7 +2379,7 @@ impl Connection {
                             .push_back(EndpointEventInner::ResetToken(self.path.remote, token));
                     }
                     self.handle_peer_params(params)?;
-                    self.issue_first_cids(now);
+                    self.issue_first_cids();
                 } else {
                     // Server-only
                     self.spaces[SpaceId::Data].pending.handshake_done = true;
@@ -2426,7 +2426,7 @@ impl Connection {
                                 reason: "transport parameters missing".into(),
                             })?;
                     self.handle_peer_params(params)?;
-                    self.issue_first_cids(now);
+                    self.issue_first_cids();
                     self.init_0rtt();
                 }
                 Ok(())
@@ -2695,7 +2695,6 @@ impl Connection {
                         .on_cid_retirement(sequence, self.peer_params.issue_cids_limit())?;
                     self.endpoint_events
                         .push_back(EndpointEventInner::RetireConnectionId(
-                            now,
                             sequence,
                             allow_more_cids,
                         ));
@@ -2922,7 +2921,7 @@ impl Connection {
     }
 
     /// Issue an initial set of connection IDs to the peer upon connection
-    fn issue_first_cids(&mut self, now: Instant) {
+    fn issue_first_cids(&mut self) {
         if self.local_cid_state.cid_len() == 0 {
             return;
         }
@@ -2930,7 +2929,7 @@ impl Connection {
         // Subtract 1 to account for the CID we supplied while handshaking
         let n = self.peer_params.issue_cids_limit() - 1;
         self.endpoint_events
-            .push_back(EndpointEventInner::NeedIdentifiers(now, n));
+            .push_back(EndpointEventInner::NeedIdentifiers(n));
     }
 
     fn populate_packet(
@@ -3407,10 +3406,10 @@ impl Connection {
     /// Instruct the peer to replace previously issued CIDs by sending a NEW_CONNECTION_ID frame
     /// with updated `retire_prior_to` field set to `v`
     #[cfg(test)]
-    pub(crate) fn rotate_local_cid(&mut self, v: u64, now: Instant) {
+    pub(crate) fn rotate_local_cid(&mut self, v: u64) {
         let n = self.local_cid_state.assign_retire_seq(v);
         self.endpoint_events
-            .push_back(EndpointEventInner::NeedIdentifiers(now, n));
+            .push_back(EndpointEventInner::NeedIdentifiers(n));
     }
 
     /// Check the current active remote CID sequence

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -84,8 +84,8 @@ impl Endpoint {
     ) -> Option<ConnectionEvent> {
         use EndpointEventInner::*;
         match event.0 {
-            NeedIdentifiers(now, n) => {
-                return Some(self.send_new_identifiers(now, ch, n));
+            NeedIdentifiers(n) => {
+                return Some(self.send_new_identifiers(ch, n));
             }
             ResetToken(remote, token) => {
                 if let Some(old) = self.connections[ch].reset_token.replace((remote, token)) {
@@ -95,12 +95,12 @@ impl Endpoint {
                     warn!("duplicate reset token");
                 }
             }
-            RetireConnectionId(now, seq, allow_more_cids) => {
+            RetireConnectionId(seq, allow_more_cids) => {
                 if let Some(cid) = self.connections[ch].loc_cids.remove(&seq) {
                     trace!("peer retired CID {}: {}", seq, cid);
                     self.index.retire(&cid);
                     if allow_more_cids {
-                        return Some(self.send_new_identifiers(now, ch, 1));
+                        return Some(self.send_new_identifiers(ch, 1));
                     }
                 }
             }
@@ -360,12 +360,7 @@ impl Endpoint {
         Ok((ch, conn))
     }
 
-    fn send_new_identifiers(
-        &mut self,
-        now: Instant,
-        ch: ConnectionHandle,
-        num: u64,
-    ) -> ConnectionEvent {
+    fn send_new_identifiers(&mut self, ch: ConnectionHandle, num: u64) -> ConnectionEvent {
         let mut ids = vec![];
         for _ in 0..num {
             let id = self.new_cid(ch);
@@ -379,7 +374,7 @@ impl Endpoint {
                 reset_token: ResetToken::new(&*self.config.reset_key, &id),
             });
         }
-        ConnectionEvent(ConnectionEventInner::NewIdentifiers(ids, now))
+        ConnectionEvent(ConnectionEventInner::NewIdentifiers(ids))
     }
 
     /// Generate a connection ID for `ch`

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -67,6 +67,9 @@ pub use crate::endpoint::{ConnectError, ConnectionHandle, DatagramEvent, Endpoin
 mod shared;
 pub use crate::shared::{ConnectionEvent, ConnectionId, EcnCodepoint};
 
+mod shared_list;
+use crate::shared_list::SharedList;
+
 mod transport_error;
 pub use crate::transport_error::{Code as TransportErrorCode, Error as TransportError};
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -65,7 +65,7 @@ mod endpoint;
 pub use crate::endpoint::{ConnectError, ConnectionHandle, DatagramEvent, Endpoint};
 
 mod shared;
-pub use crate::shared::{ConnectionEvent, ConnectionId, EcnCodepoint, EndpointEvent};
+pub use crate::shared::{ConnectionEvent, ConnectionId, EcnCodepoint};
 
 mod transport_error;
 pub use crate::transport_error::{Code as TransportErrorCode, Error as TransportError};

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -1,4 +1,12 @@
-use std::{fmt, net::SocketAddr, time::Instant};
+use std::{
+    fmt,
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicBool, AtomicU64},
+        Mutex,
+    },
+    time::Instant,
+};
 
 use bytes::{Buf, BufMut, BytesMut};
 
@@ -22,38 +30,12 @@ pub(crate) enum ConnectionEventInner {
     NewIdentifiers(Vec<IssuedCid>),
 }
 
-/// Events sent from a Connection to an Endpoint
-#[derive(Debug)]
-pub struct EndpointEvent(pub(crate) EndpointEventInner);
-
-impl EndpointEvent {
-    /// Construct an event that indicating that a `Connection` will no longer emit events
-    ///
-    /// Useful for notifying an `Endpoint` that a `Connection` has been destroyed outside of the
-    /// usual state machine flow, e.g. when being dropped by the user.
-    pub fn drained() -> Self {
-        Self(EndpointEventInner::Drained)
-    }
-
-    /// Determine whether this is the last event a `Connection` will emit
-    ///
-    /// Useful for determining when connection-related event loop state can be freed.
-    pub fn is_drained(&self) -> bool {
-        self.0 == EndpointEventInner::Drained
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum EndpointEventInner {
-    /// The connection has been drained
-    Drained,
-    /// The reset token and/or address eligible for generating resets has been updated
-    ResetToken(SocketAddr, ResetToken),
-    /// The connection needs connection identifiers
-    NeedIdentifiers(u64),
-    /// Stop routing connection ID for this sequence number to the connection
-    /// When `bool == true`, a new connection ID will be issued to peer
-    RetireConnectionId(u64, bool),
+#[derive(Debug, Default)]
+pub(crate) struct EndpointEvents {
+    pub(crate) need_identifiers: AtomicU64,
+    pub(crate) reset_token: Mutex<Option<(SocketAddr, ResetToken)>>,
+    pub(crate) retire_cids: Mutex<Vec<u64>>,
+    pub(crate) drained: AtomicBool,
 }
 
 /// Protocol-level identifier for a connection.

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -19,7 +19,7 @@ pub(crate) enum ConnectionEventInner {
         remaining: Option<BytesMut>,
     },
     /// New connection identifiers have been issued for the Connection
-    NewIdentifiers(Vec<IssuedCid>, Instant),
+    NewIdentifiers(Vec<IssuedCid>),
 }
 
 /// Events sent from a Connection to an Endpoint
@@ -50,10 +50,10 @@ pub(crate) enum EndpointEventInner {
     /// The reset token and/or address eligible for generating resets has been updated
     ResetToken(SocketAddr, ResetToken),
     /// The connection needs connection identifiers
-    NeedIdentifiers(Instant, u64),
+    NeedIdentifiers(u64),
     /// Stop routing connection ID for this sequence number to the connection
     /// When `bool == true`, a new connection ID will be issued to peer
-    RetireConnectionId(Instant, u64, bool),
+    RetireConnectionId(u64, bool),
 }
 
 /// Protocol-level identifier for a connection.

--- a/quinn-proto/src/shared_list.rs
+++ b/quinn-proto/src/shared_list.rs
@@ -1,0 +1,248 @@
+use std::{
+    marker::PhantomData,
+    ptr,
+    sync::{
+        atomic::{AtomicBool, AtomicPtr, Ordering},
+        Arc,
+    },
+};
+
+/// A thread-safe intrusive list of `Arc<T>`s singly linked via `Getter`
+///
+/// An `Arc<T>` may participate in any static number of lists by having that many distinct [`Link`]
+/// fields. The `Getter` helper defines a single `get` method which selects the field associated
+/// with a certain list.
+pub(crate) struct SharedList<T, Getter>
+where
+    Getter: LinkGetter<T>,
+{
+    head: AtomicPtr<T>,
+    _marker: PhantomData<Getter>,
+}
+
+impl<T, Getter> SharedList<T, Getter>
+where
+    Getter: LinkGetter<T>,
+{
+    /// Ensure an entry is in the list
+    ///
+    /// Does nothing if `entry` was already in the list or one of its `Drain` iterators. Otherwise,
+    /// adds it to the front of the list.
+    ///
+    /// Returns whether the list was previously empty, in which case a consumer might need to be
+    /// notified to see the new entry.
+    pub(crate) fn push(&self, entry: Arc<T>) -> bool {
+        // `Acquire` synchronizes with the `Release` in `Drain::next` to ensure we don't clobber a
+        // `next` pointer that the iterator is still going to read.
+        if Getter::get(&*entry).linked.swap(true, Ordering::Acquire) {
+            // Already linked
+            return false;
+        }
+        let entry = Arc::into_raw(entry);
+        // `Release` ordering ensures the write to `next` is (and any preceding writes to the `T` in
+        // `entry` are) visible to anyone who `Acquire`s from `self.head`
+        let prev = self
+            .head
+            .fetch_update(Ordering::Release, Ordering::Relaxed, |head| {
+                // Safety: `entry` is trivially still valid here
+                Getter::get(unsafe { &*entry })
+                    .next
+                    .store(head, Ordering::Relaxed);
+                Some(entry.cast_mut())
+            })
+            // Lambda always returns `Some`
+            .unwrap();
+        prev.is_null()
+    }
+
+    /// Consume all entries in the queue
+    pub(crate) fn drain(&self) -> Drain<T, Getter> {
+        // `Acquire` ordering ensures visibility of the `next` pointers thanks to the `Release` in
+        // `push`.
+        let head = self.head.swap(ptr::null_mut(), Ordering::Acquire);
+        Drain {
+            // Safety: above swap means we uniquely own the underlying reference
+            next: (!head.is_null()).then(|| unsafe { Arc::from_raw(head) }),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T, Getter> Drop for SharedList<T, Getter>
+where
+    Getter: LinkGetter<T>,
+{
+    fn drop(&mut self) {
+        self.drain();
+    }
+}
+
+impl<T, Getter> Default for SharedList<T, Getter>
+where
+    Getter: LinkGetter<T>,
+{
+    fn default() -> Self {
+        Self {
+            head: AtomicPtr::new(ptr::null_mut()),
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Trait of helper ZSTs that select which intrusive list for a given `T` to traverse
+pub(crate) trait LinkGetter<T>: Sized + 'static {
+    fn get(x: &T) -> &Link<T>;
+}
+
+/// A link in a [`SharedList`]
+///
+/// Each `Link<T>` field in a `T` allows an `Arc<T>` to participate in a distinct list.
+#[derive(Debug)]
+pub(crate) struct Link<T> {
+    next: AtomicPtr<T>,
+    /// Whether the link is participating in a list
+    ///
+    /// `true` when reachable through [`Drain::next`] on any existing [`Drain`] iterator, or on one
+    /// newly constructed via [`SharedList::drain`].
+    ///
+    /// This can be `true` when `next` is null when this is the last item in a list.
+    linked: AtomicBool,
+}
+
+impl<T> Default for Link<T> {
+    fn default() -> Self {
+        Self {
+            next: AtomicPtr::new(ptr::null_mut()),
+            linked: AtomicBool::new(false),
+        }
+    }
+}
+
+pub(crate) struct Drain<T, Getter>
+where
+    Getter: LinkGetter<T>,
+{
+    next: Option<Arc<T>>,
+    _marker: PhantomData<Getter>,
+}
+
+impl<T, Getter> Default for Drain<T, Getter>
+where
+    Getter: LinkGetter<T>,
+{
+    /// Construct an empty iterator
+    fn default() -> Self {
+        Self {
+            next: None,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T, Getter> Iterator for Drain<T, Getter>
+where
+    Getter: LinkGetter<T>,
+{
+    type Item = Arc<T>;
+
+    fn next(&mut self) -> Option<Arc<T>> {
+        let current = self.next.take()?;
+        let link = Getter::get(&*current);
+        let next = link.next.load(Ordering::Relaxed);
+        // `Release` synchronizes with the `Acquire` in `SharedList::push` to ensure the above read
+        // gets the current value of `next` before it's clobbered by another `push`, ensuring we
+        // don't leak the tail of the current list.
+        link.linked.store(false, Ordering::Release);
+        // Safety: The reference represented by `next` is uniquely owned by this iterator
+        self.next = (!next.is_null()).then(|| unsafe { Arc::from_raw(next) });
+        Some(current)
+    }
+}
+
+impl<T, Getter> std::iter::FusedIterator for Drain<T, Getter> where Getter: LinkGetter<T> {}
+
+impl<T, Getter> Drop for Drain<T, Getter>
+where
+    Getter: LinkGetter<T>,
+{
+    fn drop(&mut self) {
+        // Recover and drop all remaining references
+        for _ in self.by_ref() {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Item {
+        value: u32,
+        link: Link<Item>,
+    }
+
+    impl Item {
+        fn new(x: u32) -> Arc<Self> {
+            Arc::new(Self {
+                value: x,
+                link: Link::default(),
+            })
+        }
+    }
+
+    impl LinkGetter<Item> for () {
+        fn get(x: &Item) -> &Link<Item> {
+            &x.link
+        }
+    }
+
+    #[test]
+    fn insert_and_iterate() {
+        let list = SharedList::<Item, ()>::default();
+        assert!(list.push(Item::new(1)));
+        assert!(!list.push(Item::new(2)));
+        assert!(!list.push(Item::new(3)));
+
+        let mut iter = list.drain();
+        assert!(list.push(Item::new(4)));
+
+        assert_eq!(iter.next().unwrap().value, 3);
+        assert_eq!(iter.next().unwrap().value, 2);
+        assert_eq!(iter.next().unwrap().value, 1);
+        assert!(iter.next().is_none());
+
+        let mut iter = list.drain();
+        assert_eq!(iter.next().unwrap().value, 4);
+        assert!(iter.next().is_none());
+
+        let mut iter = list.drain();
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn no_leaks() {
+        let list = SharedList::<Item, ()>::default();
+        let a = Item::new(1);
+        let b = Item::new(2);
+        list.push(a.clone());
+        list.push(b.clone());
+        assert_eq!(Arc::strong_count(&a), 2);
+        assert_eq!(Arc::strong_count(&b), 2);
+        drop(list);
+        assert_eq!(Arc::strong_count(&a), 1);
+        assert_eq!(Arc::strong_count(&b), 1);
+    }
+
+    #[test]
+    fn reinsert() {
+        let list = SharedList::<Item, ()>::default();
+        let a = Item::new(1);
+        let b = Item::new(2);
+        list.push(a.clone());
+        list.push(b);
+        list.push(a);
+        let mut iter = list.drain();
+        assert_eq!(iter.next().unwrap().value, 2);
+        assert_eq!(iter.next().unwrap().value, 1);
+        assert!(iter.next().is_none());
+    }
+}

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -79,7 +79,7 @@ fn version_negotiate_client() {
             .into(),
     );
     if let Some(DatagramEvent::ConnectionEvent(_, event)) = opt_event {
-        client_ch.handle_event(event);
+        client_ch.handle_event(event, now);
     }
     assert_matches!(
         client_ch.poll(),
@@ -1391,8 +1391,7 @@ fn cid_retirement() {
     let (client_ch, server_ch) = pair.connect();
 
     // Server retires current active remote CIDs
-    pair.server_conn_mut(server_ch)
-        .rotate_local_cid(1, Instant::now());
+    pair.server_conn_mut(server_ch).rotate_local_cid(1);
     pair.drive();
     // Any unexpected behavior may trigger TransportError::CONNECTION_ID_LIMIT_ERROR
     assert!(!pair.client_conn_mut(client_ch).is_closed());
@@ -1408,7 +1407,7 @@ fn cid_retirement() {
     pair.client_conn_mut(client_ch).ping();
     // Server retires all valid remote CIDs
     pair.server_conn_mut(server_ch)
-        .rotate_local_cid(next_retire_prior_to, Instant::now());
+        .rotate_local_cid(next_retire_prior_to);
     pair.drive();
     assert!(!pair.client_conn_mut(client_ch).is_closed());
     assert!(!pair.server_conn_mut(server_ch).is_closed());

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -361,7 +361,7 @@ impl TestEndpoint {
 
                 for (_, mut events) in self.conn_events.drain() {
                     for event in events.drain(..) {
-                        conn.handle_event(event);
+                        conn.handle_event(event, now);
                     }
                 }
 
@@ -382,7 +382,7 @@ impl TestEndpoint {
             for (ch, event) in endpoint_events {
                 if let Some(event) = self.handle_event(ch, event) {
                     if let Some(conn) = self.connections.get_mut(&ch) {
-                        conn.handle_event(event);
+                        conn.handle_event(event, now);
                     }
                 }
             }

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -352,6 +352,7 @@ impl TestEndpoint {
         }
 
         loop {
+            let mut endpoint_events_pending = false;
             for conn in self.connections.values_mut() {
                 if self.timeout.map_or(false, |x| x <= now) {
                     self.timeout = None;
@@ -368,9 +369,10 @@ impl TestEndpoint {
                     self.outbound.extend(split_transmit(x));
                 }
                 self.timeout = conn.poll_timeout();
+                endpoint_events_pending |= conn.poll_endpoint_events();
             }
 
-            if !self.has_endpoint_events() {
+            if !endpoint_events_pending {
                 break;
             }
 

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quinn-udp"
 version = "0.5.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/quinn-rs/quinn"
 description = "UDP sockets with ECN information for the QUIC transport protocol"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -35,6 +35,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 async-io = { version = "1.6", optional = true }
 async-std = { version = "1.11", optional = true }
+atomic-waker = "1.1.1"
 bytes = "1"
 # Enables futures::io::{AsyncRead, AsyncWrite} support for streams
 futures-io = { version = "0.3.19", optional = true }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["quic"]
 categories = [ "network-programming", "asynchronous" ]
 workspace = ".."
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use crate::runtime::{AsyncTimer, AsyncUdpSocket, Runtime};
+use atomic_waker::AtomicWaker;
 use bytes::Bytes;
 use pin_project_lite::pin_project;
 use proto::{ConnectionError, ConnectionHandle, ConnectionStats, Dir, StreamEvent, StreamId};
@@ -43,6 +44,7 @@ impl Connecting {
         conn_events: mpsc::UnboundedReceiver<ConnectionEvent>,
         socket: Arc<dyn AsyncUdpSocket>,
         runtime: Arc<dyn Runtime>,
+        endpoint: Arc<AtomicWaker>,
     ) -> Self {
         let (on_handshake_data_send, on_handshake_data_recv) = oneshot::channel();
         let (on_connected_send, on_connected_recv) = oneshot::channel();
@@ -55,6 +57,7 @@ impl Connecting {
             on_connected_send,
             socket,
             runtime.clone(),
+            endpoint,
         );
 
         runtime.spawn(Box::pin(
@@ -750,6 +753,7 @@ impl ConnectionRef {
         on_connected: oneshot::Sender<bool>,
         socket: Arc<dyn AsyncUdpSocket>,
         runtime: Arc<dyn Runtime>,
+        endpoint: Arc<AtomicWaker>,
     ) -> Self {
         Self(Arc::new(ConnectionInner {
             state: Mutex::new(State {
@@ -771,6 +775,7 @@ impl ConnectionRef {
                 ref_count: 0,
                 socket,
                 runtime,
+                endpoint,
             }),
             shared: Shared::default(),
         }))
@@ -849,6 +854,7 @@ pub(crate) struct State {
     ref_count: usize,
     socket: Arc<dyn AsyncUdpSocket>,
     runtime: Arc<dyn Runtime>,
+    endpoint: Arc<AtomicWaker>,
 }
 
 impl State {
@@ -881,6 +887,9 @@ impl State {
     }
 
     fn forward_endpoint_events(&mut self) {
+        if self.inner.poll_endpoint_events() {
+            self.endpoint.wake();
+        }
         if self.inner.is_drained() {
             // If the endpoint driver is gone, noop.
             let _ = self

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -895,13 +895,14 @@ impl State {
         shared: &Shared,
         cx: &mut Context,
     ) -> Result<(), ConnectionError> {
+        let now = Instant::now();
         loop {
             match self.conn_events.poll_recv(cx) {
                 Poll::Ready(Some(ConnectionEvent::Ping)) => {
                     self.inner.ping();
                 }
                 Poll::Ready(Some(ConnectionEvent::Proto(event))) => {
-                    self.inner.handle_event(event);
+                    self.inner.handle_event(event, now);
                 }
                 Poll::Ready(Some(ConnectionEvent::Close { reason, error_code })) => {
                     self.close(error_code, reason, shared);

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -881,11 +881,11 @@ impl State {
     }
 
     fn forward_endpoint_events(&mut self) {
-        while let Some(event) = self.inner.poll_endpoint_events() {
+        if self.inner.is_drained() {
             // If the endpoint driver is gone, noop.
             let _ = self
                 .endpoint_events
-                .send((self.handle, EndpointEvent::Proto(event)));
+                .send((self.handle, EndpointEvent::Drained));
         }
     }
 
@@ -1100,10 +1100,9 @@ impl Drop for State {
     fn drop(&mut self) {
         if !self.inner.is_drained() {
             // Ensure the endpoint can tidy up
-            let _ = self.endpoint_events.send((
-                self.handle,
-                EndpointEvent::Proto(proto::EndpointEvent::drained()),
-            ));
+            let _ = self
+                .endpoint_events
+                .send((self.handle, EndpointEvent::Drained));
         }
     }
 }

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -97,7 +97,7 @@ enum ConnectionEvent {
 
 #[derive(Debug)]
 enum EndpointEvent {
-    Proto(proto::EndpointEvent),
+    Drained,
     Transmit(proto::Transmit),
 }
 


### PR DESCRIPTION
Work towards #1576, https://github.com/quinn-rs/quinn/issues/599.

This replaces the requirement for callers to pass `EndpointEvent`s around with shared memory managed by the proto layer, using a purpose-built lock-free intrusive mpsc queue called `SharedList`. This simplifies the proto API and may be more efficient, although endpoint events are not typically on a hot path.

Intensive review is required for the implementation of `SharedList`, which contains internal unsafety and relies on careful use of memory orderings for correctness. I couldn't find an off-the-shelf, well-audited data structure with similar semantics.

Alternative approaches to this API change include a std mpsc channel and the pre-existing `EndpointEvent` enum, or an mpsc channel of `Arc<EndpointEvents>` with an additional `AtomicBool` flag to minimize redundant messaging. These would avoid rolling our own data structure, at the cost using a more reviewed but needlessly complex and less specialized data structure. Further, `SharedList` may prove useful elsewhere within quinn: a similar queue-once MPSC pattern exists in streams, and might be leveraged to increase application parallelism when performing stream I/O (see discussion in https://github.com/quinn-rs/quinn/issues/1433).