### PR TITLE
Clamp per-RTT ACK timeouts to at most once per 10ms

### DIFF
--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -144,6 +144,11 @@ pub fn transport_config(opt: &Opt) -> quinn::TransportConfig {
     let mut config = quinn::TransportConfig::default();
     config.max_concurrent_uni_streams(opt.max_streams.try_into().unwrap());
     config.initial_mtu(opt.initial_mtu);
+
+    let mut acks = quinn::AckFrequencyConfig::default();
+    acks.ack_eliciting_threshold(10u32.into());
+    config.ack_frequency_config(Some(acks));
+
     config
 }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -803,8 +803,10 @@ impl Connection {
                     "setting RTT timer with RTT = {} ms",
                     self.path.rtt.get().as_millis()
                 );
-                self.timers
-                    .set(Timer::ImmediateAck, now + self.path.rtt.get());
+                self.timers.set(
+                    Timer::ImmediateAck,
+                    now + self.path.rtt.get().max(IMMEDIATE_ACK_PERIOD_LOWER_BOUND),
+                );
             }
 
             let sent = self.populate_packet(
@@ -1111,8 +1113,10 @@ impl Connection {
                     // for more details)
                     if space.sent_packets.len() > 1 {
                         space.immediate_ack_pending = true;
-                        self.timers
-                            .set(Timer::ImmediateAck, now + self.path.rtt.get());
+                        self.timers.set(
+                            Timer::ImmediateAck,
+                            now + self.path.rtt.get().max(IMMEDIATE_ACK_PERIOD_LOWER_BOUND),
+                        );
                     }
                 }
             }
@@ -3683,3 +3687,7 @@ impl SentFrames {
             && self.retransmits.is_empty(streams)
     }
 }
+
+/// Minimum period between ImmediateAck frames triggered by the ImmediateAck timer
+// 10ms selected somewhat arbitrarily
+const IMMEDIATE_ACK_PERIOD_LOWER_BOUND: Duration = Duration::from_millis(10);

--- a/quinn-proto/src/connection/timer.rs
+++ b/quinn-proto/src/connection/timer.rs
@@ -22,7 +22,7 @@ pub(crate) enum Timer {
     MaxAckDelay = 8,
     /// When the RTT is elapsed (used to request an immediate ack if there are local unacked
     /// ack-eliciting packets)
-    Rtt = 9,
+    ImmediateAck = 9,
 }
 
 impl Timer {
@@ -36,7 +36,7 @@ impl Timer {
         Self::Pacing,
         Self::PushNewCid,
         Self::MaxAckDelay,
-        Self::Rtt,
+        Self::ImmediateAck,
     ];
 }
 


### PR DESCRIPTION
Avoids unreasonably high ACK rates on LANs/loopback.