### PR TITLE
Generalize UdpStats::transmits to ios

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -502,7 +502,7 @@ impl Connection {
 
                 builder.finish(self, &mut buf);
                 self.stats.udp_tx.datagrams += 1;
-                self.stats.udp_tx.transmits += 1;
+                self.stats.udp_tx.ios += 1;
                 self.stats.udp_tx.bytes += buf.len() as u64;
                 return Some(Transmit {
                     destination,
@@ -912,7 +912,7 @@ impl Connection {
 
         self.stats.udp_tx.datagrams += num_datagrams as u64;
         self.stats.udp_tx.bytes += buf.len() as u64;
-        self.stats.udp_tx.transmits += 1;
+        self.stats.udp_tx.ios += 1;
 
         Some(Transmit {
             destination: self.path.remote,
@@ -2071,6 +2071,7 @@ impl Connection {
         packet: Option<Packet>,
         stateless_reset: bool,
     ) {
+        self.stats.udp_rx.ios += 1;
         if let Some(ref packet) = packet {
             trace!(
                 "got {:?} packet ({} bytes) from {} using id {}",

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -11,11 +11,10 @@ pub struct UdpStats {
     pub datagrams: u64,
     /// The total amount of bytes which have been transferred inside UDP datagrams
     pub bytes: u64,
-    /// The amount of transmit calls which have been performed
+    /// The amount of I/O operations executed
     ///
-    /// This can mismatch the amount of datagrams in case GSO is utilized for
-    /// transmitting data.
-    pub transmits: u64,
+    /// Can be less than `datagrams` when GSO, GRO, and/or batched system calls are in use.
+    pub ios: u64,
 }
 
 /// Number of frames transmitted of each frame type


### PR DESCRIPTION
Since this field exists for both tx and rx, we might as well make use of it.