### PR TITLE
Send ACK_FREQUENCY frames intelligently rather than spamming IMMEDIATE_ACK

### DIFF
--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -453,8 +453,8 @@ impl AckFrequencyConfig {
     /// This parameter represents the maximum amount of time that an endpoint waits before sending
     /// an ACK when the ack-eliciting threshold hasn't been reached.
     ///
-    /// The provided `max_ack_delay` will be clamped to be at least the peer's `min_ack_delay`
-    /// transport parameter.
+    /// The effective `max_ack_delay` will be clamped to be at least the peer's `min_ack_delay`
+    /// transport parameter, and at most the current path RTT.
     ///
     /// Defaults to `None`, in which case the peer's original `max_ack_delay` will be used, as
     /// obtained from its transport parameters.

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -454,7 +454,7 @@ impl AckFrequencyConfig {
     /// an ACK when the ack-eliciting threshold hasn't been reached.
     ///
     /// The effective `max_ack_delay` will be clamped to be at least the peer's `min_ack_delay`
-    /// transport parameter, and at most the current path RTT.
+    /// transport parameter, and at most the greater of the current path RTT or 25ms.
     ///
     /// Defaults to `None`, in which case the peer's original `max_ack_delay` will be used, as
     /// obtained from its transport parameters.

--- a/quinn-proto/src/connection/ack_frequency.rs
+++ b/quinn-proto/src/connection/ack_frequency.rs
@@ -33,9 +33,18 @@ impl AckFrequencyState {
 
     /// Returns the `max_ack_delay` that should be requested of the peer when sending an
     /// ACK_FREQUENCY frame
-    pub(super) fn candidate_max_ack_delay(&self, config: &AckFrequencyConfig) -> Duration {
+    pub(super) fn candidate_max_ack_delay(
+        &self,
+        config: &AckFrequencyConfig,
+        peer_params: &TransportParameters,
+    ) -> Duration {
         // Use the peer's max_ack_delay if no custom max_ack_delay was provided in the config
-        config.max_ack_delay.unwrap_or(self.peer_max_ack_delay)
+        config
+            .max_ack_delay
+            .unwrap_or(self.peer_max_ack_delay)
+            .max(Duration::from_micros(
+                peer_params.min_ack_delay.map_or(0, |x| x.into()),
+            ))
     }
 
     /// Returns the `max_ack_delay` for the purposes of calculating the PTO

--- a/quinn-proto/src/connection/ack_frequency.rs
+++ b/quinn-proto/src/connection/ack_frequency.rs
@@ -46,7 +46,7 @@ impl AckFrequencyState {
         config
             .max_ack_delay
             .unwrap_or(self.peer_max_ack_delay)
-            .clamp(min_ack_delay, rtt)
+            .clamp(min_ack_delay, rtt.max(MIN_AUTOMATIC_ACK_DELAY))
     }
 
     /// Returns the `max_ack_delay` for the purposes of calculating the PTO
@@ -150,3 +150,8 @@ impl AckFrequencyState {
 /// currently desired one before a new request is sent, when the peer supports the ACK frequency
 /// extension and an explicit max ACK delay is not configured.
 const MAX_RTT_ERROR: f32 = 0.2;
+
+/// Minimum value to request the peer set max ACK delay to when the peer supports the ACK frequency
+/// extension and an explicit max ACK delay is not configured.
+// Keep in sync with `AckFrequencyConfig::max_ack_delay` documentation
+const MIN_AUTOMATIC_ACK_DELAY: Duration = Duration::from_millis(25);

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2987,24 +2987,20 @@ impl Connection {
         if mem::replace(&mut space.pending.ack_frequency, false) {
             let sequence_number = self.ack_frequency.next_sequence_number();
 
-            // Safe to unwrap because these are always provided when ACK frequency is enabled
+            // Safe to unwrap because this is always provided when ACK frequency is enabled
             let config = self.config.ack_frequency_config.as_ref().unwrap();
-            let min_ack_delay_micros = self.peer_params.min_ack_delay.unwrap();
 
             // Ensure the delay is within bounds to avoid a PROTOCOL_VIOLATION error
-            let max_ack_delay = self.ack_frequency.candidate_max_ack_delay(config);
-            let max_ack_delay_micros = max_ack_delay
-                .as_micros()
-                .try_into()
-                .unwrap_or(VarInt::MAX)
-                .max(min_ack_delay_micros);
+            let max_ack_delay = self
+                .ack_frequency
+                .candidate_max_ack_delay(config, &self.peer_params);
 
             trace!(?max_ack_delay, "ACK_FREQUENCY");
 
             frame::AckFrequency {
                 sequence: sequence_number,
                 ack_eliciting_threshold: config.ack_eliciting_threshold,
-                request_max_ack_delay: max_ack_delay_micros,
+                request_max_ack_delay: max_ack_delay.as_micros().try_into().unwrap_or(VarInt::MAX),
                 reordering_threshold: config.reordering_threshold,
             }
             .encode(buf);

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2985,8 +2985,6 @@ impl Connection {
 
         // ACK_FREQUENCY
         if mem::replace(&mut space.pending.ack_frequency, false) {
-            trace!("ACK_FREQUENCY");
-
             let sequence_number = self.ack_frequency.next_sequence_number();
 
             // Safe to unwrap because these are always provided when ACK frequency is enabled
@@ -3000,6 +2998,8 @@ impl Connection {
                 .try_into()
                 .unwrap_or(VarInt::MAX)
                 .max(min_ack_delay_micros);
+
+            trace!(?max_ack_delay, "ACK_FREQUENCY");
 
             frame::AckFrequency {
                 sequence: sequence_number,

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -790,22 +790,6 @@ impl Connection {
                 break;
             }
 
-            if builder.ack_eliciting
-                && builder.space == SpaceId::Data
-                && self.peer_supports_ack_frequency()
-                && self.config.ack_frequency_config.is_some()
-                && self.timers.get(Timer::Rtt).is_none()
-            {
-                // Request an immediate ACK to ensure we receive one within RTT, as recommended by
-                // the acknowledgement frequency draft
-                self.spaces[SpaceId::Data].immediate_ack_pending = true;
-                tracing::trace!(
-                    "setting RTT timer with RTT = {} ms",
-                    self.path.rtt.get().as_millis()
-                );
-                self.timers.set(Timer::Rtt, now + self.path.rtt.get());
-            }
-
             let sent = self.populate_packet(
                 now,
                 space_id,
@@ -1090,28 +1074,6 @@ impl Connection {
                     self.spaces[SpaceId::Data]
                         .pending_acks
                         .on_max_ack_delay_timeout()
-                }
-                Timer::Rtt => {
-                    // This timer is only armed when ACK frequency has been enabled, the peer
-                    // supports it, and we are in the Data space
-                    let space = &mut self.spaces[SpaceId::Data];
-                    trace!(
-                        in_flight_ack_eliciting = space.sent_packets.len(),
-                        "rtt timer"
-                    );
-
-                    // It is recommended to request an immediate ACK once per RTT if there are
-                    // unacked packets. Packets with timer-triggered `IMMEDIATE_ACK` frames count
-                    // towards unacked packets, but we don't want to take them into account here.
-                    // For that reason, we only send an `IMMEDIATE_ACK` frame when there
-                    // are at least _two_ unacked packets. This is an approximation, but should work
-                    // well in practice (see
-                    // [this comment](https://github.com/quinn-rs/quinn/pull/1553#discussion_r1251268689)
-                    // for more details)
-                    if space.sent_packets.len() > 1 {
-                        space.immediate_ack_pending = true;
-                        self.timers.set(Timer::Rtt, now + self.path.rtt.get());
-                    }
                 }
             }
         }
@@ -3373,7 +3335,7 @@ impl Connection {
     pub(crate) fn is_idle(&self) -> bool {
         Timer::VALUES
             .iter()
-            .filter(|&&t| t != Timer::KeepAlive && t != Timer::PushNewCid && t != Timer::Rtt)
+            .filter(|&&t| t != Timer::KeepAlive && t != Timer::PushNewCid)
             .filter_map(|&t| Some((t, self.timers.get(t)?)))
             .min_by_key(|&(_, time)| time)
             .map_or(true, |(timer, _)| timer == Timer::Idle)

--- a/quinn-proto/src/connection/timer.rs
+++ b/quinn-proto/src/connection/timer.rs
@@ -20,13 +20,10 @@ pub(crate) enum Timer {
     PushNewCid = 7,
     /// When to send an immediate ACK if there are unacked ack-eliciting packets of the peer
     MaxAckDelay = 8,
-    /// When the RTT is elapsed (used to request an immediate ack if there are local unacked
-    /// ack-eliciting packets)
-    Rtt = 9,
 }
 
 impl Timer {
-    pub(crate) const VALUES: [Self; 10] = [
+    pub(crate) const VALUES: [Self; 9] = [
         Self::LossDetection,
         Self::Idle,
         Self::Close,
@@ -36,7 +33,6 @@ impl Timer {
         Self::Pacing,
         Self::PushNewCid,
         Self::MaxAckDelay,
-        Self::Rtt,
     ];
 }
 

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -24,6 +24,9 @@ pub(super) const DEFAULT_MTU: usize = 1452;
 pub(super) struct Pair {
     pub(super) server: TestEndpoint,
     pub(super) client: TestEndpoint,
+    /// Start time
+    epoch: Instant,
+    /// Current time
     pub(super) time: Instant,
     /// Simulates the maximum size allowed for UDP payloads by the link (packets exceeding this size will be dropped)
     pub(super) mtu: usize,
@@ -61,10 +64,12 @@ impl Pair {
             Ipv6Addr::LOCALHOST.into(),
             CLIENT_PORTS.lock().unwrap().next().unwrap(),
         );
+        let now = Instant::now();
         Self {
             server: TestEndpoint::new(server, server_addr),
             client: TestEndpoint::new(client, client_addr),
-            time: Instant::now(),
+            epoch: now,
+            time: now,
             mtu: DEFAULT_MTU,
             latency: Duration::new(0, 0),
             spins: 0,
@@ -87,14 +92,14 @@ impl Pair {
             Some(t) if Some(t) == client_t => {
                 if t != self.time {
                     self.time = self.time.max(t);
-                    trace!("advancing to {:?} for client", self.time);
+                    trace!("advancing to {:?} for client", self.time - self.epoch);
                 }
                 true
             }
             Some(t) if Some(t) == server_t => {
                 if t != self.time {
                     self.time = self.time.max(t);
-                    trace!("advancing to {:?} for server", self.time);
+                    trace!("advancing to {:?} for server", self.time - self.epoch);
                 }
                 true
             }


### PR DESCRIPTION
Alternative to #1654. Reduces the amount of communication required compared to the status quo when the RTT is not varying wildly.

This preserves the pre-existing behavior where `max_ack_delay` is effectively clamped below the current RTT. It might be useful to also offer an escape hatch to force it higher, although such a configuration is contrary to the "SHOULD" recommendation of the ack frequency draft.