### PR TITLE
backport to 0.9: Allow GSO to be manually disabled

### DIFF
--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -46,6 +46,8 @@ pub struct TransportConfig {
     pub(crate) datagram_send_buffer_size: usize,
 
     pub(crate) congestion_controller_factory: Box<dyn congestion::ControllerFactory + Send + Sync>,
+
+    pub(crate) enable_segmentation_offload: bool,
 }
 
 impl TransportConfig {
@@ -244,6 +246,21 @@ impl TransportConfig {
         self.congestion_controller_factory = Box::new(factory);
         self
     }
+
+    /// Whether to use "Generic Segmentation Offload" to accelerate transmits, when supported by the
+    /// environment
+    ///
+    /// Defaults to `true`.
+    ///
+    /// GSO dramatically reduces CPU consumption when sending large numbers of packets with the same
+    /// headers, such as when transmitting bulk data on a connection. However, it is not supported
+    /// by all network interface drivers or packet inspection tools. `quinn-udp` will attempt to
+    /// disable GSO automatically when unavailable, but this can lead to spurious packet loss at
+    /// startup, temporarily degrading performance.
+    pub fn enable_segmentation_offload(&mut self, enabled: bool) -> &mut Self {
+        self.enable_segmentation_offload = enabled;
+        self
+    }
 }
 
 impl Default for TransportConfig {
@@ -276,6 +293,8 @@ impl Default for TransportConfig {
             datagram_send_buffer_size: 1024 * 1024,
 
             congestion_controller_factory: Box::new(Arc::new(congestion::CubicConfig::default())),
+
+            enable_segmentation_offload: true,
         }
     }
 }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -411,7 +411,10 @@ impl Connection {
     #[must_use]
     pub fn poll_transmit(&mut self, now: Instant, max_datagrams: usize) -> Option<Transmit> {
         assert!(max_datagrams != 0);
-        let max_datagrams = max_datagrams.min(MAX_TRANSMIT_SEGMENTS);
+        let max_datagrams = match self.config.enable_segmentation_offload {
+            false => 1,
+            true => max_datagrams.min(MAX_TRANSMIT_SEGMENTS),
+        };
 
         let mut num_datagrams = 0;
 


### PR DESCRIPTION
Hi,
we love quinn but we recently had a hard time with GSO and fly.io hosting and quinn 0.9.4!

This errors are piling up in the logs:
> sendmsg error: Os { code: 22, kind: InvalidInput, message: "Invalid argument" }, Transmit: { destination: [dead:0:beef:a7b:17b:0101:2345:2]:11111, src_ip: None, enc: Some(Ect0), len: 1291, segment_size: Some(1200) }

After some research we concluded that quinn's GSO detection returns a false-positive - at least on fly.io machines!
Our reasoning:
1. The problem went away by disabling GSO with patch a06838.
2. fly.io support confirmed GSO is not supported on their platform!

### Proposed Solution
short term: backport a06838 to allow manual disabling GSO
long term: backport a fix for the feature detection

maybe the solution should be ported to 0.10 too

