### PR TITLE
Do not pre-allocate memory on streams

### DIFF
--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -244,8 +244,9 @@ impl<'a> SendStream<'a> {
 
     /// Check if this stream was stopped, get the reason if it was
     pub fn stopped(&mut self) -> Result<Option<VarInt>, UnknownStream> {
-        match self.state.send.get(&self.id).and_then(|s| s.as_ref()) {
-            Some(s) => Ok(s.stop_reason),
+        match self.state.send.get(&self.id).as_ref() {
+            Some(Some(s)) => Ok(s.stop_reason),
+            Some(None) => Ok(None),
             None => Err(UnknownStream { _private: () }),
         }
     }

--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -210,7 +210,6 @@ impl<'a> SendStream<'a> {
 
         let limit = self.state.write_limit();
 
-        // annoying to have to do this pre-emptively
         let max_send_data = self.state.max_send_data(&self.id);
 
         let stream = self

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -226,7 +226,7 @@ impl<'a> Chunks<'a> {
             .stopped
         {
             true => return Err(ReadableError::UnknownStream),
-            false => entry.remove().unwrap(), // this can't fail at this point
+            false => entry.remove().unwrap(), // this can't fail due to the previous get_or_insert_with
         };
 
         recv.assembler.ensure_ordering(ordered)?;

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -4,6 +4,7 @@ use std::mem;
 use thiserror::Error;
 use tracing::debug;
 
+use super::state::get_or_insert_recv;
 use super::{Retransmits, ShouldTransmit, StreamHalf, StreamId, StreamsState, UnknownStream};
 use crate::connection::assembler::{Assembler, Chunk, IllegalOrderedRead};
 use crate::{frame, TransportError, VarInt};
@@ -18,14 +19,14 @@ pub(super) struct Recv {
 }
 
 impl Recv {
-    pub(super) fn new(initial_max_data: u64) -> Self {
-        Self {
+    pub(super) fn new(initial_max_data: u64) -> Box<Self> {
+        Box::new(Self {
             state: RecvState::default(),
             assembler: Assembler::new(),
             sent_max_stream_data: initial_max_data,
             end: 0,
             stopped: false,
-        }
+        })
     }
 
     /// Process a STREAM frame
@@ -220,14 +221,11 @@ impl<'a> Chunks<'a> {
             Entry::Vacant(_) => return Err(ReadableError::UnknownStream),
         };
 
-        let mut recv = match entry
-            .get_mut()
-            .get_or_insert_with(|| Box::new(Recv::new(streams.stream_receive_window)))
-            .stopped
-        {
-            true => return Err(ReadableError::UnknownStream),
-            false => entry.remove().unwrap(), // this can't fail due to the previous get_or_insert_with
-        };
+        let mut recv =
+            match get_or_insert_recv(streams.stream_receive_window)(entry.get_mut()).stopped {
+                true => return Err(ReadableError::UnknownStream),
+                false => entry.remove().unwrap(), // this can't fail due to the previous get_or_insert_with
+            };
 
         recv.assembler.ensure_ordering(ordered)?;
         Ok(Self {

--- a/quinn-proto/src/connection/streams/send.rs
+++ b/quinn-proto/src/connection/streams/send.rs
@@ -18,8 +18,8 @@ pub(super) struct Send {
 }
 
 impl Send {
-    pub(super) fn new(max_data: VarInt) -> Self {
-        Self {
+    pub(super) fn new(max_data: VarInt) -> Box<Self> {
+        Box::new(Self {
             max_data: max_data.into(),
             state: SendState::Ready,
             pending: SendBuffer::new(),
@@ -27,7 +27,7 @@ impl Send {
             fin_pending: false,
             connection_blocked: false,
             stop_reason: None,
-        }
+        })
     }
 
     /// Whether the stream has been reset

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -841,25 +841,11 @@ impl StreamsState {
         let bi = id.dir() == Dir::Bi;
         // bidirectional OR (unidirectional AND NOT remote)
         if bi || !remote {
-            // if remote {
             assert!(self.send.insert(id, None).is_none());
-            // } else {
-            //     assert!(self
-            //         .send
-            //         .insert(id, Some(Box::new(Send::new(self.max_send_data(&id)))))
-            //         .is_none());
-            // }
         }
         // bidirectional OR (unidirectional AND remote)
         if bi || remote {
-            // if remote {
             assert!(self.recv.insert(id, None).is_none());
-            // } else {
-            //     assert!(self
-            //         .recv
-            //         .insert(id, Some(Box::new(Recv::new(self.stream_receive_window))))
-            //         .is_none());
-            // }
         }
     }
 

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -610,11 +610,16 @@ impl StreamsState {
             hash_map::Entry::Occupied(e) => e,
         };
 
-        // Because we only call this after sending data on this stream,
-        // this closure should be unreachable. If we did somehow screw that up,
-        // then we might hit an underflow below with unpredictable effects down
-        // the line. Best to short-circuit.
-        let stream = entry.get_mut().as_mut().unwrap();
+        let stream = match entry.get_mut().as_mut() {
+            Some(s) => s,
+            None => {
+                // Because we only call this after sending data on this stream,
+                // this closure should be unreachable. If we did somehow screw that up,
+                // then we might hit an underflow below with unpredictable effects down
+                // the line. Best to short-circuit.
+                return;
+            }
+        };
 
         if stream.is_reset() {
             // We account for outstanding data on reset streams at time of reset


### PR DESCRIPTION
This PR wraps `Recv` and `Send` streams in `Option<Box<T>>` to prevent significant memory pre-allocation.

Still a few things to verify / do:
- [ ] Make sure there's never a `None` value when it should be `Some`
- [ ] Validate the logic here, not sure when to insert a `None` or a `Some` exactly...

(Hopefully) Fixes #1677