### PR TITLE
wip: add a new trait to notify application of some events. For now only support MTU updates.

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1301,9 +1301,14 @@ impl Connection {
                 // Notify MTU discovery that a packet was acked, because it might be an MTU probe
                 let mtu_updated = self.path.mtud.on_acked(space, packet, info.size);
                 if mtu_updated {
+                    let new_mtu = self.path.mtud.current_mtu();
                     self.path
                         .congestion
-                        .on_mtu_update(self.path.mtud.current_mtu());
+                        .on_mtu_update(new_mtu);
+
+                    if let Some(ref event_sink) = self.endpoint_config.event_sink {
+                        event_sink.on_mtu_update(self, new_mtu);
+                    }
                 }
 
                 // Notify ack frequency that a packet was acked, because it might contain an ACK_FREQUENCY frame

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -51,8 +51,8 @@ pub use crate::connection::{
 
 mod config;
 pub use config::{
-    AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig,
-    ServerConfig, TransportConfig,
+    AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, EventSink, IdleTimeout,
+    MtuDiscoveryConfig, ServerConfig, TransportConfig,
 };
 
 pub mod crypto;

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -62,7 +62,7 @@ mod work_limiter;
 
 pub use proto::{
     congestion, crypto, AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ConfigError,
-    ConnectError, ConnectionClose, ConnectionError, EndpointConfig, IdleTimeout,
+    ConnectError, ConnectionClose, ConnectionError, EndpointConfig, EventSink, IdleTimeout,
     MtuDiscoveryConfig, ServerConfig, StreamId, Transmit, TransportConfig, VarInt,
 };
 #[cfg(feature = "tls-rustls")]


### PR DESCRIPTION
This is a draft PR to discuss about a possible new API to allow the application that uses quinn or quinn-proto to do some actions in reaction to some events happening on endpoints or connections.

This demonstrates (using the shortest possible code path) how it could be done to notify about MTU updates.

A possible use case for this would be for the application to lower the size of transported data. For example a VPN like client using quinn could use this to lower the MTU of the physical interfaces used to capture the packets to tunnel.
