### PR TITLE
Make `quinn-proto::{Connection, Endpoint}` deterministic

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -252,7 +252,7 @@ impl Connection {
         now: Instant,
         version: u32,
         allow_mtud: bool,
-        rng_seed: <StdRng as SeedableRng>::Seed,
+        rng_seed: [u8; 32],
     ) -> Self {
         let side = if server_config.is_some() {
             Side::Server

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -10,7 +10,7 @@ use std::{
 
 use bytes::{Bytes, BytesMut};
 use frame::StreamMetaVec;
-use rand::{rngs::StdRng, Rng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use thiserror::Error;
 use tracing::{debug, error, trace, trace_span, warn};
 
@@ -252,7 +252,7 @@ impl Connection {
         now: Instant,
         version: u32,
         allow_mtud: bool,
-        mut rng: StdRng,
+        rng_seed: <StdRng as SeedableRng>::Seed,
     ) -> Self {
         let side = if server_config.is_some() {
             Side::Server
@@ -268,6 +268,7 @@ impl Connection {
             expected_token: Bytes::new(),
             client_hello: None,
         });
+        let mut rng = StdRng::from_seed(rng_seed);
         let path_validated = server_config.as_ref().map_or(true, |c| c.use_retry);
         let mut this = Self {
             endpoint_config,

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -10,7 +10,7 @@ use std::{
 
 use bytes::{Bytes, BytesMut};
 use frame::StreamMetaVec;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, Rng};
 use thiserror::Error;
 use tracing::{debug, error, trace, trace_span, warn};
 
@@ -252,6 +252,7 @@ impl Connection {
         now: Instant,
         version: u32,
         allow_mtud: bool,
+        mut rng: StdRng,
     ) -> Self {
         let side = if server_config.is_some() {
             Side::Server
@@ -267,7 +268,6 @@ impl Connection {
             expected_token: Bytes::new(),
             client_hello: None,
         });
-        let mut rng = StdRng::from_entropy();
         let path_validated = server_config.as_ref().map_or(true, |c| c.use_retry);
         let mut this = Self {
             endpoint_config,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -57,7 +57,7 @@ impl Endpoint {
         config: Arc<EndpointConfig>,
         server_config: Option<Arc<ServerConfig>>,
         allow_mtud: bool,
-        rng_seed: Option<<StdRng as SeedableRng>::Seed>,
+        rng_seed: Option<[u8; 32]>,
     ) -> Self {
         Self {
             rng: rng_seed.map_or(StdRng::from_entropy(), StdRng::from_seed),

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use assert_matches::assert_matches;
 use bytes::Bytes;
 use hex_literal::hex;
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::RngCore;
 use ring::hmac;
 use rustls::AlertDescription;
 use tracing::info;
@@ -31,7 +31,7 @@ fn version_negotiate_server() {
         Default::default(),
         Some(Arc::new(server_config())),
         true,
-        StdRng::from_entropy(),
+        None,
     );
     let now = Instant::now();
     let event = server.handle(
@@ -41,7 +41,6 @@ fn version_negotiate_server() {
         None,
         // Long-header packet with reserved version number
         hex!("80 0a1a2a3a 04 00000000 04 00000000 00")[..].into(),
-        StdRng::from_entropy,
     );
     let Some(DatagramEvent::Response(Transmit { contents, .. })) = event else {
         panic!("expected a response");
@@ -69,16 +68,10 @@ fn version_negotiate_client() {
         }),
         None,
         true,
-        StdRng::from_entropy(),
+        None,
     );
     let (_, mut client_ch) = client
-        .connect(
-            Instant::now(),
-            client_config(),
-            server_addr,
-            "localhost",
-            StdRng::from_entropy,
-        )
+        .connect(Instant::now(), client_config(), server_addr, "localhost")
         .unwrap();
     let now = Instant::now();
     let opt_event = client.handle(
@@ -92,7 +85,6 @@ fn version_negotiate_client() {
              0a1a2a3a"
         )[..]
             .into(),
-        StdRng::from_entropy,
     );
     if let Some(DatagramEvent::ConnectionEvent(_, event)) = opt_event {
         client_ch.handle_event(event);
@@ -192,12 +184,8 @@ fn server_stateless_reset() {
     let mut pair = Pair::new(endpoint_config.clone(), server_config());
     let (client_ch, _) = pair.connect();
     pair.drive(); // Flush any post-handshake frames
-    pair.server.endpoint = Endpoint::new(
-        endpoint_config,
-        Some(Arc::new(server_config())),
-        true,
-        StdRng::from_entropy(),
-    );
+    pair.server.endpoint =
+        Endpoint::new(endpoint_config, Some(Arc::new(server_config())), true, None);
     // Force the server to generate the smallest possible stateless reset
     pair.client.connections.get_mut(&client_ch).unwrap().ping();
     info!("resetting");
@@ -222,12 +210,8 @@ fn client_stateless_reset() {
 
     let mut pair = Pair::new(endpoint_config.clone(), server_config());
     let (_, server_ch) = pair.connect();
-    pair.client.endpoint = Endpoint::new(
-        endpoint_config,
-        Some(Arc::new(server_config())),
-        true,
-        StdRng::from_entropy(),
-    );
+    pair.client.endpoint =
+        Endpoint::new(endpoint_config, Some(Arc::new(server_config())), true, None);
     // Send something big enough to allow room for a smaller stateless reset.
     pair.server.connections.get_mut(&server_ch).unwrap().close(
         pair.time,
@@ -1367,14 +1351,9 @@ fn cid_rotation() {
         }),
         Some(Arc::new(server_config())),
         true,
-        StdRng::from_entropy(),
-    );
-    let client = Endpoint::new(
-        Arc::new(EndpointConfig::default()),
         None,
-        true,
-        StdRng::from_entropy(),
     );
+    let client = Endpoint::new(Arc::new(EndpointConfig::default()), None, true, None);
 
     let mut pair = Pair::new_from_endpoint(client, server);
     let (_, server_ch) = pair.connect();
@@ -1956,7 +1935,7 @@ fn malformed_token_len() {
         Default::default(),
         Some(Arc::new(server_config())),
         true,
-        StdRng::from_entropy(),
+        None,
     );
     server.handle(
         Instant::now(),
@@ -1964,7 +1943,6 @@ fn malformed_token_len() {
         None,
         None,
         hex!("8900 0000 0101 0000 1b1b 841b 0000 0000 3f00")[..].into(),
-        StdRng::from_entropy,
     );
 }
 
@@ -2060,18 +2038,13 @@ fn migrate_detects_new_mtu_and_respects_original_peer_max_udp_payload_size() {
         Arc::new(server_endpoint_config),
         Some(Arc::new(server_config())),
         true,
-        StdRng::from_entropy(),
+        None,
     );
     let client_endpoint_config = EndpointConfig {
         max_udp_payload_size: VarInt::from(client_max_udp_payload_size),
         ..EndpointConfig::default()
     };
-    let client = Endpoint::new(
-        Arc::new(client_endpoint_config),
-        None,
-        true,
-        StdRng::from_entropy(),
-    );
+    let client = Endpoint::new(Arc::new(client_endpoint_config), None, true, None);
     let mut pair = Pair::new_from_endpoint(client, server);
     pair.mtu = 1300;
 

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -14,6 +14,7 @@ use std::{
 use assert_matches::assert_matches;
 use bytes::BytesMut;
 use lazy_static::lazy_static;
+use rand::{rngs::StdRng, SeedableRng};
 use rustls::{Certificate, KeyLogFile, PrivateKey};
 use tracing::{info_span, trace};
 
@@ -49,8 +50,13 @@ impl Pair {
     }
 
     pub(super) fn new(endpoint_config: Arc<EndpointConfig>, server_config: ServerConfig) -> Self {
-        let server = Endpoint::new(endpoint_config.clone(), Some(Arc::new(server_config)), true);
-        let client = Endpoint::new(endpoint_config, None, true);
+        let server = Endpoint::new(
+            endpoint_config.clone(),
+            Some(Arc::new(server_config)),
+            true,
+            StdRng::from_entropy(),
+        );
+        let client = Endpoint::new(endpoint_config, None, true, StdRng::from_entropy());
 
         Self::new_from_endpoint(client, server)
     }
@@ -206,7 +212,13 @@ impl Pair {
         let _guard = span.enter();
         let (client_ch, client_conn) = self
             .client
-            .connect(Instant::now(), config, self.server.addr, "localhost")
+            .connect(
+                Instant::now(),
+                config,
+                self.server.addr,
+                "localhost",
+                StdRng::from_entropy,
+            )
             .unwrap();
         self.client.connections.insert(client_ch, client_conn);
         client_ch
@@ -332,7 +344,12 @@ impl TestEndpoint {
 
         while self.inbound.front().map_or(false, |x| x.0 <= now) {
             let (recv_time, ecn, packet) = self.inbound.pop_front().unwrap();
-            if let Some(event) = self.endpoint.handle(recv_time, remote, None, ecn, packet) {
+            if let Some(event) = self
+                .endpoint
+                .handle(recv_time, remote, None, ecn, packet, || {
+                    StdRng::from_entropy()
+                })
+            {
                 match event {
                     DatagramEvent::NewConnection(ch, conn) => {
                         self.connections.insert(ch, conn);
@@ -344,10 +361,7 @@ impl TestEndpoint {
                             self.captured_packets.extend(packet);
                         }
 
-                        self.conn_events
-                            .entry(ch)
-                            .or_insert_with(VecDeque::new)
-                            .push_back(event);
+                        self.conn_events.entry(ch).or_default().push_back(event);
                     }
                     DatagramEvent::Response(transmit) => {
                         self.outbound.extend(split_transmit(transmit));

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -41,7 +41,6 @@ futures-io = { version = "0.3.19", optional = true }
 rustc-hash = "1.1"
 pin-project-lite = "0.2"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.11", default-features = false }
-rand = "0.8"
 rustls = { version = "0.21.0", default-features = false, features = ["quic"], optional = true }
 thiserror = "1.0.21"
 tracing = "0.1.10"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -41,6 +41,7 @@ futures-io = { version = "0.3.19", optional = true }
 rustc-hash = "1.1"
 pin-project-lite = "0.2"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.11", default-features = false }
+rand = "0.8"
 rustls = { version = "0.21.0", default-features = false, features = ["quic"], optional = true }
 thiserror = "1.0.21"
 tracing = "0.1.10"

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -490,7 +490,7 @@ impl Connection {
     ///
     /// The dynamic type returned is determined by the configured
     /// [`Session`](proto::crypto::Session). For the default `rustls` session, the return value can
-    /// be [`downcast`](Box::downcast) to a <code>Vec<[rustls::Certificate](rustls::Certificate)></code>
+    /// be [`downcast`](Box::downcast) to a <code>Vec<[rustls::Certificate]></code>
     pub fn peer_identity(&self) -> Option<Box<dyn Any>> {
         self.0
             .state


### PR DESCRIPTION
`quinn-proto::{Connection, Endpoint}` structs call `StdRng::from_entropy()` in their implementation. It makes it hard to reproduce errors in an otherwise deterministic test case.

This PR addresses the issue by adding a `StdRng` argument to the respective `new` functions. For other functions that may create an endpoint/connection, an argument of type `impl FnOnce() -> StdRng` is added. This avoids eager calls to generate fresh entropy. e.g. the `Endpoint::handle` function is frequently called but we'd only need the rng when handling a new incoming connection.

Fixes an unrelated lint error.

Closes #1684 