### PR TITLE
feat: use mutable transmits to AsyncUdpSocket::poll_send

### DIFF
--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -490,7 +490,7 @@ impl State {
                 break Ok(true);
             }
 
-            match self.socket.poll_send(cx, self.outgoing.as_slices().0) {
+            match self.socket.poll_send(cx, self.outgoing.as_mut_slices().0) {
                 Poll::Ready(Ok(n)) => {
                     let contents_len: usize =
                         self.outgoing.drain(..n).map(|t| t.contents.len()).sum();

--- a/quinn/src/runtime.rs
+++ b/quinn/src/runtime.rs
@@ -33,8 +33,11 @@ pub trait AsyncTimer: Send + Debug + 'static {
 pub trait AsyncUdpSocket: Send + Sync + Debug + 'static {
     /// Send UDP datagrams from `transmits`, or register to be woken if sending may succeed in the
     /// future
-    fn poll_send(&self, cx: &mut Context, transmits: &[Transmit])
-        -> Poll<Result<usize, io::Error>>;
+    fn poll_send(
+        &self,
+        cx: &mut Context,
+        transmits: &mut [Transmit],
+    ) -> Poll<Result<usize, io::Error>>;
 
     /// Receive UDP datagrams, or register to be woken if receiving may succeed in the future
     fn poll_recv(

--- a/quinn/src/runtime/async_std.rs
+++ b/quinn/src/runtime/async_std.rs
@@ -49,7 +49,11 @@ struct UdpSocket {
 }
 
 impl AsyncUdpSocket for UdpSocket {
-    fn poll_send(&self, cx: &mut Context, transmits: &[udp::Transmit]) -> Poll<io::Result<usize>> {
+    fn poll_send(
+        &self,
+        cx: &mut Context,
+        transmits: &mut [udp::Transmit],
+    ) -> Poll<io::Result<usize>> {
         loop {
             ready!(self.io.poll_writable(cx))?;
             if let Ok(res) = self.inner.send((&self.io).into(), transmits) {

--- a/quinn/src/runtime/tokio.rs
+++ b/quinn/src/runtime/tokio.rs
@@ -51,7 +51,11 @@ struct UdpSocket {
 }
 
 impl AsyncUdpSocket for UdpSocket {
-    fn poll_send(&self, cx: &mut Context, transmits: &[udp::Transmit]) -> Poll<io::Result<usize>> {
+    fn poll_send(
+        &self,
+        cx: &mut Context,
+        transmits: &mut [udp::Transmit],
+    ) -> Poll<io::Result<usize>> {
         let inner = &self.inner;
         let io = &self.io;
         loop {


### PR DESCRIPTION
In our implementation (n0-computer/iroh) we currently have to maniuplate the destination addresses based on internal mappings. Currently we need to copy the full `Transmit` slice in order to update these addresses. To avoid this copy, this changes it such that a mutable reference is passed in.