### PR TITLE
Yield protocol violation for packets without frames

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2192,7 +2192,7 @@ impl Connection {
                 return Ok(());
             }
             State::Closed(_) => {
-                for result in frame::Iter::new(packet.payload.freeze()) {
+                for result in frame::Iter::new(packet.payload.freeze())? {
                     let frame = match result {
                         Ok(frame) => frame,
                         Err(err) => {
@@ -2441,7 +2441,7 @@ impl Connection {
         debug_assert_ne!(packet.header.space(), SpaceId::Data);
         let payload_len = packet.payload.len();
         let mut ack_eliciting = false;
-        for result in frame::Iter::new(packet.payload.freeze()) {
+        for result in frame::Iter::new(packet.payload.freeze())? {
             let frame = result?;
             let span = match frame {
                 Frame::Padding => continue,
@@ -2499,7 +2499,7 @@ impl Connection {
         let mut close = None;
         let payload_len = payload.len();
         let mut ack_eliciting = false;
-        for result in frame::Iter::new(payload) {
+        for result in frame::Iter::new(payload)? {
             let frame = result?;
             let span = match frame {
                 Frame::Padding => continue,

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -526,29 +526,6 @@ pub(crate) struct Iter {
     last_ty: Option<Type>,
 }
 
-enum IterErr {
-    UnexpectedEnd,
-    InvalidFrameId,
-    Malformed,
-}
-
-impl IterErr {
-    fn reason(&self) -> &'static str {
-        use self::IterErr::*;
-        match *self {
-            UnexpectedEnd => "unexpected end",
-            InvalidFrameId => "invalid frame ID",
-            Malformed => "malformed",
-        }
-    }
-}
-
-impl From<UnexpectedEnd> for IterErr {
-    fn from(_: UnexpectedEnd) -> Self {
-        Self::UnexpectedEnd
-    }
-}
-
 impl Iter {
     pub(crate) fn new(payload: Bytes) -> Result<Self, TransportError> {
         if payload.is_empty() {
@@ -784,6 +761,29 @@ fn scan_ack_blocks(buf: &mut io::Cursor<Bytes>, largest: u64, n: usize) -> Resul
         smallest = smallest.checked_sub(block).ok_or(IterErr::Malformed)?;
     }
     Ok(())
+}
+
+enum IterErr {
+    UnexpectedEnd,
+    InvalidFrameId,
+    Malformed,
+}
+
+impl IterErr {
+    fn reason(&self) -> &'static str {
+        use self::IterErr::*;
+        match *self {
+            UnexpectedEnd => "unexpected end",
+            InvalidFrameId => "invalid frame ID",
+            Malformed => "malformed",
+        }
+    }
+}
+
+impl From<UnexpectedEnd> for IterErr {
+    fn from(_: UnexpectedEnd) -> Self {
+        Self::UnexpectedEnd
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -2257,6 +2257,7 @@ fn single_ack_eliciting_packet_triggers_ack_after_delay() {
     // The ACK delay is properly calculated
     assert_eq!(pair.client.captured_packets.len(), 1);
     let mut frames = frame::Iter::new(pair.client.captured_packets.remove(0).into())
+        .unwrap()
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
     assert_eq!(frames.len(), 1);

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -344,10 +344,7 @@ impl TestEndpoint {
                             self.captured_packets.extend(packet);
                         }
 
-                        self.conn_events
-                            .entry(ch)
-                            .or_insert_with(VecDeque::new)
-                            .push_back(event);
+                        self.conn_events.entry(ch).or_default().push_back(event);
                     }
                     DatagramEvent::Response(transmit) => {
                         self.outbound.extend(split_transmit(transmit));

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -490,7 +490,7 @@ impl Connection {
     ///
     /// The dynamic type returned is determined by the configured
     /// [`Session`](proto::crypto::Session). For the default `rustls` session, the return value can
-    /// be [`downcast`](Box::downcast) to a <code>Vec<[rustls::Certificate](rustls::Certificate)></code>
+    /// be [`downcast`](Box::downcast) to a <code>Vec<[rustls::Certificate]></code>
     pub fn peer_identity(&self) -> Option<Box<dyn Any>> {
         self.0
             .state


### PR DESCRIPTION
Received a private bug report from @QUICTester. Thanks!

This should probably have a test, which I don't have energy for right now. @Ralith any suggestion for where such a test should live?

I don't love that this equates "no frames" to "empty payload" which feels like a potential conceptual jump, but the for-loop formulation makes the alternative a decent bit more verbose...