### PR TITLE
ensure LICENSE files are present in all published crates

### DIFF
--- a/quinn-proto/LICENSE-APACHE
+++ b/quinn-proto/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/quinn-proto/LICENSE-MIT
+++ b/quinn-proto/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/quinn-udp/LICENSE-APACHE
+++ b/quinn-udp/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/quinn-udp/LICENSE-MIT
+++ b/quinn-udp/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/quinn/LICENSE-APACHE
+++ b/quinn/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/quinn/LICENSE-MIT
+++ b/quinn/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
This PR adds symbolic links for the `LICENSE-APACHE` and `LICENSE-MIT` files into the `quinn`, `quinn-proto`, and `quinn-udp` workspace members so that `cargo package` / `cargo publish` picks them up and includes them when publishing crates.

Both the Apache-2.0 and the MIT license requires that (re)distributed sources contain a copy of the license text. Not including the license text is a problem, especially for Linux distributions that package this crate as a dependency, for example, for the HTTP/3 support in the `reqwest` crate.

I have not added a symlink into workspace members that have `publish = false` set in their cargo metadata.