### PR TITLE
fix: don't fail when `finish` is called on a stopped stream

### DIFF
--- a/quinn-proto/src/connection/streams/send.rs
+++ b/quinn-proto/src/connection/streams/send.rs
@@ -37,16 +37,19 @@ impl Send {
 
     pub(super) fn finish(&mut self) -> Result<(), FinishError> {
         if let Some(error_code) = self.stop_reason {
-            Err(FinishError::Stopped(error_code))
-        } else if self.state == SendState::Ready {
+            return Err(FinishError::Stopped(error_code))
+        }
+
+        if self.state == SendState::Ready {
             self.state = SendState::DataSent {
                 finish_acked: false,
             };
             self.fin_pending = true;
-            Ok(())
-        } else {
-            Err(FinishError::UnknownStream)
+
+            return Ok(())
         }
+
+        Err(FinishError::UnknownStream)
     }
 
     pub(super) fn write<S: BytesSource>(

--- a/quinn-proto/src/connection/streams/send.rs
+++ b/quinn-proto/src/connection/streams/send.rs
@@ -42,7 +42,7 @@ impl Send {
             if self.pending.is_fully_acked() {
                 // All data we sent was already acked
 
-                tracing::debug!(%error_code, "Stream is already stopped");
+                tracing::debug!(%error_code, "Stream is already stopped, unable to send `FIN`");
                 self.state = SendState::DataSent {
                     finish_acked: true, // Pretend that the remote acked the `FIN`. Actually trying to send it would fail because the remote has stopped the stream already.
                 };

--- a/quinn-proto/src/connection/streams/send.rs
+++ b/quinn-proto/src/connection/streams/send.rs
@@ -47,10 +47,10 @@ impl Send {
                     finish_acked: true, // Pretend that the remote acked the `FIN`. Actually trying to send it would fail because the remote has stopped the stream already.
                 };
 
-                return Ok(())
+                return Ok(());
             }
 
-            return Err(FinishError::Stopped(error_code))
+            return Err(FinishError::Stopped(error_code));
         }
 
         if self.state == SendState::Ready {
@@ -59,7 +59,7 @@ impl Send {
             };
             self.fin_pending = true;
 
-            return Ok(())
+            return Ok(());
         }
 
         Err(FinishError::UnknownStream)

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -241,7 +241,7 @@ fn endpoint_with_config(transport_config: TransportConfig) -> Endpoint {
         server_config,
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
     )
-        .unwrap();
+    .unwrap();
     let mut client_config = ClientConfig::with_root_certificates(roots);
     client_config.transport_config(transport_config);
     endpoint.set_default_client_config(client_config);
@@ -452,7 +452,7 @@ fn run_echo(args: EchoArgs) {
                 server_sock,
                 Arc::new(TokioRuntime),
             )
-                .unwrap()
+            .unwrap()
         };
 
         let mut roots = rustls::RootCertStore::empty();
@@ -527,7 +527,7 @@ fn run_echo(args: EchoArgs) {
                 new_conn.close(0u32.into(), b"done");
                 client.wait_idle().await;
             }
-                .instrument(error_span!("client")),
+            .instrument(error_span!("client")),
         );
         handle
     };
@@ -639,7 +639,7 @@ async fn rebind_recv() {
         server_config,
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
     )
-        .unwrap();
+    .unwrap();
     let server_addr = server.local_addr().unwrap();
 
     const MSG: &[u8; 5] = b"hello";
@@ -751,9 +751,13 @@ async fn finish_finished_stream_no_error() {
     let endpoint = endpoint();
 
     let (client, server) = tokio::join!(
-        async { endpoint
-            .connect(endpoint.local_addr().unwrap(), "localhost")
-            .unwrap().await.unwrap() },
+        async {
+            endpoint
+                .connect(endpoint.local_addr().unwrap(), "localhost")
+                .unwrap()
+                .await
+                .unwrap()
+        },
         async { endpoint.accept().await.unwrap().await.unwrap() }
     );
 


### PR DESCRIPTION
At the moment, calling `finish` on a stream that has been stopped by the remote fails. This can lead to weird race conditions in application protocols. I added a test that showcases this. Depending on where you place the `send_stream.finish` in the client, the test either succeeds or fails. In other words, if the `recv_stream` at the opposite side is still alive, calling `finish` will work but if it is not, `finish` will fail.

In a real-world setting, we cannot influence how fast the remote is in processing your data and / or when they drop (i.e. stop) the stream. I think `quinn` should not fail `finish` if the other party has already stopped the stream. Instead, we should assume that they've read all the data they expected and thus no longer need the stream.

Unfortunately, the only workaround for this issue is to not call `finish` at all. Whilst that may fine for some usecases, I'd argue that it is not very clean and `finish` should in fact be idempotent.

To fix this issue, we check whether we all data we sent has been acknowledged and in that case, exit `finish` gracefully, pretending that the remote acked our `FIN`.