### PR TITLE
Backport to 0.10.x: Downgrade duplicate packet message to debug level

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-proto"
-version = "0.10.5"
+version = "0.10.6"
 edition = "2021"
 rust-version = "1.63"
 license = "MIT OR Apache-2.0"

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2040,7 +2040,7 @@ impl Connection {
 
                 let is_duplicate = |n| self.spaces[packet.header.space()].dedup.insert(n);
                 if number.map_or(false, is_duplicate) {
-                    warn!("discarding possible duplicate packet");
+                    debug!("discarding possible duplicate packet");
                     return;
                 } else if self.state.is_handshake() && packet.header.is_short() {
                     // TODO: SHOULD buffer these to improve reordering tolerance.


### PR DESCRIPTION
The same as https://github.com/quinn-rs/quinn/pull/1705 + version bump