### PR TITLE
Run FreeBSD workflow on Ubuntu

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
   # see https://github.com/actions/runner/issues/385
   # use https://github.com/vmactions/freebsd-vm for now
     name: test on freebsd
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: test on freebsd


### PR DESCRIPTION
As recommended in [release notes](https://github.com/vmactions/freebsd-vm/releases/tag/v1.0.0) for v1 of the Action.