### PR TITLE
Transmit directly from connection tasks

### DIFF
--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use thiserror::Error;
 use tracing::{debug, trace};
 
@@ -141,7 +141,7 @@ impl DatagramState {
         Ok(was_empty)
     }
 
-    pub(super) fn write(&mut self, buf: &mut BytesMut, max_size: usize) -> bool {
+    pub(super) fn write(&mut self, buf: &mut Vec<u8>, max_size: usize) -> bool {
         let datagram = match self.outgoing.pop_front() {
             Some(x) => x,
             None => return false,

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -463,7 +463,7 @@ impl Connection {
         &mut self,
         now: Instant,
         max_datagrams: usize,
-        buf: &mut BytesMut,
+        buf: &mut Vec<u8>,
     ) -> Option<Transmit> {
         assert!(max_datagrams != 0);
         let max_datagrams = match self.config.enable_segmentation_offload {
@@ -2958,7 +2958,7 @@ impl Connection {
         &mut self,
         now: Instant,
         space_id: SpaceId,
-        buf: &mut BytesMut,
+        buf: &mut Vec<u8>,
         max_size: usize,
         pn: u64,
     ) -> SentFrames {
@@ -3183,7 +3183,7 @@ impl Connection {
         receiving_ecn: bool,
         sent: &mut SentFrames,
         space: &mut PacketSpace,
-        buf: &mut BytesMut,
+        buf: &mut Vec<u8>,
         stats: &mut ConnectionStats,
     ) {
         debug_assert!(!space.pending_acks.ranges().is_empty());

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use rand::Rng;
 use tracing::{trace, trace_span};
 
@@ -36,7 +36,7 @@ impl PacketBuilder {
     pub(super) fn new(
         now: Instant,
         space_id: SpaceId,
-        buffer: &mut BytesMut,
+        buffer: &mut Vec<u8>,
         buffer_capacity: usize,
         datagram_start: usize,
         ack_eliciting: bool,
@@ -178,7 +178,7 @@ impl PacketBuilder {
         now: Instant,
         conn: &mut Connection,
         sent: Option<SentFrames>,
-        buffer: &mut BytesMut,
+        buffer: &mut Vec<u8>,
     ) {
         let ack_eliciting = self.ack_eliciting;
         let exact_number = self.exact_number;
@@ -221,7 +221,7 @@ impl PacketBuilder {
     }
 
     /// Encrypt packet, returning the length of the packet and whether padding was added
-    pub(super) fn finish(self, conn: &mut Connection, buffer: &mut BytesMut) -> (usize, bool) {
+    pub(super) fn finish(self, conn: &mut Connection, buffer: &mut Vec<u8>) -> (usize, bool) {
         let pad = buffer.len() < self.min_size;
         if pad {
             trace!("PADDING * {}", self.min_size - buffer.len());

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -4,7 +4,7 @@ use std::{
     mem,
 };
 
-use bytes::{BufMut, BytesMut};
+use bytes::BufMut;
 use rustc_hash::FxHashMap;
 use tracing::{debug, trace};
 
@@ -363,7 +363,7 @@ impl StreamsState {
 
     pub(in crate::connection) fn write_control_frames(
         &mut self,
-        buf: &mut BytesMut,
+        buf: &mut Vec<u8>,
         pending: &mut Retransmits,
         retransmits: &mut ThinRetransmits,
         stats: &mut FrameStats,
@@ -489,7 +489,7 @@ impl StreamsState {
 
     pub(crate) fn write_stream_frames(
         &mut self,
-        buf: &mut BytesMut,
+        buf: &mut Vec<u8>,
         max_buf_size: usize,
     ) -> StreamMetaVec {
         let mut stream_frames = StreamMetaVec::new();
@@ -897,7 +897,7 @@ mod tests {
         connection::State as ConnState, connection::Streams, ReadableError, RecvStream, SendStream,
         TransportErrorCode, WriteError,
     };
-    use bytes::{Bytes, BytesMut};
+    use bytes::Bytes;
 
     fn make(side: Side) -> StreamsState {
         StreamsState::new(
@@ -1289,7 +1289,7 @@ mod tests {
         high.set_priority(1).unwrap();
         high.write(b"high").unwrap();
 
-        let mut buf = BytesMut::with_capacity(40);
+        let mut buf = Vec::with_capacity(40);
         let meta = server.write_stream_frames(&mut buf, 40);
         assert_eq!(meta[0].id, id_high);
         assert_eq!(meta[1].id, id_mid);
@@ -1348,7 +1348,7 @@ mod tests {
         };
         high.set_priority(-1).unwrap();
 
-        let mut buf = BytesMut::with_capacity(1000);
+        let mut buf = Vec::with_capacity(1000);
         let meta = server.write_stream_frames(&mut buf, 40);
         assert_eq!(meta.len(), 1);
         assert_eq!(meta[0].id, id_high);

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -4,7 +4,7 @@ use std::{
     ops::{Range, RangeInclusive},
 };
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes};
 use tinyvec::TinyVec;
 
 use crate::{
@@ -892,7 +892,7 @@ impl FrameStruct for Datagram {
 }
 
 impl Datagram {
-    pub(crate) fn encode(&self, length: bool, out: &mut BytesMut) {
+    pub(crate) fn encode(&self, length: bool, out: &mut Vec<u8>) {
         out.write(Type(*DATAGRAM_TYS.start() | u64::from(length))); // 1 byte
         if length {
             // Safe to unwrap because we check length sanity before queueing datagrams

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -278,7 +278,7 @@ pub(crate) enum Header {
 }
 
 impl Header {
-    pub(crate) fn encode(&self, w: &mut BytesMut) -> PartialEncode {
+    pub(crate) fn encode(&self, w: &mut Vec<u8>) -> PartialEncode {
         use self::Header::*;
         let start = w.len();
         match *self {
@@ -878,7 +878,7 @@ mod tests {
 
         let suite = initial_suite_from_provider(&std::sync::Arc::new(provider)).unwrap();
         let client = initial_keys(Version::V1, &dcid, Side::Client, &suite);
-        let mut buf = BytesMut::new();
+        let mut buf = Vec::new();
         let header = Header::Initial(InitialHeader {
             number: PacketNumber::U8(0),
             src_cid: ConnectionId::new(&[]),
@@ -909,7 +909,7 @@ mod tests {
 
         let server = initial_keys(Version::V1, &dcid, Side::Server, &suite);
         let supported_versions = DEFAULT_SUPPORTED_VERSIONS.to_vec();
-        let decode = PartialDecode::new(buf, 0, &supported_versions, false)
+        let decode = PartialDecode::new(buf.as_slice().into(), 0, &supported_versions, false)
             .unwrap()
             .0;
         let mut packet = decode.finish(Some(&*server.header.remote)).unwrap();

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use assert_matches::assert_matches;
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use hex_literal::hex;
 use rand::RngCore;
 use ring::hmac;
@@ -39,7 +39,7 @@ fn version_negotiate_server() {
         None,
     );
     let now = Instant::now();
-    let mut buf = BytesMut::with_capacity(server.config().get_max_udp_payload_size() as usize);
+    let mut buf = Vec::with_capacity(server.config().get_max_udp_payload_size() as usize);
     let event = server.handle(
         now,
         client_addr,
@@ -81,7 +81,7 @@ fn version_negotiate_client() {
         .connect(Instant::now(), client_config(), server_addr, "localhost")
         .unwrap();
     let now = Instant::now();
-    let mut buf = BytesMut::with_capacity(client.config().get_max_udp_payload_size() as usize);
+    let mut buf = Vec::with_capacity(client.config().get_max_udp_payload_size() as usize);
     let opt_event = client.handle(
         now,
         server_addr,
@@ -253,7 +253,7 @@ fn stateless_reset_limit() {
         None,
     );
     let time = Instant::now();
-    let mut buf = BytesMut::new();
+    let mut buf = Vec::new();
     let event = endpoint.handle(time, remote, None, None, [0u8; 1024][..].into(), &mut buf);
     assert!(matches!(event, Some(DatagramEvent::Response(_))));
     let event = endpoint.handle(time, remote, None, None, [0u8; 1024][..].into(), &mut buf);
@@ -2026,7 +2026,7 @@ fn malformed_token_len() {
         true,
         None,
     );
-    let mut buf = BytesMut::with_capacity(server.config().get_max_udp_payload_size() as usize);
+    let mut buf = Vec::with_capacity(server.config().get_max_udp_payload_size() as usize);
     server.handle(
         Instant::now(),
         client_addr,

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -667,7 +667,7 @@ fn split_transmit(transmit: Transmit, mut buffer: Bytes) -> Vec<(Transmit, Bytes
         transmits.push((
             Transmit {
                 destination: transmit.destination,
-                size: buffer.len(),
+                size: contents.len(),
                 ecn: transmit.ecn,
                 segment_size: None,
                 src_ip: transmit.src_ip,

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -22,7 +22,6 @@ log = ["tracing/log"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-bytes = "1"
 libc = "0.2.113"
 socket2 = "0.5"
 tracing = "0.1.10"

--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -24,9 +24,9 @@ impl UdpSocketState {
         })
     }
 
-    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit) -> io::Result<()> {
+    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
         let Err(e) = socket.0.send_to(
-            &transmit.contents,
+            transmit.contents,
             &socket2::SockAddr::from(transmit.destination),
         ) else {
             return Ok(());

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -37,7 +37,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use bytes::Bytes;
 use tracing::warn;
 
 #[cfg(any(unix, windows))]
@@ -103,13 +102,13 @@ impl Default for RecvMeta {
 
 /// An outgoing packet
 #[derive(Debug, Clone)]
-pub struct Transmit {
+pub struct Transmit<'a> {
     /// The socket this datagram should be sent to
     pub destination: SocketAddr,
     /// Explicit congestion notification bits to set on the packet
     pub ecn: Option<EcnCodepoint>,
     /// Contents of the datagram
-    pub contents: Bytes,
+    pub contents: &'a [u8],
     /// The segment size if this transmission contains multiple datagrams.
     /// This is `None` if the transmit only contains a single datagram
     pub segment_size: Option<usize>,

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -156,7 +156,7 @@ impl UdpSocketState {
         })
     }
 
-    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit) -> io::Result<()> {
+    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
         send(self, socket.0, transmit)
     }
 
@@ -213,7 +213,7 @@ fn send(
     #[allow(unused_variables)] // only used on Linux
     state: &UdpSocketState,
     io: SockRef<'_>,
-    transmit: &Transmit,
+    transmit: &Transmit<'_>,
 ) -> io::Result<()> {
     #[allow(unused_mut)] // only mutable on FreeBSD
     let mut encode_src_ip = true;
@@ -294,7 +294,7 @@ fn send(
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-fn send(state: &UdpSocketState, io: SockRef<'_>, transmit: &Transmit) -> io::Result<()> {
+fn send(state: &UdpSocketState, io: SockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
     let mut hdr: libc::msghdr = unsafe { mem::zeroed() };
     let mut iov: libc::iovec = unsafe { mem::zeroed() };
     let mut ctrl = cmsg::Aligned([0u8; CMSG_LEN]);
@@ -467,7 +467,7 @@ unsafe fn recvmmsg_fallback(
 const CMSG_LEN: usize = 88;
 
 fn prepare_msg(
-    transmit: &Transmit,
+    transmit: &Transmit<'_>,
     dst_addr: &socket2::SockAddr,
     hdr: &mut libc::msghdr,
     iov: &mut libc::iovec,

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -122,7 +122,7 @@ impl UdpSocketState {
         })
     }
 
-    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit) -> io::Result<()> {
+    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
         // we cannot use [`socket2::sendmsg()`] and [`socket2::MsgHdr`] as we do not have access
         // to the inner field which holds the WSAMSG
         let mut ctrl_buf = cmsg::Aligned([0; CMSG_LEN]);

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -122,122 +122,109 @@ impl UdpSocketState {
         })
     }
 
-    pub fn send(&self, socket: UdpSockRef<'_>, transmits: &[Transmit]) -> io::Result<usize> {
-        let mut sent = 0;
-        for transmit in transmits {
-            // we cannot use [`socket2::sendmsg()`] and [`socket2::MsgHdr`] as we do not have access
-            // to the inner field which holds the WSAMSG
-            let mut ctrl_buf = cmsg::Aligned([0; CMSG_LEN]);
-            let daddr = socket2::SockAddr::from(transmit.destination);
+    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit) -> io::Result<()> {
+        // we cannot use [`socket2::sendmsg()`] and [`socket2::MsgHdr`] as we do not have access
+        // to the inner field which holds the WSAMSG
+        let mut ctrl_buf = cmsg::Aligned([0; CMSG_LEN]);
+        let daddr = socket2::SockAddr::from(transmit.destination);
 
-            let mut data = WinSock::WSABUF {
-                buf: transmit.contents.as_ptr() as *mut _,
-                len: transmit.contents.len() as _,
-            };
+        let mut data = WinSock::WSABUF {
+            buf: transmit.contents.as_ptr() as *mut _,
+            len: transmit.contents.len() as _,
+        };
 
-            let ctrl = WinSock::WSABUF {
-                buf: ctrl_buf.0.as_mut_ptr(),
-                len: ctrl_buf.0.len() as _,
-            };
+        let ctrl = WinSock::WSABUF {
+            buf: ctrl_buf.0.as_mut_ptr(),
+            len: ctrl_buf.0.len() as _,
+        };
 
-            let mut wsa_msg = WinSock::WSAMSG {
-                name: daddr.as_ptr() as *mut _,
-                namelen: daddr.len(),
-                lpBuffers: &mut data,
-                Control: ctrl,
-                dwBufferCount: 1,
-                dwFlags: 0,
-            };
+        let mut wsa_msg = WinSock::WSAMSG {
+            name: daddr.as_ptr() as *mut _,
+            namelen: daddr.len(),
+            lpBuffers: &mut data,
+            Control: ctrl,
+            dwBufferCount: 1,
+            dwFlags: 0,
+        };
 
-            // Add control messages (ECN and PKTINFO)
-            let mut encoder = unsafe { cmsg::Encoder::new(&mut wsa_msg) };
+        // Add control messages (ECN and PKTINFO)
+        let mut encoder = unsafe { cmsg::Encoder::new(&mut wsa_msg) };
 
-            if let Some(ip) = transmit.src_ip {
-                let ip = std::net::SocketAddr::new(ip, 0);
-                let ip = socket2::SockAddr::from(ip);
-                match ip.family() {
-                    WinSock::AF_INET => {
-                        let src_ip =
-                            unsafe { ptr::read(ip.as_ptr() as *const WinSock::SOCKADDR_IN) };
-                        let pktinfo = WinSock::IN_PKTINFO {
-                            ipi_addr: src_ip.sin_addr,
-                            ipi_ifindex: 0,
-                        };
-                        encoder.push(WinSock::IPPROTO_IP, WinSock::IP_PKTINFO, pktinfo);
-                    }
-                    WinSock::AF_INET6 => {
-                        let src_ip =
-                            unsafe { ptr::read(ip.as_ptr() as *const WinSock::SOCKADDR_IN6) };
-                        let pktinfo = WinSock::IN6_PKTINFO {
-                            ipi6_addr: src_ip.sin6_addr,
-                            ipi6_ifindex: unsafe { src_ip.Anonymous.sin6_scope_id },
-                        };
-                        encoder.push(WinSock::IPPROTO_IPV6, WinSock::IPV6_PKTINFO, pktinfo);
-                    }
-                    _ => {
-                        return Err(io::Error::from(io::ErrorKind::InvalidInput));
-                    }
+        if let Some(ip) = transmit.src_ip {
+            let ip = std::net::SocketAddr::new(ip, 0);
+            let ip = socket2::SockAddr::from(ip);
+            match ip.family() {
+                WinSock::AF_INET => {
+                    let src_ip = unsafe { ptr::read(ip.as_ptr() as *const WinSock::SOCKADDR_IN) };
+                    let pktinfo = WinSock::IN_PKTINFO {
+                        ipi_addr: src_ip.sin_addr,
+                        ipi_ifindex: 0,
+                    };
+                    encoder.push(WinSock::IPPROTO_IP, WinSock::IP_PKTINFO, pktinfo);
                 }
-            }
-
-            // ECN is a C integer https://learn.microsoft.com/en-us/windows/win32/winsock/winsock-ecn
-            let ecn = transmit.ecn.map_or(0, |x| x as c_int);
-            // True for IPv4 or IPv4-Mapped IPv6
-            let is_ipv4 = transmit.destination.is_ipv4()
-                || matches!(transmit.destination.ip(), IpAddr::V6(addr) if addr.to_ipv4_mapped().is_some());
-            if is_ipv4 {
-                encoder.push(WinSock::IPPROTO_IP, WinSock::IP_ECN, ecn);
-            } else {
-                encoder.push(WinSock::IPPROTO_IPV6, WinSock::IPV6_ECN, ecn);
-            }
-
-            // Segment size is a u32 https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-wsasetudpsendmessagesize
-            if let Some(segment_size) = transmit.segment_size {
-                encoder.push(
-                    WinSock::IPPROTO_UDP,
-                    WinSock::UDP_SEND_MSG_SIZE,
-                    segment_size as u32,
-                );
-            }
-
-            encoder.finish();
-
-            let mut len = 0;
-            let rc = unsafe {
-                WinSock::WSASendMsg(
-                    socket.0.as_raw_socket() as usize,
-                    &wsa_msg,
-                    0,
-                    &mut len,
-                    ptr::null_mut(),
-                    None,
-                )
-            };
-
-            if rc == 0 {
-                sent += 1;
-            } else if sent != 0 {
-                // We need to report that some packets were sent in this case, so we rely on
-                // errors being either harmlessly transient (in the case of WouldBlock) or
-                // recurring on the next call.
-                return Ok(sent);
-            } else {
-                let e = io::Error::last_os_error();
-                if e.kind() == io::ErrorKind::WouldBlock {
-                    return Err(e);
+                WinSock::AF_INET6 => {
+                    let src_ip = unsafe { ptr::read(ip.as_ptr() as *const WinSock::SOCKADDR_IN6) };
+                    let pktinfo = WinSock::IN6_PKTINFO {
+                        ipi6_addr: src_ip.sin6_addr,
+                        ipi6_ifindex: unsafe { src_ip.Anonymous.sin6_scope_id },
+                    };
+                    encoder.push(WinSock::IPPROTO_IPV6, WinSock::IPV6_PKTINFO, pktinfo);
                 }
-
-                // Other errors are ignored, since they will usually be handled
-                // by higher level retransmits and timeouts.
-                // - PermissionDenied errors have been observed due to iptable rules.
-                //   Those are not fatal errors, since the
-                //   configuration can be dynamically changed.
-                // - Destination unreachable errors have been observed for other
-                log_sendmsg_error(&self.last_send_error, e, transmit);
-                sent += 1;
+                _ => {
+                    return Err(io::Error::from(io::ErrorKind::InvalidInput));
+                }
             }
         }
-        Ok(sent)
+
+        // ECN is a C integer https://learn.microsoft.com/en-us/windows/win32/winsock/winsock-ecn
+        let ecn = transmit.ecn.map_or(0, |x| x as c_int);
+        // True for IPv4 or IPv4-Mapped IPv6
+        let is_ipv4 = transmit.destination.is_ipv4()
+            || matches!(transmit.destination.ip(), IpAddr::V6(addr) if addr.to_ipv4_mapped().is_some());
+        if is_ipv4 {
+            encoder.push(WinSock::IPPROTO_IP, WinSock::IP_ECN, ecn);
+        } else {
+            encoder.push(WinSock::IPPROTO_IPV6, WinSock::IPV6_ECN, ecn);
+        }
+
+        // Segment size is a u32 https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-wsasetudpsendmessagesize
+        if let Some(segment_size) = transmit.segment_size {
+            encoder.push(
+                WinSock::IPPROTO_UDP,
+                WinSock::UDP_SEND_MSG_SIZE,
+                segment_size as u32,
+            );
+        }
+
+        encoder.finish();
+
+        let mut len = 0;
+        let rc = unsafe {
+            WinSock::WSASendMsg(
+                socket.0.as_raw_socket() as usize,
+                &wsa_msg,
+                0,
+                &mut len,
+                ptr::null_mut(),
+                None,
+            )
+        };
+
+        if rc != 0 {
+            let e = io::Error::last_os_error();
+            if e.kind() == io::ErrorKind::WouldBlock {
+                return Err(e);
+            }
+
+            // Other errors are ignored, since they will usually be handled
+            // by higher level retransmits and timeouts.
+            // - PermissionDenied errors have been observed due to iptable rules.
+            //   Those are not fatal errors, since the
+            //   configuration can be dynamically changed.
+            // - Destination unreachable errors have been observed for other
+            log_sendmsg_error(&self.last_send_error, e, transmit);
+        }
+        Ok(())
     }
 
     pub fn recv(

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -164,9 +164,7 @@ fn test_send_recv(send: &Socket, recv: &Socket, transmit: Transmit) {
     // Reverse non-blocking flag set by `UdpSocketState` to make the test non-racy
     recv.set_nonblocking(false).unwrap();
 
-    send_state
-        .send((&send).into(), slice::from_ref(&transmit))
-        .unwrap();
+    send_state.send(send.into(), &transmit).unwrap();
 
     let mut buf = [0; u16::MAX as usize];
     let mut meta = RecvMeta::default();

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -4,7 +4,6 @@ use std::{
     slice,
 };
 
-use bytes::Bytes;
 use quinn_udp::{EcnCodepoint, RecvMeta, Transmit, UdpSocketState};
 use socket2::Socket;
 
@@ -23,7 +22,7 @@ fn basic() {
         Transmit {
             destination: dst_addr,
             ecn: None,
-            contents: Bytes::from_static(b"hello"),
+            contents: b"hello",
             segment_size: None,
             src_ip: None,
         },
@@ -63,7 +62,7 @@ fn ecn_v6() {
                 Transmit {
                     destination: dst,
                     ecn: Some(codepoint),
-                    contents: Bytes::from_static(b"hello"),
+                    contents: b"hello",
                     segment_size: None,
                     src_ip: None,
                 },
@@ -83,7 +82,7 @@ fn ecn_v4() {
             Transmit {
                 destination: recv.local_addr().unwrap().as_socket().unwrap(),
                 ecn: Some(codepoint),
-                contents: Bytes::from_static(b"hello"),
+                contents: b"hello",
                 segment_size: None,
                 src_ip: None,
             },
@@ -121,7 +120,7 @@ fn ecn_v4_mapped_v6() {
             Transmit {
                 destination: recv_v4_mapped_v6,
                 ecn: Some(codepoint),
-                contents: Bytes::from_static(b"hello"),
+                contents: b"hello",
                 segment_size: None,
                 src_ip: None,
             },
@@ -150,7 +149,7 @@ fn gso() {
         Transmit {
             destination: dst_addr,
             ecn: None,
-            contents: Bytes::copy_from_slice(&msg),
+            contents: &msg,
             segment_size: Some(SEGMENT_SIZE),
             src_ip: None,
         },

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -9,10 +9,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::runtime::{AsyncTimer, AsyncUdpSocket, Runtime};
 use bytes::{Bytes, BytesMut};
 use pin_project_lite::pin_project;
-use proto::{ConnectionError, ConnectionHandle, ConnectionStats, Dir, StreamEvent, StreamId};
 use rustc_hash::FxHashMap;
 use thiserror::Error;
 use tokio::sync::{futures::Notified, mpsc, oneshot, Notify};
@@ -21,10 +19,14 @@ use tracing::{debug_span, Instrument, Span};
 use crate::{
     mutex::Mutex,
     recv_stream::RecvStream,
+    runtime::{AsyncTimer, AsyncUdpSocket, Runtime},
     send_stream::{SendStream, WriteError},
     ConnectionEvent, EndpointEvent, VarInt,
 };
-use proto::congestion::Controller;
+use proto::{
+    congestion::Controller, ConnectionError, ConnectionHandle, ConnectionStats, Dir, StreamEvent,
+    StreamId,
+};
 
 /// In-progress connection attempt future
 #[derive(Debug)]

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -10,7 +10,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use pin_project_lite::pin_project;
 use rustc_hash::FxHashMap;
 use thiserror::Error;
@@ -863,7 +863,7 @@ impl ConnectionRef {
                 io_poller: socket.clone().create_io_poller(),
                 socket,
                 runtime,
-                send_buffer: BytesMut::new(),
+                send_buffer: Vec::new(),
                 buffered_transmit: None,
             }),
             shared: Shared::default(),
@@ -945,7 +945,7 @@ pub(crate) struct State {
     socket: Arc<dyn AsyncUdpSocket>,
     io_poller: Pin<Box<dyn UdpPoller>>,
     runtime: Arc<dyn Runtime>,
-    send_buffer: BytesMut,
+    send_buffer: Vec<u8>,
     /// We buffer a transmit when the underlying I/O would block
     buffered_transmit: Option<proto::Transmit>,
 }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -985,8 +985,8 @@ impl State {
                 return Ok(false);
             }
 
-            let retry = match self.socket.try_send(std::slice::from_ref(&t)) {
-                Ok(n) => n == 0,
+            let retry = match self.socket.try_send(&t) {
+                Ok(()) => false,
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => true,
                 Err(e) => return Err(e),
             };

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -986,7 +986,8 @@ impl State {
     ) -> Result<(), ConnectionError> {
         loop {
             match self.conn_events.poll_recv(cx) {
-                Poll::Ready(Some(ConnectionEvent::LocalAddressChanged)) => {
+                Poll::Ready(Some(ConnectionEvent::Rebind(socket))) => {
+                    self.socket = socket;
                     self.inner.local_address_changed();
                 }
                 Poll::Ready(Some(ConnectionEvent::Proto(event))) => {

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -514,11 +514,8 @@ fn respond(transmit: proto::Transmit, response_buffer: &mut BytesMut, socket: &d
     // to transmit. This is morally equivalent to the packet getting
     // lost due to congestion further along the link, which
     // similarly relies on peer retries for recovery.
-    let contents_len = transmit.size;
-    _ = socket.try_send(&udp_transmit(
-        transmit,
-        response_buffer.split_to(contents_len).freeze(),
-    ));
+    _ = socket.try_send(&udp_transmit(&transmit, &response_buffer[..transmit.size]));
+    response_buffer.clear();
 }
 
 #[inline]

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -12,7 +12,10 @@ use std::{
     time::Instant,
 };
 
-use crate::runtime::{default_runtime, AsyncUdpSocket, Runtime};
+use crate::{
+    runtime::{default_runtime, AsyncUdpSocket, Runtime},
+    udp_transmit,
+};
 use bytes::{Bytes, BytesMut};
 use pin_project_lite::pin_project;
 use proto::{
@@ -576,26 +579,6 @@ impl TransmitState {
 
     fn transmits(&self) -> &[udp::Transmit] {
         self.outgoing.as_slices().0
-    }
-}
-
-#[inline]
-fn udp_transmit(t: proto::Transmit, buffer: Bytes) -> udp::Transmit {
-    udp::Transmit {
-        destination: t.destination,
-        ecn: t.ecn.map(udp_ecn),
-        contents: buffer,
-        segment_size: t.segment_size,
-        src_ip: t.src_ip,
-    }
-}
-
-#[inline]
-fn udp_ecn(ecn: proto::EcnCodepoint) -> udp::EcnCodepoint {
-    match ecn {
-        proto::EcnCodepoint::Ect0 => udp::EcnCodepoint::Ect0,
-        proto::EcnCodepoint::Ect1 => udp::EcnCodepoint::Ect1,
-        proto::EcnCodepoint::Ce => udp::EcnCodepoint::Ce,
     }
 }
 

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -227,10 +227,10 @@ impl Endpoint {
         inner.io_poller = inner.socket.clone().create_io_poller();
         inner.ipv6 = addr.is_ipv6();
 
-        // Generate some activity so peers notice the rebind
+        // Update connection socket references
         for sender in inner.recv_state.connections.senders.values() {
             // Ignoring errors from dropped connections
-            let _ = sender.send(ConnectionEvent::LocalAddressChanged);
+            let _ = sender.send(ConnectionEvent::Rebind(inner.socket.clone()));
         }
 
         Ok(())

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -515,10 +515,10 @@ fn respond(transmit: proto::Transmit, response_buffer: &mut BytesMut, socket: &d
     // lost due to congestion further along the link, which
     // similarly relies on peer retries for recovery.
     let contents_len = transmit.size;
-    _ = socket.try_send(&[udp_transmit(
+    _ = socket.try_send(&udp_transmit(
         transmit,
         response_buffer.split_to(contents_len).freeze(),
-    )]);
+    ));
 }
 
 #[inline]

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -533,7 +533,6 @@ impl State {
                                 .send(ConnectionEvent::Proto(event));
                         }
                     }
-                    Transmit(t, buf) => self.transmit_state.enqueue(t, buf),
                 },
                 Poll::Ready(None) => unreachable!("EndpointInner owns one sender"),
                 Poll::Pending => {
@@ -568,12 +567,6 @@ impl TransmitState {
             transmit,
             response_buffer.split_to(contents_len).freeze(),
         ));
-        self.contents_len = self.contents_len.saturating_add(contents_len);
-    }
-
-    fn enqueue(&mut self, t: proto::Transmit, buf: Bytes) {
-        let contents_len = buf.len();
-        self.outgoing.push_back(udp_transmit(t, buf));
         self.contents_len = self.contents_len.saturating_add(contents_len);
     }
 

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -61,7 +61,6 @@ mod runtime;
 mod send_stream;
 mod work_limiter;
 
-use bytes::Bytes;
 pub use proto::{
     congestion, crypto, AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ConfigError,
     ConnectError, ConnectionClose, ConnectionError, EndpointConfig, IdleTimeout,
@@ -100,7 +99,7 @@ enum ConnectionEvent {
     Rebind(Arc<dyn AsyncUdpSocket>),
 }
 
-fn udp_transmit(t: proto::Transmit, buffer: Bytes) -> udp::Transmit {
+fn udp_transmit<'a>(t: &proto::Transmit, buffer: &'a [u8]) -> udp::Transmit<'a> {
     udp::Transmit {
         destination: t.destination,
         ecn: t.ecn.map(udp_ecn),

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -41,7 +41,7 @@
 #![warn(unreachable_pub)]
 #![warn(clippy::use_self)]
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 macro_rules! ready {
     ($e:expr $(,)?) => {
@@ -96,8 +96,8 @@ enum ConnectionEvent {
         error_code: VarInt,
         reason: bytes::Bytes,
     },
-    LocalAddressChanged,
     Proto(proto::ConnectionEvent),
+    Rebind(Arc<dyn AsyncUdpSocket>),
 }
 
 #[derive(Debug)]

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -84,7 +84,7 @@ pub use crate::runtime::AsyncStdRuntime;
 pub use crate::runtime::SmolRuntime;
 #[cfg(feature = "runtime-tokio")]
 pub use crate::runtime::TokioRuntime;
-pub use crate::runtime::{default_runtime, AsyncTimer, AsyncUdpSocket, Runtime};
+pub use crate::runtime::{default_runtime, AsyncTimer, AsyncUdpSocket, Runtime, UdpPoller};
 pub use crate::send_stream::{SendStream, StoppedError, WriteError};
 
 #[cfg(test)]

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -132,14 +132,6 @@ const IO_LOOP_BOUND: usize = 160;
 /// batch of size 32 was observed to take 30us on some systems.
 const RECV_TIME_BOUND: Duration = Duration::from_micros(50);
 
-/// The maximum amount of time that should be spent in `sendmsg()` calls per endpoint iteration
-const SEND_TIME_BOUND: Duration = Duration::from_micros(50);
-
-/// The maximum size of content length of packets in the outgoing transmit queue. Transmit packets
-/// generated from the endpoint (retry or initial close) can be dropped when this limit is being execeeded.
-/// Chose to represent 100 MB of data.
-const MAX_TRANSMIT_QUEUE_CONTENTS_LEN: usize = 100_000_000;
-
 /// The maximum number of `IncomingConnection`s we allow to be enqueued at a time before we start
 /// rejecting new `IncomingConnection`s automatically. Assuming each `IncomingConnection` accounts
 /// for little over 1200 bytes of memory maximum, this should limit an endpoint's incoming

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -106,6 +106,24 @@ enum EndpointEvent {
     Transmit(proto::Transmit, Bytes),
 }
 
+fn udp_transmit(t: proto::Transmit, buffer: Bytes) -> udp::Transmit {
+    udp::Transmit {
+        destination: t.destination,
+        ecn: t.ecn.map(udp_ecn),
+        contents: buffer,
+        segment_size: t.segment_size,
+        src_ip: t.src_ip,
+    }
+}
+
+fn udp_ecn(ecn: proto::EcnCodepoint) -> udp::EcnCodepoint {
+    match ecn {
+        proto::EcnCodepoint::Ect0 => udp::EcnCodepoint::Ect0,
+        proto::EcnCodepoint::Ect1 => udp::EcnCodepoint::Ect1,
+        proto::EcnCodepoint::Ce => udp::EcnCodepoint::Ce,
+    }
+}
+
 /// Maximum number of datagrams processed in send/recv calls to make before moving on to other processing
 ///
 /// This helps ensure we don't starve anything when the CPU is slower than the link.

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -100,11 +100,6 @@ enum ConnectionEvent {
     Rebind(Arc<dyn AsyncUdpSocket>),
 }
 
-#[derive(Debug)]
-enum EndpointEvent {
-    Proto(proto::EndpointEvent),
-}
-
 fn udp_transmit(t: proto::Transmit, buffer: Bytes) -> udp::Transmit {
     udp::Transmit {
         destination: t.destination,

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -103,7 +103,6 @@ enum ConnectionEvent {
 #[derive(Debug)]
 enum EndpointEvent {
     Proto(proto::EndpointEvent),
-    Transmit(proto::Transmit, Bytes),
 }
 
 fn udp_transmit(t: proto::Transmit, buffer: Bytes) -> udp::Transmit {

--- a/quinn/src/runtime.rs
+++ b/quinn/src/runtime.rs
@@ -47,7 +47,7 @@ pub trait AsyncUdpSocket: Send + Sync + Debug + 'static {
     ///
     /// If this returns [`io::ErrorKind::WouldBlock`], [`UdpPoller::poll_writable`] must be called
     /// to register the calling task to be woken when a send should be attempted again.
-    fn try_send(&self, transmits: &[Transmit]) -> Result<usize, io::Error>;
+    fn try_send(&self, transmit: &Transmit) -> io::Result<()>;
 
     /// Receive UDP datagrams, or register to be woken if receiving may succeed in the future
     fn poll_recv(

--- a/quinn/src/runtime.rs
+++ b/quinn/src/runtime.rs
@@ -31,10 +31,23 @@ pub trait AsyncTimer: Send + Debug + 'static {
 
 /// Abstract implementation of a UDP socket for runtime independence
 pub trait AsyncUdpSocket: Send + Sync + Debug + 'static {
-    /// Send UDP datagrams from `transmits`, or register to be woken if sending may succeed in the
-    /// future
-    fn poll_send(&self, cx: &mut Context, transmits: &[Transmit])
-        -> Poll<Result<usize, io::Error>>;
+    /// Create a [`UdpPoller`] that can register a single task for write-readiness notifications
+    ///
+    /// A `poll_send` method on a single object can usually store only one [`Waker`] at a time,
+    /// i.e. allow at most one caller to wait for an event. This method allows any number of
+    /// interested tasks to construct their own [`UdpPoller`] object. They can all then wait for the
+    /// same event and be notified concurrently, because each [`UdpPoller`] can store a separate
+    /// [`Waker`].
+    ///
+    /// [`Waker`]: std::task::Waker
+    fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn UdpPoller>>;
+
+    /// Send UDP datagrams from `transmits`, or return `WouldBlock` and clear the underlying
+    /// socket's readiness, or return an I/O error
+    ///
+    /// If this returns [`io::ErrorKind::WouldBlock`], [`UdpPoller::poll_writable`] must be called
+    /// to register the calling task to be woken when a send should be attempted again.
+    fn try_send(&self, transmits: &[Transmit]) -> Result<usize, io::Error>;
 
     /// Receive UDP datagrams, or register to be woken if receiving may succeed in the future
     fn poll_recv(
@@ -63,6 +76,72 @@ pub trait AsyncUdpSocket: Send + Sync + Debug + 'static {
     /// option.
     fn may_fragment(&self) -> bool {
         true
+    }
+}
+
+/// An object polled to detect when an associated [`AsyncUdpSocket`] is writable
+///
+/// Any number of `UdpPoller`s may exist for a single [`AsyncUdpSocket`]. Each `UdpPoller` is
+/// responsible for notifying at most one task when that socket becomes writable.
+pub trait UdpPoller: Send + Sync + Debug + 'static {
+    /// Check whether the associated socket is likely to be writable
+    ///
+    /// Must be called after [`AsyncUdpSocket::try_send`] returns [`io::ErrorKind::WouldBlock`] to
+    /// register the task associated with `cx` to be woken when a send should be attempted
+    /// again. Unlike in [`Future::poll`], a [`UdpPoller`] may be reused indefinitely no matter how
+    /// many times `poll_writable` returns [`Poll::Ready`].
+    fn poll_writable(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>>;
+}
+
+pin_project_lite::pin_project! {
+    /// Helper adapting a function `MakeFut` that constructs a single-use future `Fut` into a
+    /// [`UdpPoller`] that may be reused indefinitely
+    struct UdpPollHelper<MakeFut, Fut> {
+        make_fut: MakeFut,
+        #[pin]
+        fut: Option<Fut>,
+    }
+}
+
+impl<MakeFut, Fut> UdpPollHelper<MakeFut, Fut> {
+    /// Construct a [`UdpPoller`] that calls `make_fut` to get the future to poll, storing it until
+    /// it yields [`Poll::Ready`], then creating a new one on the next
+    /// [`poll_writable`](UdpPoller::poll_writable)
+    fn new(make_fut: MakeFut) -> Self {
+        Self {
+            make_fut,
+            fut: None,
+        }
+    }
+}
+
+impl<MakeFut, Fut> UdpPoller for UdpPollHelper<MakeFut, Fut>
+where
+    MakeFut: Fn() -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = io::Result<()>> + Send + Sync + 'static,
+{
+    fn poll_writable(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        let mut this = self.project();
+        if this.fut.is_none() {
+            this.fut.set(Some((this.make_fut)()));
+        }
+        // We're forced to `unwrap` here because `Fut` may be `!Unpin`, which means we can't safely
+        // obtain an `&mut Fut` after storing it in `self.fut` when `self` is already behind `Pin`,
+        // and if we didn't store it then we wouldn't be able to keep it alive between
+        // `poll_writable` calls.
+        let result = this.fut.as_mut().as_pin_mut().unwrap().poll(cx);
+        if result.is_ready() {
+            // Polling an arbitrary `Future` after it becomes ready is a logic error, so arrange for
+            // a new `Future` to be created on the next call.
+            this.fut.set(None);
+        }
+        result
+    }
+}
+
+impl<MakeFut, Fut> Debug for UdpPollHelper<MakeFut, Fut> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UdpPollHelper").finish_non_exhaustive()
     }
 }
 

--- a/quinn/src/runtime/async_io.rs
+++ b/quinn/src/runtime/async_io.rs
@@ -102,8 +102,8 @@ impl AsyncUdpSocket for UdpSocket {
         }))
     }
 
-    fn try_send(&self, transmits: &[udp::Transmit]) -> io::Result<usize> {
-        self.inner.send((&self.io).into(), transmits)
+    fn try_send(&self, transmit: &udp::Transmit) -> io::Result<()> {
+        self.inner.send((&self.io).into(), transmit)
     }
 
     fn poll_recv(

--- a/quinn/src/runtime/tokio.rs
+++ b/quinn/src/runtime/tokio.rs
@@ -58,9 +58,9 @@ impl AsyncUdpSocket for UdpSocket {
         }))
     }
 
-    fn try_send(&self, transmits: &[udp::Transmit]) -> io::Result<usize> {
+    fn try_send(&self, transmit: &udp::Transmit) -> io::Result<()> {
         self.io.try_io(Interest::WRITABLE, || {
-            self.inner.send((&self.io).into(), transmits)
+            self.inner.send((&self.io).into(), transmit)
         })
     }
 

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -683,11 +683,14 @@ async fn rebind_recv() {
 
     let server_config =
         crate::ServerConfig::with_single_cert(vec![cert.clone()], key.into()).unwrap();
-    let server = Endpoint::server(
-        server_config,
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
-    )
-    .unwrap();
+    let server = {
+        let _guard = tracing::error_span!("server").entered();
+        Endpoint::server(
+            server_config,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+        )
+        .unwrap()
+    };
     let server_addr = server.local_addr().unwrap();
 
     const MSG: &[u8; 5] = b"hello";
@@ -706,11 +709,14 @@ async fn rebind_recv() {
         stream.finish().await.unwrap();
     });
 
-    let connection = client
-        .connect(server_addr, "localhost")
-        .unwrap()
-        .await
-        .unwrap();
+    let connection = {
+        let _guard = tracing::error_span!("client").entered();
+        client
+            .connect(server_addr, "localhost")
+            .unwrap()
+            .await
+            .unwrap()
+    };
     info!("connected");
     connected_recv.notified().await;
     client


### PR DESCRIPTION
This allows outgoing data to parallelize perfectly. Initial informal testing suggests a performance improvement for bulk data, likely due to reduced allocation and cross-task messaging. A larger performance benefit should be expected for endpoints hosting numerous connections.

I'd left the original userspace-multiplexed transmit strategy in place for a long time because I assumed the UDP socket had a mutex-guarded send buffer, so leaning into task-parallelism for sending would just lead to contention. This turns out to be complete nonsense, at least on Linux: outgoing UDP datagrams are buffered by the kernel with dynamically allocated memory, and the primitive NIC queuing operation is apparently scalable, as borne out by empirical testing. The following minimal test scales almost linearly with physical parallelism on Linux:

```rs
use std::{
    net::{SocketAddr, UdpSocket},
    thread,
    time::Instant,
};

fn main() {
    let sock = UdpSocket::bind("[::]:0").unwrap();
    let target: SocketAddr = "[::1]:1234".parse().unwrap();
    let start = Instant::now();
    const DATAGRAMS: usize = 1_000_000;
    thread::scope(|scope| {
        let threads = thread::available_parallelism().unwrap().get();
        dbg!(threads);
        let each = DATAGRAMS / threads;
        let sock = &sock;
        for _ in 0..threads {
            scope.spawn(move || {
                for _ in 0..each {
                    sock.send_to(b"hello, world", target).unwrap();
                }
            });
        }
    });
    let seconds = start.elapsed().as_secs_f32();
    println!("{} pps", DATAGRAMS as f32 / seconds);
}
```

It'd be interesting to see how this compares on other major platforms, but Linux's drastic improvement and the simplification of Quinn's internals are enough to satisfy me that we should go this way.