### PR TITLE
Replace rustls-native-certs with rustls-platform-verifier

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -19,8 +19,8 @@ maintenance = { status = "experimental" }
 [features]
 default = ["tls-rustls", "log"]
 tls-rustls = ["rustls", "ring"]
-# Provides `ClientConfig::with_native_roots()` convenience method
-native-certs = ["rustls-native-certs"]
+# Provides `ClientConfig::with_platform_verifier()` convenience method
+platform-verifier = ["rustls-platform-verifier"]
 # Write logs via the `log` crate when no `tracing` subscriber exists
 log = ["tracing/log"]
 
@@ -31,7 +31,7 @@ rustc-hash = "1.1"
 rand = "0.8"
 ring = { version = "0.16.7", optional = true }
 rustls = { version = "0.21.0", default-features = false, features = ["quic"], optional = true }
-rustls-native-certs = { version = "0.6", optional = true }
+rustls-platform-verifier = { version = "0.1.1", optional = true }
 slab = "0.4"
 thiserror = "1.0.21"
 tinyvec = { version = "1.1", features = ["alloc"] }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -15,11 +15,11 @@ rust-version = "1.65"
 all-features = true
 
 [features]
-default = ["native-certs", "tls-rustls", "runtime-tokio", "log"]
+default = ["platform-verifier", "tls-rustls", "runtime-tokio", "log"]
 # Records how long locks are held, and warns if they are held >= 1ms
 lock_tracking = []
-# Provides `ClientConfig::with_native_roots()` convenience method
-native-certs = ["proto/native-certs"]
+# Provides `ClientConfig::with_platform_verifier()` convenience method
+platform-verifier = ["proto/platform-verifier"]
 tls-rustls = ["rustls", "proto/tls-rustls", "ring"]
 # Enables `Endpoint::client` and `Endpoint::server` conveniences
 ring = ["proto/ring"]


### PR DESCRIPTION
rustls-platform-verifier doesn't seem to support rustls 0.22 yet, so we might want to hold off on this in the hopes of not complicating #1715. Still, long-term, this seems like a safer default to promote.