### PR TITLE
udp: use io::Result<> where possible

### DIFF
--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -31,7 +31,7 @@ impl UdpSocketState {
         socket: UdpSockRef<'_>,
         _state: &UdpState,
         transmits: &[Transmit],
-    ) -> Result<usize, io::Error> {
+    ) -> io::Result<usize> {
         let mut sent = 0;
         for transmit in transmits {
             match socket.0.send_to(

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -150,7 +150,7 @@ impl UdpSocketState {
         })
     }
 
-    pub fn send(&self, socket: UdpSockRef<'_>, transmits: &[Transmit]) -> Result<usize, io::Error> {
+    pub fn send(&self, socket: UdpSockRef<'_>, transmits: &[Transmit]) -> io::Result<usize> {
         send(self, socket.0, transmits)
     }
 
@@ -823,7 +823,7 @@ fn set_socket_option_supported(
     level: libc::c_int,
     name: libc::c_int,
     value: libc::c_int,
-) -> Result<bool, io::Error> {
+) -> io::Result<bool> {
     match set_socket_option(socket, level, name, value) {
         Ok(()) => Ok(true),
         Err(err) if err.raw_os_error() == Some(libc::ENOPROTOOPT) => Ok(false),
@@ -836,7 +836,7 @@ fn set_socket_option(
     level: libc::c_int,
     name: libc::c_int,
     value: libc::c_int,
-) -> Result<(), io::Error> {
+) -> io::Result<()> {
     let rc = unsafe {
         libc::setsockopt(
             socket.as_raw_fd(),

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -371,7 +371,7 @@ fn set_socket_option(
     level: i32,
     name: i32,
     value: u32,
-) -> Result<(), io::Error> {
+) -> io::Result<()> {
     let rc = unsafe {
         WinSock::setsockopt(
             socket.as_raw_socket() as usize,


### PR DESCRIPTION
Use `io::Result<>` in `quinn-udp` module. This was found as non blocking in #1701
