### PR TITLE
Send path validation responses to the correct remote

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -617,9 +617,10 @@ impl Connection {
                 // for starting another datagram. If there is any anti-amplification
                 // budget left, we always allow a full MTU to be sent
                 // (see https://github.com/quinn-rs/quinn/issues/1082)
-                if self.path.anti_amplification_blocked(
-                    self.path.current_mtu() as u64 * num_datagrams as u64 + 1,
-                ) {
+                if self
+                    .path
+                    .anti_amplification_blocked(self.path.current_mtu() as u64 * num_datagrams + 1)
+                {
                     trace!("blocked by anti-amplification");
                     break;
                 }
@@ -728,7 +729,7 @@ impl Connection {
                 space_id,
                 buf,
                 buf_capacity,
-                (num_datagrams - 1) * (self.path.current_mtu() as usize),
+                (num_datagrams as usize - 1) * (self.path.current_mtu() as usize),
                 ack_eliciting,
                 self,
                 self.version,
@@ -898,7 +899,7 @@ impl Connection {
         trace!("sending {} bytes in {} datagrams", buf.len(), num_datagrams);
         self.path.total_sent = self.path.total_sent.saturating_add(buf.len() as u64);
 
-        self.stats.udp_tx.on_sent(num_datagrams as u64, buf.len());
+        self.stats.udp_tx.on_sent(num_datagrams, buf.len());
 
         Some(Transmit {
             destination: self.path.remote,

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -57,8 +57,8 @@ mod packet_crypto;
 use packet_crypto::{PrevCrypto, ZeroRttCrypto};
 
 mod paths;
-use paths::PathData;
 pub use paths::RttEstimator;
+use paths::{PathData, PathResponse};
 
 mod send_buffer;
 
@@ -3610,12 +3610,6 @@ pub enum Event {
     Stream(StreamEvent),
     /// One or more application datagrams have been received
     DatagramReceived,
-}
-
-struct PathResponse {
-    /// The packet number the corresponding PATH_CHALLENGE was received in
-    packet: u64,
-    token: u64,
 }
 
 fn instant_saturating_sub(x: Instant, y: Instant) -> Duration {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -508,9 +508,7 @@ impl Connection {
                 builder.pad_to(MIN_INITIAL_SIZE);
 
                 builder.finish(self, buf);
-                self.stats.udp_tx.datagrams += 1;
-                self.stats.udp_tx.ios += 1;
-                self.stats.udp_tx.bytes += buf.len() as u64;
+                self.stats.udp_tx.on_sent(1, buf.len());
                 return Some(Transmit {
                     destination,
                     size: buf.len(),
@@ -900,9 +898,7 @@ impl Connection {
         trace!("sending {} bytes in {} datagrams", buf.len(), num_datagrams);
         self.path.total_sent = self.path.total_sent.saturating_add(buf.len() as u64);
 
-        self.stats.udp_tx.datagrams += num_datagrams as u64;
-        self.stats.udp_tx.bytes += buf.len() as u64;
-        self.stats.udp_tx.ios += 1;
+        self.stats.udp_tx.on_sent(num_datagrams as u64, buf.len());
 
         Some(Transmit {
             destination: self.path.remote,

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -165,8 +165,29 @@ impl RttEstimator {
     }
 }
 
-pub(crate) struct PathResponse {
+#[derive(Default)]
+pub(crate) struct PathResponses {
+    pending: Option<PathResponse>,
+}
+
+impl PathResponses {
+    pub(crate) fn push(&mut self, packet: u64, token: u64) {
+        if self.pending.as_ref().map_or(true, |x| x.packet <= packet) {
+            self.pending = Some(PathResponse { packet, token });
+        }
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<u64> {
+        Some(self.pending.take()?.token)
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.pending.is_none()
+    }
+}
+
+struct PathResponse {
     /// The packet number the corresponding PATH_CHALLENGE was received in
-    pub(crate) packet: u64,
-    pub(crate) token: u64,
+    packet: u64,
+    token: u64,
 }

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -1,5 +1,7 @@
 use std::{cmp, net::SocketAddr, time::Duration, time::Instant};
 
+use tracing::trace;
+
 use super::{mtud::MtuDiscovery, pacing::Pacer};
 use crate::{config::MtuDiscoveryConfig, congestion, packet::SpaceId, TIMER_GRANULARITY};
 
@@ -167,27 +169,67 @@ impl RttEstimator {
 
 #[derive(Default)]
 pub(crate) struct PathResponses {
-    pending: Option<PathResponse>,
+    pending: Vec<PathResponse>,
 }
 
 impl PathResponses {
-    pub(crate) fn push(&mut self, packet: u64, token: u64) {
-        if self.pending.as_ref().map_or(true, |x| x.packet <= packet) {
-            self.pending = Some(PathResponse { packet, token });
+    pub(crate) fn push(&mut self, packet: u64, token: u64, remote: SocketAddr) {
+        /// Arbitrary permissive limit to prevent abuse
+        const MAX_PATH_RESPONSES: usize = 16;
+        let response = PathResponse {
+            packet,
+            token,
+            remote,
+        };
+        let existing = self.pending.iter_mut().find(|x| x.remote == remote);
+        if let Some(existing) = existing {
+            // Update a queued response
+            if existing.packet <= packet {
+                *existing = response;
+            }
+            return;
+        }
+        if self.pending.len() < MAX_PATH_RESPONSES {
+            self.pending.push(response);
+        } else {
+            // We don't expect to ever hit this with well-behaved peers, so we don't bother dropping
+            // older challenges.
+            trace!("ignoring excessive PATH_CHALLENGE");
         }
     }
 
-    pub(crate) fn pop(&mut self) -> Option<u64> {
-        Some(self.pending.take()?.token)
+    pub(crate) fn pop_off_path(&mut self, remote: &SocketAddr) -> Option<(u64, SocketAddr)> {
+        let response = *self.pending.last()?;
+        if response.remote == *remote {
+            // We don't bother searching further because we expect that the on-path response will
+            // get drained in the immediate future by a call to `pop_on_path`
+            return None;
+        }
+        self.pending.pop();
+        Some((response.token, response.remote))
+    }
+
+    pub(crate) fn pop_on_path(&mut self, remote: &SocketAddr) -> Option<u64> {
+        let response = *self.pending.last()?;
+        if response.remote != *remote {
+            // We don't bother searching further because we expect that the off-path response will
+            // get drained in the immediate future by a call to `pop_off_path`
+            return None;
+        }
+        self.pending.pop();
+        Some(response.token)
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.pending.is_none()
+        self.pending.is_empty()
     }
 }
 
+#[derive(Copy, Clone)]
 struct PathResponse {
     /// The packet number the corresponding PATH_CHALLENGE was received in
     packet: u64,
     token: u64,
+    /// The address the corresponding PATH_CHALLENGE was received from
+    remote: SocketAddr,
 }

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -164,3 +164,9 @@ impl RttEstimator {
         }
     }
 }
+
+pub(crate) struct PathResponse {
+    /// The packet number the corresponding PATH_CHALLENGE was received in
+    pub(crate) packet: u64,
+    pub(crate) token: u64,
+}

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -17,6 +17,14 @@ pub struct UdpStats {
     pub ios: u64,
 }
 
+impl UdpStats {
+    pub(crate) fn on_sent(&mut self, datagrams: u64, bytes: usize) {
+        self.datagrams += datagrams;
+        self.bytes += bytes as u64;
+        self.ios += 1;
+    }
+}
+
 /// Number of frames transmitted of each frame type
 #[derive(Default, Copy, Clone)]
 #[non_exhaustive]


### PR DESCRIPTION
We previously always sent these on the active path, which undermines a peer's validation of the return direction of a candidate new path.