### PR TITLE
Upgrade ring to 0.17.7

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -29,7 +29,7 @@ arbitrary = { version = "1.0.1", features = ["derive"], optional = true }
 bytes = "1"
 rustc-hash = "1.1"
 rand = "0.8"
-ring = { version = "0.16.7", optional = true }
+ring = { version = "0.17.7", optional = true }
 rustls = { version = "0.21.0", default-features = false, features = ["quic"], optional = true }
 rustls-platform-verifier = { version = "0.1.1", optional = true }
 slab = "0.4"


### PR DESCRIPTION
ring 0.17.7 brings new platform support such as RISC-V and LoongArch, and is in line with rustls' ring version, thus avoiding multiple ring packages of different versions to be built.