### PR TITLE
Expose remote_cid() and local_cid() on quinn::Connection

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1228,6 +1228,16 @@ impl Connection {
         self.path.remote
     }
 
+    /// The remote handshake cid
+    pub fn remote_cid(&self) -> ConnectionId {
+        self.rem_handshake_cid
+    }
+
+    /// The local handshake cid
+    pub fn local_cid(&self) -> ConnectionId {
+        self.handshake_cid
+    }
+
     /// The local IP address which was used when the peer established
     /// the connection
     ///

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1229,12 +1229,17 @@ impl Connection {
     }
 
     /// The remote handshake cid
-    pub fn remote_cid(&self) -> ConnectionId {
+    pub fn remote_handshake_cid(&self) -> ConnectionId {
         self.rem_handshake_cid
     }
 
+    /// The remote original/initial cid
+    pub fn remote_original_cid(&self) -> ConnectionId {
+        self.orig_rem_cid
+    }
+
     /// The local handshake cid
-    pub fn local_cid(&self) -> ConnectionId {
+    pub fn local_handshake_cid(&self) -> ConnectionId {
         self.handshake_cid
     }
 

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -522,6 +522,16 @@ impl Connection {
         self.0.stable_id()
     }
 
+    /// The remote handshake cid
+    pub fn remote_cid(&self) -> proto::ConnectionId {
+        self.0.state.lock("remote_cid").inner.remote_cid()
+    }
+
+    /// The local handshake cid
+    pub fn local_cid(&self) -> proto::ConnectionId {
+        self.0.state.lock("local_cid").inner.local_cid()
+    }
+
     // Update traffic keys spontaneously for testing purposes.
     #[doc(hidden)]
     pub fn force_key_update(&self) {

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -523,13 +523,26 @@ impl Connection {
     }
 
     /// The remote handshake cid
-    pub fn remote_cid(&self) -> proto::ConnectionId {
-        self.0.state.lock("remote_cid").inner.remote_cid()
+    pub fn remote_handshake_cid(&self) -> proto::ConnectionId {
+        self.0
+            .state
+            .lock("remote_handshake_cid")
+            .inner
+            .remote_handshake_cid()
+    }
+
+    /// The remote original/initital cid
+    pub fn remote_original_cid(&self) -> proto::ConnectionId {
+        self.0
+            .state
+            .lock("remote_original_cid")
+            .inner
+            .remote_original_cid()
     }
 
     /// The local handshake cid
-    pub fn local_cid(&self) -> proto::ConnectionId {
-        self.0.state.lock("local_cid").inner.local_cid()
+    pub fn local_handshake_cid(&self) -> proto::ConnectionId {
+        self.0.state.lock("local_cid").inner.local_handshake_cid()
     }
 
     // Update traffic keys spontaneously for testing purposes.


### PR DESCRIPTION
This adds some functions to expose the local/remote CID on a connection handle.  This allows a server to extract CIDs that were generated by a quinn client with a custom ConnectionIdGenerator 