### PR TITLE
Don't double-count buffer consumption in close length checks

### DIFF
--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -18,7 +18,11 @@ pub(super) struct PacketBuilder {
     pub(super) ack_eliciting: bool,
     pub(super) exact_number: u64,
     pub(super) short_header: bool,
+    /// Smallest absolute position in the associated buffer that must be occupied by this packet's
+    /// frames
     pub(super) min_size: usize,
+    /// Largest absolute position in the associated buffer that may be occupied by this packet's
+    /// frames
     pub(super) max_size: usize,
     pub(super) tag_len: usize,
     pub(super) span: tracing::Span,
@@ -147,7 +151,7 @@ impl PacketBuilder {
             buffer.len() + (sample_size + 4).saturating_sub(number.len() + tag_len),
             partial_encode.start + conn.rem_cids.active().len() + 6,
         );
-        let max_size = buffer_capacity - partial_encode.start - partial_encode.header_len - tag_len;
+        let max_size = buffer_capacity - tag_len;
 
         Some(Self {
             datagram_start,


### PR DESCRIPTION
PacketBuilder::max_size previously subtracted out the start index and header size of the packet, and therefore described the admissible size of the packet's frames. However, most of our logic operates in terms of absolute buffer positions instead. This was confusing, and led to erroneous double-counting of space use in close packets.

Discovered while drafting #1767.