### PR TITLE
Make `quinn_proto::Connection` and `quinn_proto::Endpoint` impl `Sync`

### DIFF
--- a/quinn-proto/src/cid_generator.rs
+++ b/quinn-proto/src/cid_generator.rs
@@ -6,7 +6,7 @@ use crate::shared::ConnectionId;
 use crate::MAX_CID_SIZE;
 
 /// Generates connection IDs for incoming connections
-pub trait ConnectionIdGenerator: Send {
+pub trait ConnectionIdGenerator: Send + Sync {
     /// Generates a new CID
     ///
     /// Connection IDs MUST NOT contain any information that can be used by

--- a/quinn-proto/src/congestion.rs
+++ b/quinn-proto/src/congestion.rs
@@ -14,7 +14,7 @@ pub use cubic::{Cubic, CubicConfig};
 pub use new_reno::{NewReno, NewRenoConfig};
 
 /// Common interface for different congestion controllers
-pub trait Controller: Send {
+pub trait Controller: Send + Sync {
     /// One or more packets were just sent
     #[allow(unused_variables)]
     fn on_sent(&mut self, now: Instant, bytes: u64, last_packet_number: u64) {}

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -25,7 +25,7 @@ pub(crate) mod ring;
 pub mod rustls;
 
 /// A cryptographic session (commonly TLS)
-pub trait Session: Send + 'static {
+pub trait Session: Send + Sync + 'static {
     /// Create the initial set of keys given the client's initial destination ConnectionId
     fn initial_keys(&self, dst_cid: &ConnectionId, side: Side) -> Keys;
 
@@ -146,7 +146,7 @@ pub trait ServerConfig: Send + Sync {
 }
 
 /// Keys used to protect packet payloads
-pub trait PacketKey: Send {
+pub trait PacketKey: Send + Sync {
     /// Encrypt the packet payload with the given packet number
     fn encrypt(&self, packet: u64, buf: &mut [u8], header_len: usize);
     /// Decrypt the packet payload with the given packet number
@@ -166,7 +166,7 @@ pub trait PacketKey: Send {
 }
 
 /// Keys used to protect packet headers
-pub trait HeaderKey: Send {
+pub trait HeaderKey: Send + Sync {
     /// Decrypt the given packet's header
     fn decrypt(&self, pn_offset: usize, packet: &mut [u8]);
     /// Encrypt the given packet's header

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -2828,3 +2828,10 @@ fn reject_manually() {
         }) if close.error_code == TransportErrorCode::CONNECTION_REFUSED
     ));
 }
+
+#[test]
+fn endpoint_and_connection_impl_send_sync() {
+    const fn is_send_sync<T: Send + Sync>() {}
+    is_send_sync::<Endpoint>();
+    is_send_sync::<Connection>();
+}


### PR DESCRIPTION
The only things preventing these types from already being `Sync` were a lack of `Sync` bounds on trait objects they were storing, and a `RefCell` that was only being used to work around a limitation in the API of `BinaryHeap`.

Adding `Sync` bounds to the relevant traits was simple enough and didn't cause any warnings or errors, but to remove the `RefCell` it was necessary to rework the way that pending stream IDs were stored.

The specific motivation for this PR was so that I could store these types as components directly in the [Bevy ECS](https://bevyengine.org/), which requires component types be `Send + Sync` for multi-threaded system scheduling. The alternative would be to wrap the types in a `Mutex` or other synchronization primitive, but removing the limitation entirely seemed like the better option, given how the only non-trivial blocker was just a hacky workaround an API limitation.

The aforementioned rework to remove the `RefCell` also (IMO) simplifies the logic a fair bit, by utilizing the `BinaryHeap`'s sorting for both priority and fairness. Sorting for stream IDs with the same priority falls back to a `recency` counter, which is decremented each time that stream is processed. This causes the streams of the same priority to be 'cycled' through, in the same way that was achieved previously by popping from the front and pushing to the back of a `VecDeque` that has now been removed.  Technically the u64 could underflow and break the cycling, but that is highly unlikely to ever happen, due to the counter being initialized to `u64::MAX` and only being decremented by 1 at a time.