### PR TITLE
Use the correct MTU for prev_path

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -480,7 +480,7 @@ impl Connection {
                     SpaceId::Data,
                     "PATH_CHALLENGE queued without 1-RTT keys"
                 );
-                buf.reserve(self.path.current_mtu() as usize);
+                buf.reserve(MIN_INITIAL_SIZE as usize);
 
                 let buf_capacity = buf.capacity();
 


### PR DESCRIPTION
I've just bumped into this.  I'm not confident this is really a bug, but using the MTU of a different path seems a wrong thing to do. 
