### PR TITLE
Maintain in-flight counters separately per path

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3438,8 +3438,7 @@ impl Connection {
     fn remove_in_flight(&mut self, pn: u64, packet: &SentPacket) {
         // Visit known paths from newest to oldest to find the one `pn` was sent on
         for path in [&mut self.path].into_iter().chain(self.prev_path.as_mut()) {
-            if path.first_packet.map_or(false, |first| first <= pn) {
-                path.in_flight.remove(packet);
+            if path.remove_in_flight(pn, packet) {
                 return;
             }
         }

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -203,11 +203,8 @@ impl PacketBuilder {
             stream_frames: sent.stream_frames,
         };
 
-        conn.path.in_flight.insert(&packet);
-        if conn.path.first_packet.is_none() {
-            conn.path.first_packet = Some(exact_number);
-        }
-        conn.path.in_flight.bytes -= conn.spaces[space_id].sent(exact_number, packet);
+        conn.path
+            .sent(exact_number, packet, &mut conn.spaces[space_id]);
         conn.stats.path.sent_packets += 1;
         conn.reset_keep_alive(now);
         if size != 0 {

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -203,8 +203,11 @@ impl PacketBuilder {
             stream_frames: sent.stream_frames,
         };
 
-        conn.in_flight.insert(&packet);
-        conn.in_flight.bytes -= conn.spaces[space_id].sent(exact_number, packet);
+        conn.path.in_flight.insert(&packet);
+        if conn.path.first_packet.is_none() {
+            conn.path.first_packet = Some(exact_number);
+        }
+        conn.path.in_flight.bytes -= conn.spaces[space_id].sent(exact_number, packet);
         conn.stats.path.sent_packets += 1;
         conn.reset_keep_alive(now);
         if size != 0 {

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -2,7 +2,7 @@ use std::{cmp, net::SocketAddr, time::Duration, time::Instant};
 
 use tracing::trace;
 
-use super::{mtud::MtuDiscovery, pacing::Pacer};
+use super::{mtud::MtuDiscovery, pacing::Pacer, spaces::SentPacket};
 use crate::{config::MtuDiscoveryConfig, congestion, packet::SpaceId, TIMER_GRANULARITY};
 
 /// Description of a particular network path
@@ -32,6 +32,12 @@ pub(super) struct PathData {
     ///
     /// Used in persistent congestion determination.
     pub(super) first_packet_after_rtt_sample: Option<(SpaceId, u64)>,
+    pub(super) in_flight: InFlight,
+    /// Number of the first packet sent on this path
+    ///
+    /// Used to determine whether a packet was sent on an earlier path. Insufficient to determine if
+    /// a packet was sent on a later path.
+    pub(super) first_packet: Option<u64>,
 }
 
 impl PathData {
@@ -61,6 +67,8 @@ impl PathData {
                 MtuDiscovery::new(initial_mtu, min_mtu, peer_max_udp_payload_size, config)
             }),
             first_packet_after_rtt_sample: None,
+            in_flight: InFlight::new(),
+            first_packet: None,
         }
     }
 
@@ -80,6 +88,8 @@ impl PathData {
             total_recvd: 0,
             mtud: prev.mtud.clone(),
             first_packet_after_rtt_sample: prev.first_packet_after_rtt_sample,
+            in_flight: InFlight::new(),
+            first_packet: None,
         }
     }
 
@@ -232,4 +242,40 @@ struct PathResponse {
     token: u64,
     /// The address the corresponding PATH_CHALLENGE was received from
     remote: SocketAddr,
+}
+
+/// Summary statistics of packets that have been sent on a particular path, but which have not yet
+/// been acked or deemed lost
+pub(super) struct InFlight {
+    /// Sum of the sizes of all sent packets considered "in flight" by congestion control
+    ///
+    /// The size does not include IP or UDP overhead. Packets only containing ACK frames do not
+    /// count towards this to ensure congestion control does not impede congestion feedback.
+    pub(super) bytes: u64,
+    /// Number of packets in flight containing frames other than ACK and PADDING
+    ///
+    /// This can be 0 even when bytes is not 0 because PADDING frames cause a packet to be
+    /// considered "in flight" by congestion control. However, if this is nonzero, bytes will always
+    /// also be nonzero.
+    pub(super) ack_eliciting: u64,
+}
+
+impl InFlight {
+    pub(super) fn new() -> Self {
+        Self {
+            bytes: 0,
+            ack_eliciting: 0,
+        }
+    }
+
+    pub(super) fn insert(&mut self, packet: &SentPacket) {
+        self.bytes += u64::from(packet.size);
+        self.ack_eliciting += u64::from(packet.ack_eliciting);
+    }
+
+    /// Update counters to account for a packet becoming acknowledged, lost, or abandoned
+    pub(super) fn remove(&mut self, packet: &SentPacket) {
+        self.bytes -= u64::from(packet.size);
+        self.ack_eliciting -= u64::from(packet.ack_eliciting);
+    }
 }


### PR DESCRIPTION
Fixes #1775, theoretically. @nemethf can you confirm?

RFC9000 §9.4:

> The capacity available on the new path might not be the same as the old path. Packets sent on the old path MUST NOT contribute to congestion control or RTT estimation for the new path.

We accomplish this by tracking the first packet number on each path, which allows the logic that removes acked/lost packets from congestion control counters to determine which, if any, known path a packet was sent on.