### PR TITLE
Break linkability on client-side after planned migration

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2909,6 +2909,12 @@ impl Connection {
         );
     }
 
+    /// Handle a change in the local address, i.e. an active migration
+    pub fn local_address_changed(&mut self) {
+        self.update_rem_cid();
+        self.ping();
+    }
+
     /// Switch to a previously unused remote connection ID, if possible
     fn update_rem_cid(&mut self) {
         let (reset_token, retired) = match self.rem_cids.next() {

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -915,8 +915,8 @@ impl State {
     ) -> Result<(), ConnectionError> {
         loop {
             match self.conn_events.poll_recv(cx) {
-                Poll::Ready(Some(ConnectionEvent::Ping)) => {
-                    self.inner.ping();
+                Poll::Ready(Some(ConnectionEvent::LocalAddressChanged)) => {
+                    self.inner.local_address_changed();
                 }
                 Poll::Ready(Some(ConnectionEvent::Proto(event))) => {
                     self.inner.handle_event(event);

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -221,7 +221,7 @@ impl Endpoint {
         // Generate some activity so peers notice the rebind
         for sender in inner.connections.senders.values() {
             // Ignoring errors from dropped connections
-            let _ = sender.send(ConnectionEvent::Ping);
+            let _ = sender.send(ConnectionEvent::LocalAddressChanged);
         }
 
         Ok(())

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -96,8 +96,8 @@ enum ConnectionEvent {
         error_code: VarInt,
         reason: bytes::Bytes,
     },
+    LocalAddressChanged,
     Proto(proto::ConnectionEvent),
-    Ping,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
The server switches to a new CID as well, but it sends a path-challenge on the old path with the new CID.  So it is still possible to trace back the connection to the old path after the client switches to a new socket.