### PR TITLE
refactor(endpoint): use array::from_fn instead of unsafe MaybeUninit

### DIFF
--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -440,6 +440,9 @@ impl State {
                 .chunks_mut(self.recv_buf.len() / BATCH_SIZE)
                 .map(IoSliceMut::new);
 
+            // expect() safe as self.recv_buf is chunked into BATCH_SIZE items
+            // and iovs will be of size BATCH_SIZE, thus from_fn is called
+            // exactly BATCH_SIZE times.
             std::array::from_fn(|_| bufs.next().expect("BATCH_SIZE elements"))
         };
         loop {

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -431,7 +431,7 @@ pub(crate) struct Shared {
 }
 
 impl State {
-    fn drive_recv<'a>(&'a mut self, cx: &mut Context, now: Instant) -> Result<bool, io::Error> {
+    fn drive_recv(&mut self, cx: &mut Context, now: Instant) -> Result<bool, io::Error> {
         self.recv_limiter.start_cycle();
         let mut metas = [RecvMeta::default(); BATCH_SIZE];
         let mut iovs: [IoSliceMut; BATCH_SIZE] = {


### PR DESCRIPTION
With Rust 1.63.0 one can initialize a `std::array` via `std::array::from_fn`.

https://doc.rust-lang.org/std/array/fn.from_fn.html

Thus there is no need to start with an uninitialized array via `MaybeUninit`, initialize it and then use `unsafe` to `assume_init`. Instead one can initialize the array with the concrete elements right away.

---

Meta: `quinn-udp` has been very helpful in https://github.com/mozilla/neqo/pull/1741. Thanks!