### PR TITLE
Fix riscv64 compilation

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -29,7 +29,7 @@ arbitrary = { version = "1.0.1", features = ["derive"], optional = true }
 bytes = "1"
 rustc-hash = "1.1"
 rand = "0.8"
-ring = { version = "0.16.7", optional = true }
+ring = { version = "0.17.8", optional = true }
 rustls = { version = "0.21.0", default-features = false, features = ["quic"], optional = true }
 rustls-platform-verifier = { version = "0.1.1", optional = true }
 slab = "0.4"


### PR DESCRIPTION
Fix #1812

```
time cargo build --release
   Compiling ring v0.17.8
   Compiling tracing-attributes v0.1.27
   Compiling rustls v0.21.10
   Compiling thiserror-impl v1.0.58
   Compiling socket2 v0.5.6
   Compiling rustls-webpki v0.101.7
   Compiling sct v0.7.1
   Compiling tracing v0.1.40
   Compiling num-traits v0.2.18
   Compiling anstyle v1.0.6
   Compiling anstyle-query v1.0.2
   Compiling regex-syntax v0.6.29
   Compiling tinyvec_macros v0.1.1
   Compiling regex-syntax v0.8.3
   Compiling bytes v1.6.0
   Compiling colorchoice v1.0.0
   Compiling anstream v0.6.13
   Compiling regex-automata v0.4.6
   Compiling regex-automata v0.1.10
   Compiling tinyvec v1.6.0
   Compiling thiserror v1.0.58
   Compiling slab v0.4.9
   Compiling rand v0.8.5
   Compiling tokio-macros v2.2.0
   Compiling signal-hook-registry v1.4.1
   Compiling mio v0.8.11
   Compiling anyhow v1.0.81
   Compiling rustc-hash v1.1.0
   Compiling strsim v0.11.1
   Compiling overload v0.1.1
   Compiling clap_lex v0.7.0
   Compiling lazy_static v1.4.0
   Compiling heck v0.5.0
   Compiling sharded-slab v0.1.7
   Compiling clap_derive v4.5.4
   Compiling clap_builder v4.5.2
   Compiling nu-ansi-term v0.46.0
   Compiling tokio v1.37.0
   Compiling rustls-platform-verifier v0.1.1
   Compiling matchers v0.1.0
   Compiling regex v1.10.4
   Compiling quinn-proto v0.11.0 (/root/quinn/quinn-proto)
   Compiling quinn-udp v0.5.0 (/root/quinn/quinn-udp)
   Compiling yasna v0.5.2
   Compiling pem v3.0.3
   Compiling thread_local v1.1.8
   Compiling byteorder v1.5.0
   Compiling serde v1.0.197
   Compiling hdrhistogram v7.5.4
   Compiling tracing-subscriber v0.3.18
   Compiling rcgen v0.12.1
   Compiling quinn v0.11.0 (/root/quinn/quinn)
   Compiling clap v4.5.4
   Compiling serde_derive v1.0.197
   Compiling serde_json v1.0.115
   Compiling ryu v1.0.17
   Compiling bench v0.1.0 (/root/quinn/bench)
   Compiling perf v0.1.0 (/root/quinn/perf)
    Finished release [optimized + debuginfo] target(s) in 18m 02s
```