### PR TITLE
perf: change throughput units from MiB/s into Mb/s.

### DIFF
--- a/perf/src/stats.rs
+++ b/perf/src/stats.rs
@@ -95,13 +95,13 @@ impl Stats {
 
         let print_metric = |label: &'static str, get_metric: fn(&Histogram<u64>) -> u64| {
             println!(
-                " {} │ {:>15.2?} │ {:>17.2?} │  {:>9.2?} │ {:11.2} MiB/s │ {:13.2} MiB/s",
+                " {} │ {:>15.2?} │ {:>17.2?} │  {:>9.2?} │ {:12.2} Mb/s │ {:13.2} Mb/s",
                 label,
                 Duration::from_micros(get_metric(&self.upload_duration)),
                 Duration::from_micros(get_metric(&self.download_duration)),
                 Duration::from_micros(get_metric(&self.fbl)),
-                get_metric(&self.upload_throughput) as f64 / 1024.0 / 1024.0,
-                get_metric(&self.download_throughput) as f64 / 1024.0 / 1024.0,
+                get_metric(&self.upload_throughput) as f64 * 8.0 / 1000.0 / 1000.0,
+                get_metric(&self.download_throughput) as f64 * 8.0 / 1000.0 / 1000.0,
             );
         };
 


### PR DESCRIPTION
Use a more commonly used bandwidth unit in perf_client and perf_server.