### PR TITLE
end endpoint driver on manually close

### DIFF
--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -326,7 +326,8 @@ impl Future for EndpointDriver {
             self.0.shared.incoming.notify_waiters();
         }
 
-        if endpoint.ref_count == 0 && endpoint.connections.is_empty() {
+        let manually_closed = endpoint.connections.close.is_some();
+        if (manually_closed || endpoint.ref_count == 0) && endpoint.connections.is_empty() {
             Poll::Ready(Ok(()))
         } else {
             drop(endpoint);


### PR DESCRIPTION
When calling `quinn::Endpoint::close` the socket resources are not freed until all references to the endpoint are dropped. This makes it so that the socket is freed on close.

Any suggestions on the best way to test this are welcome