### PR TITLE
Refuse incoming/forbid outgoing connections after endpoint is closed

### DIFF
--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -180,7 +180,7 @@ impl Endpoint {
         server_name: &str,
     ) -> Result<Connecting, ConnectError> {
         let mut endpoint = self.inner.state.lock().unwrap();
-        if endpoint.driver_lost {
+        if endpoint.driver_lost || endpoint.connections.close.is_some() {
             return Err(ConnectError::EndpointStopping);
         }
         if addr.is_ipv6() && !endpoint.ipv6 {


### PR DESCRIPTION
`Endpoint::accept` can yield `None` after `Endpoint::close` is called and any previously pending `Incoming` connections are drained, so it's likely that the application's accept loop will terminate and not see any further `Incoming`s. This could lead to painful slow timeouts, so let's eagerly reject them instead.