### PR TITLE
ci: pass codecov token explicitly

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,5 +15,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true


### PR DESCRIPTION
This has been failing intermittently on main. Originally IIRC the token did not need to be passed for public repositories but this changed at some point in the past.