### PR TITLE
Remove badges from metadata

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -13,9 +13,6 @@ workspace = ".."
 [package.metadata.docs.rs]
 all-features = true
 
-[badges]
-maintenance = { status = "experimental" }
-
 [features]
 default = ["rustls", "log"]
 rustls = ["dep:rustls", "ring"]

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -18,9 +18,6 @@ default = ["log"]
 # Write logs via the `log` crate when no `tracing` subscriber exists
 log = ["tracing/log"]
 
-[badges]
-maintenance = { status = "experimental" }
-
 [dependencies]
 libc = "0.2.113"
 socket2 = "0.5"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -30,10 +30,6 @@ runtime-smol = ["async-io", "smol"]
 # Write logs via the `log` crate when no `tracing` subscriber exists
 log = ["tracing/log", "proto/log", "udp/log"]
 
-[badges]
-codecov = { repository = "djc/quinn" }
-maintenance = { status = "experimental" }
-
 [dependencies]
 async-io = { version = "2.0", optional = true }
 async-std = { version = "1.11", optional = true }


### PR DESCRIPTION
I don't think describing these as "experimental" makes sense, and badges are pretty much deprecated:

> Note: [crates.io](https://crates.io/) previously displayed badges next to a crate on its website, but that functionality has been removed. Packages should place badges in its README file which will be displayed on [crates.io](https://crates.io/) (see [the readme field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field)).

https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section