### PR TITLE
Match GSO segment size to the first datagram, not the MTU

### DIFF
--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -67,8 +67,11 @@ impl<'a> Datagrams<'a> {
     ///
     /// Not necessarily the maximum size of received datagrams.
     pub fn max_size(&self) -> Option<usize> {
+        // We use the conservative overhead bound for any packet number, reducing the budget by at
+        // most 3 bytes, so that PN size fluctuations don't cause users sending maximum-size
+        // datagrams to suffer avoidable packet loss.
         let max_size = self.conn.path.current_mtu() as usize
-            - self.conn.max_1rtt_overhead()
+            - self.conn.predict_1rtt_overhead(None)
             - Datagram::SIZE_BOUND;
         let limit = self
             .conn

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -166,6 +166,8 @@ impl PacketBuilder {
         })
     }
 
+    /// Append the minimum amount of padding such that, after encryption, the packet will occupy at
+    /// least `min_size` bytes
     pub(super) fn pad_to(&mut self, min_size: u16) {
         let prev = self.min_size;
         self.min_size = self.datagram_start + (min_size as usize) - self.tag_len;


### PR DESCRIPTION
Fixes #1832.

~Still working on~ how to handle the case where a datagram is queued but won't fit with the current segment size. We need to either detect this in advance and finish the GSO batch before beginning another packet, or gracefully abandon packet assembly after failing to fit any frames. ~Currently leaning towards the latter.~ This will need careful testing.

~Also still TODO: End the GSO batch early if the amount of padding in the current packet would be excessive.~