### PR TITLE
Make SendStream::finish synchronous

### DIFF
--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -138,7 +138,9 @@ pub async fn send_data_on_stream(stream: &mut quinn::SendStream, stream_size: u6
             .context("failed sending data")?;
     }
 
-    stream.finish().await.context("failed finishing stream")?;
+    stream.finish().unwrap();
+    // Wait for stream to close
+    _ = stream.stopped().await;
 
     Ok(())
 }

--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -302,7 +302,7 @@ async fn request(
     let upload_start = Instant::now();
     send.write_all(&download.to_be_bytes()).await?;
     if upload == 0 {
-        send.finish().await?;
+        send.finish().unwrap();
         return Ok(());
     }
 
@@ -317,7 +317,9 @@ async fn request(
         send_stream_stats.on_bytes(chunk_len as usize);
         upload -= chunk_len;
     }
-    send.finish().await?;
+    send.finish().unwrap();
+    // Wait for stream to close
+    _ = send.stopped().await;
     send_stream_stats.finish(upload_start.elapsed());
 
     debug!("upload finished on {}", send.id());

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -81,8 +81,8 @@ pub use streams::StreamsState;
 #[cfg(not(fuzzing))]
 use streams::StreamsState;
 pub use streams::{
-    BytesSource, Chunks, FinishError, ReadError, ReadableError, RecvStream, SendStream,
-    StreamEvent, Streams, UnknownStream, WriteError, Written,
+    BytesSource, Chunks, ClosedStream, FinishError, ReadError, ReadableError, RecvStream,
+    SendStream, StreamEvent, Streams, WriteError, Written,
 };
 
 mod timer;

--- a/quinn-proto/src/connection/streams/send.rs
+++ b/quinn-proto/src/connection/streams/send.rs
@@ -45,7 +45,7 @@ impl Send {
             self.fin_pending = true;
             Ok(())
         } else {
-            Err(FinishError::UnknownStream)
+            Err(FinishError::ClosedStream)
         }
     }
 
@@ -55,7 +55,7 @@ impl Send {
         limit: u64,
     ) -> Result<Written, WriteError> {
         if !self.is_writable() {
-            return Err(WriteError::UnknownStream);
+            return Err(WriteError::ClosedStream);
         }
         if let Some(error_code) = self.stop_reason {
             return Err(WriteError::Stopped(error_code));
@@ -274,8 +274,8 @@ pub enum WriteError {
     #[error("stopped by peer: code {0}")]
     Stopped(VarInt),
     /// The stream has not been opened or has already been finished or reset
-    #[error("unknown stream")]
-    UnknownStream,
+    #[error("closed stream")]
+    ClosedStream,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -300,8 +300,8 @@ pub enum FinishError {
     #[error("stopped by peer: code {0}")]
     Stopped(VarInt),
     /// The stream has not been opened or was already finished or reset
-    #[error("unknown stream")]
-    UnknownStream,
+    #[error("closed stream")]
+    ClosedStream,
 }
 
 #[cfg(test)]

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -1111,8 +1111,8 @@ mod tests {
         assert!(!recv.pending.max_data);
 
         assert!(recv.stop(0u32.into()).is_err());
-        assert_eq!(recv.read(true).err(), Some(ReadableError::UnknownStream));
-        assert_eq!(recv.read(false).err(), Some(ReadableError::UnknownStream));
+        assert_eq!(recv.read(true).err(), Some(ReadableError::ClosedStream));
+        assert_eq!(recv.read(false).err(), Some(ReadableError::ClosedStream));
 
         assert_eq!(client.local_max_data - initial_max, 32);
         assert_eq!(
@@ -1220,7 +1220,7 @@ mod tests {
         assert_eq!(stream.write(&[]), Err(WriteError::Stopped(error_code)));
 
         stream.reset(0u32.into()).unwrap();
-        assert_eq!(stream.write(&[]), Err(WriteError::UnknownStream));
+        assert_eq!(stream.write(&[]), Err(WriteError::ClosedStream));
 
         // A duplicate frame is a no-op
         stream.state.received_stop_sending(id, error_code);

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -42,9 +42,9 @@ pub use varint::{VarInt, VarIntBoundsExceeded};
 
 mod connection;
 pub use crate::connection::{
-    BytesSource, Chunk, Chunks, Connection, ConnectionError, ConnectionStats, Datagrams, Event,
-    FinishError, FrameStats, PathStats, ReadError, ReadableError, RecvStream, RttEstimator,
-    SendDatagramError, SendStream, StreamEvent, Streams, UdpStats, UnknownStream, WriteError,
+    BytesSource, Chunk, Chunks, ClosedStream, Connection, ConnectionError, ConnectionStats,
+    Datagrams, Event, FinishError, FrameStats, PathStats, ReadError, ReadableError, RecvStream,
+    RttEstimator, SendDatagramError, SendStream, StreamEvent, Streams, UdpStats, WriteError,
     Written,
 };
 

--- a/quinn/benches/bench.rs
+++ b/quinn/benches/bench.rs
@@ -54,7 +54,9 @@ fn send_data(bench: &mut Bencher, data: &'static [u8], concurrent_streams: usize
             handles.push(runtime.spawn(async move {
                 let mut stream = client.open_uni().await.unwrap();
                 stream.write_all(data).await.unwrap();
-                stream.finish().await.unwrap();
+                stream.finish().unwrap();
+                // Wait for stream to close
+                _ = stream.stopped().await;
             }));
         }
 

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -131,9 +131,7 @@ async fn run(options: Opt) -> Result<()> {
     send.write_all(request.as_bytes())
         .await
         .map_err(|e| anyhow!("failed to send request: {}", e))?;
-    send.finish()
-        .await
-        .map_err(|e| anyhow!("failed to shutdown stream: {}", e))?;
+    send.finish().unwrap();
     let response_start = Instant::now();
     eprintln!("request sent at {:?}", response_start - start);
     let resp = recv

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -232,9 +232,7 @@ async fn handle_request(
         .await
         .map_err(|e| anyhow!("failed to send response: {}", e))?;
     // Gracefully terminate the stream
-    send.finish()
-        .await
-        .map_err(|e| anyhow!("failed to shutdown stream: {}", e))?;
+    send.finish().unwrap();
     info!("complete");
     Ok(())
 }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -1268,25 +1268,25 @@ const MAX_TRANSMIT_DATAGRAMS: usize = 20;
 
 /// Error indicating that a stream has already been finished or reset
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
-#[error("unknown stream")]
-pub struct UnknownStream {
+#[error("closed stream")]
+pub struct ClosedStream {
     _private: (),
 }
 
-impl UnknownStream {
+impl ClosedStream {
     pub(crate) fn new() -> Self {
         Self { _private: () }
     }
 }
 
-impl From<proto::UnknownStream> for UnknownStream {
-    fn from(_: proto::UnknownStream) -> Self {
+impl From<proto::ClosedStream> for ClosedStream {
+    fn from(_: proto::ClosedStream) -> Self {
         Self { _private: () }
     }
 }
 
-impl From<UnknownStream> for io::Error {
-    fn from(x: UnknownStream) -> Self {
+impl From<ClosedStream> for io::Error {
+    fn from(x: ClosedStream) -> Self {
         Self::new(io::ErrorKind::NotConnected, x)
     }
 }

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -71,8 +71,8 @@ pub use rustls;
 pub use udp;
 
 pub use crate::connection::{
-    AcceptBi, AcceptUni, Connecting, Connection, OpenBi, OpenUni, ReadDatagram, SendDatagramError,
-    UnknownStream, ZeroRttAccepted,
+    AcceptBi, AcceptUni, ClosedStream, Connecting, Connection, OpenBi, OpenUni, ReadDatagram,
+    SendDatagramError, ZeroRttAccepted,
 };
 pub use crate::endpoint::{Accept, Endpoint};
 pub use crate::incoming::{Incoming, IncomingFuture, RetryError};

--- a/quinn/tests/many_connections.rs
+++ b/quinn/tests/many_connections.rs
@@ -103,10 +103,9 @@ async fn read_from_peer(mut stream: quinn::RecvStream) -> Result<(), quinn::Conn
             use quinn::ReadToEndError::*;
             use ReadError::*;
             match e {
-                TooLong
-                | Read(UnknownStream)
-                | Read(ZeroRttRejected)
-                | Read(IllegalOrderedRead) => unreachable!(),
+                TooLong | Read(ClosedStream) | Read(ZeroRttRejected) | Read(IllegalOrderedRead) => {
+                    unreachable!()
+                }
                 Read(Reset(error_code)) => panic!("unexpected stream reset: {error_code}"),
                 Read(ConnectionLost(e)) => Err(e),
             }


### PR DESCRIPTION
Followup to https://github.com/quinn-rs/quinn/pull/1699. `SendStream::finish` as a future has proved to be a footgun, so this converts it into a synchronous method, delegating "wait until received" duties to `SendStream::stopped`. We expect that to rarely be required in real applications, though it does come up several times in our tests where we specifically want some data to be received before we drop a connection or take a time measurement.