### PR TITLE
Allow resetting of congestion controller state

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1316,6 +1316,21 @@ impl Connection {
         self.path.congestion.as_ref()
     }
 
+    /// Resets the congestion controller and round-trip estimator for the current path.
+    ///
+    /// This force-resets the congestion controller and round-trip estimator for the current
+    /// path.
+    pub fn reset_congestion_state(&mut self) {
+        let now = Instant::now();
+        self.path.rtt = RttEstimator::new(self.config.initial_rtt);
+        self.path.congestion = self
+            .config
+            .congestion_controller_factory
+            .clone()
+            .build(now, self.config.get_initial_mtu());
+        // TODO: probably needs MTU discovery reset as well.
+    }
+
     /// Modify the number of remotely initiated streams that may be concurrently open
     ///
     /// No streams may be opened by the peer unless fewer than `count` are already open. Large

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -142,7 +142,7 @@ pub struct RttEstimator {
 }
 
 impl RttEstimator {
-    fn new(initial_rtt: Duration) -> Self {
+    pub(super) fn new(initial_rtt: Duration) -> Self {
         Self {
             latest: initial_rtt,
             smoothed: None,

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -5,7 +5,7 @@ use std::{
     io,
     net::{IpAddr, SocketAddr},
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, Weak},
     task::{Context, Poll, Waker},
     time::{Duration, Instant},
 };
@@ -275,6 +275,11 @@ impl Future for ConnectionDriver {
 pub struct Connection(ConnectionRef);
 
 impl Connection {
+    /// Returns a weak handle so some low-level connection toggles.
+    pub fn weak_handle(&self) -> WeakConnectionHandle {
+        WeakConnectionHandle(Arc::downgrade(&self.0 .0))
+    }
+
     /// Initiate a new outgoing unidirectional stream.
     ///
     /// Streams are cheap and instantaneous to open unless blocked by flow control. As a
@@ -909,6 +914,33 @@ impl std::ops::Deref for ConnectionRef {
 pub(crate) struct ConnectionInner {
     pub(crate) state: Mutex<State>,
     pub(crate) shared: Shared,
+}
+
+/// A handle to some connection internals, use with care.
+///
+/// This contains a weak reference to the connection so will not itself keep the connection
+/// alive.
+pub struct WeakConnectionHandle(Weak<ConnectionInner>);
+
+impl WeakConnectionHandle {
+    /// Resets the congestion controller and round-trip estimator for the current path.
+    ///
+    /// This force-resets the congestion controller and round-trip estimator for the current
+    /// path.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the connection still existed and the congestion controller state was
+    /// reset.  `false` otherwise.
+    pub fn reset_congestion_state(&self) -> bool {
+        if let Some(inner) = self.0.upgrade() {
+            let mut inner_state = inner.state.lock("reset-congestion-state");
+            inner_state.inner.reset_congestion_state();
+            true
+        } else {
+            false
+        }
+    }
 }
 
 #[derive(Debug, Default)]

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -72,7 +72,7 @@ pub use udp;
 
 pub use crate::connection::{
     AcceptBi, AcceptUni, Connecting, Connection, OpenBi, OpenUni, ReadDatagram, SendDatagramError,
-    UnknownStream, ZeroRttAccepted,
+    UnknownStream, WeakConnectionHandle, ZeroRttAccepted,
 };
 pub use crate::endpoint::{Accept, Endpoint};
 pub use crate::incoming::{Incoming, IncomingFuture, RetryError};


### PR DESCRIPTION
This is a bit of a push, and I appreciate this exposes some innards from Quinn which you may not want to see exposed.  Nevertheless I'm curious what you think of this.  Is this something that at all even reasonable to do?  And would there be a shape of this API that you could consider including?

This allows resetting of the congestion controller state from outside of Quinn.  To do so in introduces a low-level handle to the InnerConnection which does not itself keep the connection alive.

This is useful when you have out-of-band information about the underlying network path and you know the network path has changed. This can occur when using a custom AsyncUdpSocket for example.  In this case it can speed up reaching accurate latency estimates and thus improve throughput.