### PR TITLE
Add ring to default features

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.66"
 all-features = true
 
 [features]
-default = ["platform-verifier", "rustls", "ring", "runtime-tokio", "log"]
+default = ["log", "platform-verifier", "ring", "runtime-tokio", "rustls"]
 # Records how long locks are held, and warns if they are held >= 1ms
 lock_tracking = []
 # Provides `ClientConfig::with_platform_verifier()` convenience method

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.66"
 all-features = true
 
 [features]
-default = ["platform-verifier", "rustls", "runtime-tokio", "log"]
+default = ["platform-verifier", "rustls", "ring", "runtime-tokio", "log"]
 # Records how long locks are held, and warns if they are held >= 1ms
 lock_tracking = []
 # Provides `ClientConfig::with_platform_verifier()` convenience method


### PR DESCRIPTION
Required for `Endpoint::{client, server}` and various other helpers intended to simplify getting started.

`"ring"` was previously implied by `"tls-rustls"`, but that dependency was lost in the update to 0.23. We could add it back directly, but this seems more granular and future-proof.