### PR TITLE
[fix] should not break directly

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -698,6 +698,7 @@ impl Connection {
                                 "GSO truncated by demand for {} padding bytes",
                                 segment_size - packet_len_unpadded
                             );
+                            pad_datagram = false;
                             break;
                         }
 
@@ -927,7 +928,7 @@ impl Connection {
                 builder.pad_to(MIN_INITIAL_SIZE);
             }
             let last_packet_number = builder.exact_number;
-            builder.finish_and_track(now, self, sent_frames.take(), buf);
+            builder.finish_and_track(now, self, sent_frames, buf);
             self.path
                 .congestion
                 .on_sent(now, buf.len() as u64, last_packet_number);

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -927,7 +927,7 @@ impl Connection {
                 builder.pad_to(MIN_INITIAL_SIZE);
             }
             let last_packet_number = builder.exact_number;
-            builder.finish_and_track(now, self, sent_frames, buf);
+            builder.finish_and_track(now, self, sent_frames.take(), buf);
             self.path
                 .congestion
                 .on_sent(now, buf.len() as u64, last_packet_number);

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -693,15 +693,17 @@ impl Connection {
                         let packet_len_unpadded = cmp::max(builder.min_size, buf.len())
                             - datagram_start
                             + builder.tag_len;
-                        if packet_len_unpadded + MAX_PADDING >= segment_size {
+                        if packet_len_unpadded + MAX_PADDING < segment_size {
                             trace!(
                                 "GSO truncated by demand for {} padding bytes",
                                 segment_size - packet_len_unpadded
                             );
-                            // Pad the current packet to GSO segment size so it can be included in the
-                            // GSO batch.
-                            builder.pad_to(segment_size as u16);
+                            pad_datagram = true;
+                            break;
                         }
+                        // Pad the current packet to GSO segment size so it can be included in the
+                        // GSO batch.
+                        builder.pad_to(segment_size as u16);
                     }
 
                     builder.finish_and_track(now, self, sent_frames.take(), buf);


### PR DESCRIPTION
We should invoke the `take` function for `sent_frames`, which is the same as in lines 709 and 753.