### PR TITLE
Suppress ACK-only packet sanity-check when datagrams are queued

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-proto"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 rust-version = "1.66"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Fixes https://github.com/quinn-rs/quinn/issues/1850.

This bug caused occasional panics in debug builds in applications which send large application datagrams. The `debug_assert` did not account for the possibility of ACK-only packets arising due to queued non-ACK being too large to fit into the same packet, which became a problem when 6a8758ade2b81c2fc529a425722288dcca21130f introduced the possibility of ACK frames being sent alongside application data (such as large application datagrams) at times when it would be illegal to send an ACK frame spontaneously on its own.