### PR TITLE
Support openbsd

### DIFF
--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -85,7 +85,7 @@ pub struct RecvMeta {
     pub ecn: Option<EcnCodepoint>,
     /// The destination IP address which was encoded in this datagram
     ///
-    /// Populated on platforms: Windows, Linux, Android, FreeBSD, macOS, and iOS.
+    /// Populated on platforms: Windows, Linux, Android, FreeBSD, OpenBSD, macOS, and iOS.
     pub dst_ip: Option<IpAddr>,
 }
 

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -1,6 +1,8 @@
+#[cfg(not(target_os = "openbsd"))]
+use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::{
     io::IoSliceMut,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, UdpSocket},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, UdpSocket},
     slice,
 };
 
@@ -31,6 +33,46 @@ fn basic() {
 
 #[test]
 fn ecn_v6() {
+    let send = Socket::from(UdpSocket::bind("[::1]:0").unwrap());
+    let recv = Socket::from(UdpSocket::bind("[::1]:0").unwrap());
+    for codepoint in [EcnCodepoint::Ect0, EcnCodepoint::Ect1] {
+        test_send_recv(
+            &send,
+            &recv,
+            Transmit {
+                destination: recv.local_addr().unwrap().as_socket().unwrap(),
+                ecn: Some(codepoint),
+                contents: b"hello",
+                segment_size: None,
+                src_ip: None,
+            },
+        );
+    }
+}
+
+#[test]
+#[cfg(not(target_os = "openbsd"))]
+fn ecn_v4() {
+    let send = Socket::from(UdpSocket::bind("127.0.0.1:0").unwrap());
+    let recv = Socket::from(UdpSocket::bind("127.0.0.1:0").unwrap());
+    for codepoint in [EcnCodepoint::Ect0, EcnCodepoint::Ect1] {
+        test_send_recv(
+            &send,
+            &recv,
+            Transmit {
+                destination: recv.local_addr().unwrap().as_socket().unwrap(),
+                ecn: Some(codepoint),
+                contents: b"hello",
+                segment_size: None,
+                src_ip: None,
+            },
+        );
+    }
+}
+
+#[test]
+#[cfg(not(target_os = "openbsd"))]
+fn ecn_v6_dualstack() {
     let recv = socket2::Socket::new(
         socket2::Domain::IPV6,
         socket2::Type::DGRAM,
@@ -72,25 +114,7 @@ fn ecn_v6() {
 }
 
 #[test]
-fn ecn_v4() {
-    let send = Socket::from(UdpSocket::bind("127.0.0.1:0").unwrap());
-    let recv = Socket::from(UdpSocket::bind("127.0.0.1:0").unwrap());
-    for codepoint in [EcnCodepoint::Ect0, EcnCodepoint::Ect1] {
-        test_send_recv(
-            &send,
-            &recv,
-            Transmit {
-                destination: recv.local_addr().unwrap().as_socket().unwrap(),
-                ecn: Some(codepoint),
-                contents: b"hello",
-                segment_size: None,
-                src_ip: None,
-            },
-        );
-    }
-}
-
-#[test]
+#[cfg(not(target_os = "openbsd"))]
 fn ecn_v4_mapped_v6() {
     let send = socket2::Socket::new(
         socket2::Domain::IPV6,

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -532,6 +532,7 @@ fn run_echo(args: EchoArgs) {
             // platforms in the doc comment of `quinn_udp::RecvMeta::dst_ip`.
             if cfg!(target_os = "linux")
                 || cfg!(target_os = "freebsd")
+                || cfg!(target_os = "openbsd")
                 || cfg!(target_os = "macos")
                 || cfg!(target_os = "windows")
             {


### PR DESCRIPTION
This makes Quinn compile on openbsd and the test suite passes as well.

As far as I understand ECN is not supported as part of a control message on recvmsg.  So I disabled the ECN tests for it.