### PR TITLE
proto: make PartialDecode API public

### DIFF
--- a/fuzz/fuzz_targets/packet.rs
+++ b/fuzz/fuzz_targets/packet.rs
@@ -5,7 +5,7 @@ extern crate proto;
 use libfuzzer_sys::fuzz_target;
 use proto::{
     fuzzing::{PacketParams, PartialDecode},
-    DEFAULT_SUPPORTED_VERSIONS,
+    FixedLengthConnectionIdParser, DEFAULT_SUPPORTED_VERSIONS,
 };
 
 fuzz_target!(|data: PacketParams| {
@@ -13,7 +13,7 @@ fuzz_target!(|data: PacketParams| {
     let supported_versions = DEFAULT_SUPPORTED_VERSIONS.to_vec();
     if let Ok(decoded) = PartialDecode::new(
         data.buf,
-        data.local_cid_len,
+        &FixedLengthConnectionIdParser::new(data.local_cid_len),
         &supported_versions,
         data.grease_quic_bit,
     ) {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -23,8 +23,8 @@ use crate::{
     frame,
     frame::{Close, Datagram, FrameStruct},
     packet::{
-        Header, InitialHeader, InitialPacket, LongType, Packet, PacketNumber, PartialDecode,
-        SpaceId,
+        FixedLengthConnectionIdParser, Header, InitialHeader, InitialPacket, LongType, Packet,
+        PacketNumber, PartialDecode, SpaceId,
     },
     range_set::ArrayRangeSet,
     shared::{
@@ -2101,7 +2101,7 @@ impl Connection {
         while let Some(data) = remaining {
             match PartialDecode::new(
                 data,
-                self.local_cid_state.cid_len(),
+                &FixedLengthConnectionIdParser::new(self.local_cid_state.cid_len()),
                 &[self.version],
                 self.endpoint_config.grease_quic_bit,
             ) {

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -24,7 +24,7 @@ use crate::{
     frame,
     packet::{
         FixedLengthConnectionIdParser, Header, InitialHeader, InitialPacket, Packet,
-        PacketDecodeError, PacketNumber, PartialDecode, PlainInitialHeader,
+        PacketDecodeError, PacketNumber, PartialDecode, ProtectedInitialHeader,
     },
     shared::{
         ConnectionEvent, ConnectionEventInner, ConnectionId, DatagramConnectionEvent, EcnCodepoint,
@@ -684,7 +684,7 @@ impl Endpoint {
     /// Check if we should refuse a connection attempt regardless of the packet's contents
     fn early_validate_first_packet(
         &mut self,
-        header: &PlainInitialHeader,
+        header: &ProtectedInitialHeader,
     ) -> Result<(), TransportError> {
         let config = &self.server_config.as_ref().unwrap();
         if self.cids_exhausted() || self.incoming_buffers.len() >= config.max_incoming {

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -23,8 +23,8 @@ use crate::{
     crypto::{self, Keys, UnsupportedVersion},
     frame,
     packet::{
-        Header, InitialHeader, InitialPacket, Packet, PacketDecodeError, PacketNumber,
-        PartialDecode, PlainInitialHeader,
+        FixedLengthConnectionIdParser, Header, InitialHeader, InitialPacket, Packet,
+        PacketDecodeError, PacketNumber, PartialDecode, PlainInitialHeader,
     },
     shared::{
         ConnectionEvent, ConnectionEventInner, ConnectionId, DatagramConnectionEvent, EcnCodepoint,
@@ -144,7 +144,7 @@ impl Endpoint {
         let datagram_len = data.len();
         let (first_decode, remaining) = match PartialDecode::new(
             data,
-            self.local_cid_generator.cid_len(),
+            &FixedLengthConnectionIdParser::new(self.local_cid_generator.cid_len()),
             &self.config.supported_versions,
             self.config.grease_quic_bit,
         ) {

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -31,7 +31,6 @@ mod cid_queue;
 #[doc(hidden)]
 pub mod coding;
 mod constant_time;
-mod packet;
 mod range_set;
 #[cfg(all(test, feature = "rustls"))]
 mod tests;
@@ -64,6 +63,9 @@ mod endpoint;
 pub use crate::endpoint::{
     AcceptError, ConnectError, ConnectionHandle, DatagramEvent, Endpoint, Incoming, RetryError,
 };
+
+mod packet;
+pub use packet::{LongType, PacketDecodeError, PartialDecode, PlainHeader, PlainInitialHeader};
 
 mod shared;
 pub use crate::shared::{ConnectionEvent, ConnectionId, EcnCodepoint, EndpointEvent};

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -65,7 +65,10 @@ pub use crate::endpoint::{
 };
 
 mod packet;
-pub use packet::{LongType, PacketDecodeError, PartialDecode, PlainHeader, PlainInitialHeader};
+pub use packet::{
+    ConnectionIdParser, FixedLengthConnectionIdParser, LongType, PacketDecodeError, PartialDecode,
+    PlainHeader, PlainInitialHeader,
+};
 
 mod shared;
 pub use crate::shared::{ConnectionEvent, ConnectionId, EcnCodepoint, EndpointEvent};

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -67,7 +67,7 @@ pub use crate::endpoint::{
 mod packet;
 pub use packet::{
     ConnectionIdParser, FixedLengthConnectionIdParser, LongType, PacketDecodeError, PartialDecode,
-    PlainHeader, PlainInitialHeader,
+    ProtectedHeader, ProtectedInitialHeader,
 };
 
 mod shared;

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -86,7 +86,7 @@ impl ConnectionId {
     /// Constructs cid by reading `len` bytes from a `Buf`
     ///
     /// Callers need to assure that `buf.remaining() >= len`
-    pub(crate) fn from_buf(buf: &mut impl Buf, len: usize) -> Self {
+    pub fn from_buf(buf: &mut impl Buf, len: usize) -> Self {
         debug_assert!(len <= MAX_CID_SIZE);
         let mut res = Self {
             len: len as u8,


### PR DESCRIPTION
Context: #1860.

This PR did a bit more than just expose symbols to public, a trait `ConnectionIdValidator` was introduced, due to the fact that a QUIC Load balancer have to support different kind of Connection ID Schemes, per [QUIC-LB-DRAFT Secion 4.1]( https://www.ietf.org/archive/id/draft-ietf-quic-load-balancers-19.html#section-4.1). 
Also some documents was added to suppress the clippy warning after those symbol being made public.

