### PR TITLE
Centralize and update `local_ip` platform support documentation

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1288,15 +1288,9 @@ impl Connection {
     /// This can be different from the address the endpoint is bound to, in case
     /// the endpoint is bound to a wildcard address like `0.0.0.0` or `::`.
     ///
-    /// This will return `None` for clients.
-    ///
-    /// Retrieving the local IP address is currently supported on the following
-    /// platforms:
-    /// - Linux
-    /// - Windows
-    ///
-    /// On all non-supported platforms the local IP address will not be available,
-    /// and the method will return `None`.
+    /// This will return `None` for clients, or when no `local_ip` was passed to
+    /// [`Endpoint::handle()`](crate::Endpoint::handle) for the datagrams establishing this
+    /// connection.
     pub fn local_ip(&self) -> Option<IpAddr> {
         self.local_ip
     }

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -84,6 +84,8 @@ pub struct RecvMeta {
     /// The Explicit Congestion Notification bits for the datagram(s) in the buffer
     pub ecn: Option<EcnCodepoint>,
     /// The destination IP address which was encoded in this datagram
+    ///
+    /// Populated on platforms: Windows, Linux, Android, FreeBSD, macOS, and iOS.
     pub dst_ip: Option<IpAddr>,
 }
 

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -151,16 +151,9 @@ impl Connecting {
     /// This can be different from the address the endpoint is bound to, in case
     /// the endpoint is bound to a wildcard address like `0.0.0.0` or `::`.
     ///
-    /// This will return `None` for clients.
-    ///
-    /// Retrieving the local IP address is currently supported on the following
-    /// platforms:
-    /// - Linux
-    /// - FreeBSD
-    /// - macOS
-    ///
-    /// On all non-supported platforms the local IP address will not be available,
-    /// and the method will return `None`.
+    /// This will return `None` for clients, or when the platform does not expose this
+    /// information. See [`quinn_udp::RecvMeta::dst_ip`](udp::RecvMeta::dst_ip) for a list of
+    /// supported platforms when using [`quinn_udp`](udp) for I/O, which is the default.
     pub fn local_ip(&self) -> Option<IpAddr> {
         let conn = self.conn.as_ref().unwrap();
         let inner = conn.state.lock("local_ip");
@@ -478,14 +471,9 @@ impl Connection {
     /// This can be different from the address the endpoint is bound to, in case
     /// the endpoint is bound to a wildcard address like `0.0.0.0` or `::`.
     ///
-    /// This will return `None` for clients.
-    ///
-    /// Retrieving the local IP address is currently supported on the following
-    /// platforms:
-    /// - Linux
-    ///
-    /// On all non-supported platforms the local IP address will not be available,
-    /// and the method will return `None`.
+    /// This will return `None` for clients, or when the platform does not expose this
+    /// information. See [`quinn_udp::RecvMeta::dst_ip`](udp::RecvMeta::dst_ip) for a list of
+    /// supported platforms when using [`quinn_udp`](udp) for I/O, which is the default.
     pub fn local_ip(&self) -> Option<IpAddr> {
         self.0.state.lock("local_ip").inner.local_ip()
     }

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -529,7 +529,7 @@ fn run_echo(args: EchoArgs) {
             // Note for anyone modifying the platform support in this test:
             // If `local_ip` gets available on additional platforms - which
             // requires modifying this test - please update the list of supported
-            // platforms in the doc comments of the various `local_ip` functions.
+            // platforms in the doc comment of `quinn_udp::RecvMeta::dst_ip`.
             if cfg!(target_os = "linux")
                 || cfg!(target_os = "freebsd")
                 || cfg!(target_os = "macos")


### PR DESCRIPTION
Fixes https://github.com/quinn-rs/quinn/issues/1864 by establishing a single source of truth in quinn-udp.