### PR TITLE
Fix stopped recv stream flow control underflow under reordering

### DIFF
--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -200,10 +200,6 @@ impl Assembler {
         }
     }
 
-    pub(super) fn set_bytes_read(&mut self, new: u64) {
-        self.bytes_read = new;
-    }
-
     /// Number of bytes consumed by the application
     pub(super) fn bytes_read(&self) -> u64 {
         self.bytes_read

--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -145,7 +145,7 @@ impl<'a> RecvStream<'a> {
         // We need to keep stopped streams around until they're finished or reset so we can update
         // connection-level flow control to account for discarded data. Otherwise, we can discard
         // state immediately.
-        if !stream.receiving_unknown_size() {
+        if !stream.final_offset_unknown() {
             entry.remove();
             self.state.stream_freed(self.id, StreamHalf::Recv);
         }

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -107,7 +107,8 @@ impl Recv {
         // smaller than `stream_receive_window` in order to make sure the stream
         // does not get stuck.
         let diff = max_stream_data - self.sent_max_stream_data;
-        let transmit = self.receiving_unknown_size() && diff >= (stream_receive_window / 8);
+        let transmit =
+            self.receiving_unknown_size() && !self.stopped && diff >= (stream_receive_window / 8);
         (max_stream_data, ShouldTransmit(transmit))
     }
 

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -298,7 +298,7 @@ impl StreamsState {
         }
         self.on_stream_frame(!stopped, id);
 
-        // Update flow control
+        // Update connection-level flow control
         Ok(if bytes_read != final_offset.into_inner() {
             // bytes_read is always <= end, so this won't underflow.
             self.data_recvd = self

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -358,7 +358,7 @@ impl StreamsState {
         self.recv
             .get(&id)
             .and_then(|s| s.as_ref())
-            .map_or(false, |s| s.final_offset_unknown() && !s.stopped)
+            .map_or(false, |s| s.can_send_flow_control())
     }
 
     pub(in crate::connection) fn write_control_frames(
@@ -446,7 +446,7 @@ impl StreamsState {
                 Some(x) => x,
                 None => continue,
             };
-            if !rs.final_offset_unknown() || rs.stopped {
+            if !rs.can_send_flow_control() {
                 continue;
             }
             retransmits.get_or_create().max_stream_data.insert(id);

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -358,7 +358,7 @@ impl StreamsState {
         self.recv
             .get(&id)
             .and_then(|s| s.as_ref())
-            .map_or(false, |s| s.receiving_unknown_size())
+            .map_or(false, |s| s.receiving_unknown_size() && !s.stopped)
     }
 
     pub(in crate::connection) fn write_control_frames(
@@ -446,7 +446,7 @@ impl StreamsState {
                 Some(x) => x,
                 None => continue,
             };
-            if !rs.receiving_unknown_size() {
+            if !rs.receiving_unknown_size() || rs.stopped {
                 continue;
             }
             retransmits.get_or_create().max_stream_data.insert(id);

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -358,7 +358,7 @@ impl StreamsState {
         self.recv
             .get(&id)
             .and_then(|s| s.as_ref())
-            .map_or(false, |s| s.receiving_unknown_size() && !s.stopped)
+            .map_or(false, |s| s.final_offset_unknown() && !s.stopped)
     }
 
     pub(in crate::connection) fn write_control_frames(
@@ -446,7 +446,7 @@ impl StreamsState {
                 Some(x) => x,
                 None => continue,
             };
-            if !rs.receiving_unknown_size() || rs.stopped {
+            if !rs.final_offset_unknown() || rs.stopped {
                 continue;
             }
             retransmits.get_or_create().max_stream_data.insert(id);


### PR DESCRIPTION
Fixes #1818 (probably). Second commit isn't necessary but feels a bit tidier.