### PR TITLE
Relax unnecessary unique borrow

### DIFF
--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -240,7 +240,7 @@ impl<'a> SendStream<'a> {
     }
 
     /// Check if this stream was stopped, get the reason if it was
-    pub fn stopped(&mut self) -> Result<Option<VarInt>, ClosedStream> {
+    pub fn stopped(&self) -> Result<Option<VarInt>, ClosedStream> {
         match self.state.send.get(&self.id).as_ref() {
             Some(Some(s)) => Ok(s.stop_reason),
             Some(None) => Ok(None),


### PR DESCRIPTION
Technically breaking, but spectacularly unlikely to break any real use, and arguably a mistake, so I think we can justify it.