### PR TITLE
Introduce RecvStream::reset

### DIFF
--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -187,6 +187,13 @@ impl Recv {
         Ok(true)
     }
 
+    pub(super) fn reset_code(&self) -> Option<VarInt> {
+        match self.state {
+            RecvState::ResetRecvd { error_code, .. } => Some(error_code),
+            _ => None,
+        }
+    }
+
     /// Compute the amount of flow control credit consumed, or return an error if more was consumed
     /// than issued
     fn credit_consumed_by(

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -308,7 +308,7 @@ impl RecvStream {
 
         // If we stored an error during a previous call, return it now. This can happen if a
         // `read_fn` both wants to return data and also returns an error in its final stream status.
-        let status = match self.reset.take() {
+        let status = match self.reset {
             Some(code) => ReadStatus::Failed(None, Reset(code)),
             None => {
                 let mut recv = conn.inner.recv_stream(self.stream);
@@ -340,6 +340,7 @@ impl RecvStream {
             ReadStatus::Failed(read, Reset(error_code)) => match read {
                 None => {
                     self.all_data_read = true;
+                    self.reset = Some(error_code);
                     Poll::Ready(Err(ReadError::Reset(error_code)))
                 }
                 done => {


### PR DESCRIPTION
Fixes #1870. I'm pretty sure I handled the state cleanup and flow control implications properly, but close review desired there all the same.