### PR TITLE
Simpler and more precise ID flow control update check in Chunks

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2897,11 +2897,7 @@ impl Connection {
         // are only freed, and hence only issue credit, once the application has been notified
         // during a read on the stream.
         let pending = &mut self.spaces[SpaceId::Data].pending;
-        for dir in Dir::iter() {
-            if self.streams.take_max_streams_dirty(dir) {
-                pending.max_stream_id[dir as usize] = true;
-            }
-        }
+        self.streams.queue_max_stream_id(pending);
 
         if let Some(reason) = close {
             self.error = Some(reason.into());

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -313,10 +313,9 @@ impl<'a> Chunks<'a> {
 
         let mut should_transmit = false;
         // We issue additional stream ID credit after the application is notified that a previously
-        // open stream has finished or been reset and we've therefore disposed of its state.
-        if matches!(state, ChunksState::Finished | ChunksState::Reset(_))
-            && self.streams.side != self.id.initiator()
-        {
+        // open stream has finished or been reset and we've therefore disposed of its state, as
+        // recorded by `stream_freed` calls in `next`.
+        if self.streams.take_max_streams_dirty(self.id.dir()) {
             self.pending.max_stream_id[self.id.dir() as usize] = true;
             should_transmit = true;
         }

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -311,14 +311,10 @@ impl<'a> Chunks<'a> {
             return ShouldTransmit(false);
         }
 
-        let mut should_transmit = false;
         // We issue additional stream ID credit after the application is notified that a previously
         // open stream has finished or been reset and we've therefore disposed of its state, as
         // recorded by `stream_freed` calls in `next`.
-        if self.streams.take_max_streams_dirty(self.id.dir()) {
-            self.pending.max_stream_id[self.id.dir() as usize] = true;
-            should_transmit = true;
-        }
+        let mut should_transmit = self.streams.queue_max_stream_id(self.pending);
 
         // If the stream hasn't finished, we may need to issue stream-level flow control credit
         if let ChunksState::Readable(mut rs) = state {

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -742,8 +742,17 @@ impl StreamsState {
         self.events.pop_front()
     }
 
-    pub(crate) fn take_max_streams_dirty(&mut self, dir: Dir) -> bool {
-        mem::replace(&mut self.max_streams_dirty[dir as usize], false)
+    /// Queues MAX_STREAM_ID frames in `pending` if needed
+    ///
+    /// Returns whether any frames were queued.
+    pub(crate) fn queue_max_stream_id(&mut self, pending: &mut Retransmits) -> bool {
+        let mut queued = false;
+        for dir in Dir::iter() {
+            let dirty = mem::replace(&mut self.max_streams_dirty[dir as usize], false);
+            pending.max_stream_id[dir as usize] |= dirty;
+            queued |= dirty;
+        }
+        queued
     }
 
     /// Check for errors entailed by the peer's use of `id` as a send stream


### PR DESCRIPTION
Noticed this looked like a redundant approximation while working on #1873. Careful review desired. The original logic here seems to date back to 2021 or earlier, but e.g. a3b35f93c25045b00849e846713cb9b94bc681c5 looks like a somewhat shorter-sighted hack around this same quirk. See commit description for additional rationale.