### PR TITLE
proto: make NoInitialCipherSuite Copy

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-proto"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 rust-version = "1.66"
 license = "MIT OR Apache-2.0"

--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -1,4 +1,7 @@
-use std::collections::{hash_map, BinaryHeap};
+use std::{
+    collections::{hash_map, BinaryHeap},
+    io,
+};
 
 use bytes::Bytes;
 use thiserror::Error;
@@ -441,6 +444,19 @@ impl ShouldTransmit {
 #[error("closed stream")]
 pub struct ClosedStream {
     _private: (),
+}
+
+impl ClosedStream {
+    #[doc(hidden)] // For use in quinn only
+    pub fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl From<ClosedStream> for io::Error {
+    fn from(x: ClosedStream) -> Self {
+        Self::new(io::ErrorKind::NotConnected, x)
+    }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -367,7 +367,7 @@ impl TryFrom<Arc<rustls::ClientConfig>> for QuicClientConfig {
 /// [`CryptoProvider`][provider], that provider must reference a cipher suite with the same ID.
 ///
 /// [provider]: rustls::crypto::CryptoProvider
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct NoInitialCipherSuite {
     /// Whether the initial cipher suite was supplied by the caller
     specific: bool,

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.66"
 license = "MIT OR Apache-2.0"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn"
-version = "0.11.0"
+version = "0.11.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/quinn-rs/quinn"
 description = "Versatile QUIC transport protocol implementation"
@@ -38,7 +38,7 @@ bytes = "1"
 futures-io = { version = "0.3.19", optional = true }
 rustc-hash = "1.1"
 pin-project-lite = "0.2"
-proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.11", default-features = false }
+proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.11.2", default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"], optional = true }
 smol = { version = "2", optional = true }
 thiserror = "1.0.21"

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -1253,28 +1253,3 @@ pub enum SendDatagramError {
 /// This limits the amount of CPU resources consumed by datagram generation,
 /// and allows other tasks (like receiving ACKs) to run in between.
 const MAX_TRANSMIT_DATAGRAMS: usize = 20;
-
-/// Error indicating that a stream has already been finished or reset
-#[derive(Debug, Error, Clone, PartialEq, Eq)]
-#[error("closed stream")]
-pub struct ClosedStream {
-    _private: (),
-}
-
-impl ClosedStream {
-    pub(crate) fn new() -> Self {
-        Self { _private: () }
-    }
-}
-
-impl From<proto::ClosedStream> for ClosedStream {
-    fn from(_: proto::ClosedStream) -> Self {
-        Self { _private: () }
-    }
-}
-
-impl From<ClosedStream> for io::Error {
-    fn from(x: ClosedStream) -> Self {
-        Self::new(io::ErrorKind::NotConnected, x)
-    }
-}

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -62,8 +62,8 @@ mod send_stream;
 mod work_limiter;
 
 pub use proto::{
-    congestion, crypto, AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ConfigError,
-    ConnectError, ConnectionClose, ConnectionError, EndpointConfig, IdleTimeout,
+    congestion, crypto, AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ClosedStream,
+    ConfigError, ConnectError, ConnectionClose, ConnectionError, EndpointConfig, IdleTimeout,
     MtuDiscoveryConfig, ServerConfig, StreamId, Transmit, TransportConfig, VarInt,
 };
 #[cfg(feature = "rustls")]
@@ -71,8 +71,8 @@ pub use rustls;
 pub use udp;
 
 pub use crate::connection::{
-    AcceptBi, AcceptUni, ClosedStream, Connecting, Connection, OpenBi, OpenUni, ReadDatagram,
-    SendDatagramError, ZeroRttAccepted,
+    AcceptBi, AcceptUni, Connecting, Connection, OpenBi, OpenUni, ReadDatagram, SendDatagramError,
+    ZeroRttAccepted,
 };
 pub use crate::endpoint::{Accept, Endpoint};
 pub use crate::incoming::{Incoming, IncomingFuture, RetryError};

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -6,14 +6,11 @@ use std::{
 };
 
 use bytes::Bytes;
-use proto::{Chunk, Chunks, ConnectionError, ReadableError, StreamId};
+use proto::{Chunk, Chunks, ClosedStream, ConnectionError, ReadableError, StreamId};
 use thiserror::Error;
 use tokio::io::ReadBuf;
 
-use crate::{
-    connection::{ClosedStream, ConnectionRef},
-    VarInt,
-};
+use crate::{connection::ConnectionRef, VarInt};
 
 /// A stream that can only be used to receive data
 ///

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -6,13 +6,10 @@ use std::{
 };
 
 use bytes::Bytes;
-use proto::{ConnectionError, FinishError, StreamId, Written};
+use proto::{ClosedStream, ConnectionError, FinishError, StreamId, Written};
 use thiserror::Error;
 
-use crate::{
-    connection::{ClosedStream, ConnectionRef},
-    VarInt,
-};
+use crate::{connection::ConnectionRef, VarInt};
 
 /// A stream that can only be used to send data
 ///
@@ -189,7 +186,7 @@ impl SendStream {
     /// Get the priority of the send stream
     pub fn priority(&self) -> Result<i32, ClosedStream> {
         let mut conn = self.conn.state.lock("SendStream::priority");
-        Ok(conn.inner.send_stream(self.stream).priority()?)
+        conn.inner.send_stream(self.stream).priority()
     }
 
     /// Completes when the stream is stopped or read to completion by the peer


### PR DESCRIPTION
`hickory-proto::ProtoErrorKind`, which will include this, implements `Clone`.

Downstream PR: https://github.com/hickory-dns/hickory-dns/pull/2217.