### PR TITLE
Make ConnectionIdParser object-safe, and accept trait object impls

### DIFF
--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -630,8 +630,8 @@ pub struct EndpointConfig {
 impl EndpointConfig {
     /// Create a default config with a particular `reset_key`
     pub fn new(reset_key: Arc<dyn HmacKey>) -> Self {
-        let cid_factory: fn() -> Box<dyn ConnectionIdGenerator> =
-            || Box::<HashedConnectionIdGenerator>::default();
+        let cid_factory =
+            || -> Box<dyn ConnectionIdGenerator> { Box::<HashedConnectionIdGenerator>::default() };
         Self {
             reset_key,
             max_udp_payload_size: (1500u32 - 28).into(), // Ethernet MTU minus IP + UDP headers

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -32,7 +32,7 @@ impl PartialDecode {
     /// Begin decoding a QUIC packet from `bytes`, returning any trailing data not part of that packet
     pub fn new(
         bytes: BytesMut,
-        cid_parser: &impl ConnectionIdParser,
+        cid_parser: &(impl ConnectionIdParser + ?Sized),
         supported_versions: &[u32],
         grease_quic_bit: bool,
     ) -> Result<(Self, Option<BytesMut>), PacketDecodeError> {
@@ -564,7 +564,7 @@ impl ProtectedHeader {
     /// Decode a plain header from given buffer, with given [`ConnectionIdParser`].
     pub fn decode(
         buf: &mut io::Cursor<BytesMut>,
-        cid_parser: &impl ConnectionIdParser,
+        cid_parser: &(impl ConnectionIdParser + ?Sized),
         supported_versions: &[u32],
         grease_quic_bit: bool,
     ) -> Result<Self, PacketDecodeError> {
@@ -780,7 +780,7 @@ impl FixedLengthConnectionIdParser {
 }
 
 impl ConnectionIdParser for FixedLengthConnectionIdParser {
-    fn parse(&self, buffer: &mut impl Buf) -> Result<ConnectionId, PacketDecodeError> {
+    fn parse(&self, buffer: &mut dyn Buf) -> Result<ConnectionId, PacketDecodeError> {
         (buffer.remaining() >= self.expected_len)
             .then(|| ConnectionId::from_buf(buffer, self.expected_len))
             .ok_or(PacketDecodeError::InvalidHeader("packet too small"))
@@ -790,7 +790,7 @@ impl ConnectionIdParser for FixedLengthConnectionIdParser {
 /// Parse connection id in short header packet
 pub trait ConnectionIdParser {
     /// Parse a connection id from given buffer
-    fn parse(&self, buf: &mut impl Buf) -> Result<ConnectionId, PacketDecodeError>;
+    fn parse(&self, buf: &mut dyn Buf) -> Result<ConnectionId, PacketDecodeError>;
 }
 
 /// Long packet type including non-uniform cases

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -86,7 +86,7 @@ impl ConnectionId {
     /// Constructs cid by reading `len` bytes from a `Buf`
     ///
     /// Callers need to assure that `buf.remaining() >= len`
-    pub fn from_buf(buf: &mut impl Buf, len: usize) -> Self {
+    pub fn from_buf(buf: &mut (impl Buf + ?Sized), len: usize) -> Self {
         debug_assert!(len <= MAX_CID_SIZE);
         let mut res = Self {
             len: len as u8,


### PR DESCRIPTION
Groundwork to eventually make `ConnectionIdGenerator` require or somehow expose `ConnectionIdParser`, towards eventually supporting variable-length CIDs in Quinn. Further changes in this direction will be breaking so we shouldn't pursue them immediately, but getting this in before the next release will reduce the magnitude of that breakage.

CC @thynson