### PR TITLE
Add support for NetBSD, fix OpenBSD

### DIFF
--- a/quinn-udp/src/cmsg/mod.rs
+++ b/quinn-udp/src/cmsg/mod.rs
@@ -124,6 +124,10 @@ pub(crate) trait MsgHdr {
 
     fn cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage;
 
+    /// Sets the number of control messages added to this `struct msghdr`.
+    ///
+    /// Note that this is a destructive operation and should only be done as a finalisation
+    /// step.
     fn set_control_len(&mut self, len: usize);
 
     fn control_len(&self) -> usize;

--- a/quinn-udp/src/cmsg/unix.rs
+++ b/quinn-udp/src/cmsg/unix.rs
@@ -20,6 +20,11 @@ impl MsgHdr for libc::msghdr {
 
     fn set_control_len(&mut self, len: usize) {
         self.msg_controllen = len as _;
+        if len == 0 {
+            // netbsd is particular about this being a NULL pointer if there are no control
+            // messages.
+            self.msg_control = std::ptr::null_mut();
+        }
     }
 
     fn control_len(&self) -> usize {

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -85,7 +85,8 @@ pub struct RecvMeta {
     pub ecn: Option<EcnCodepoint>,
     /// The destination IP address which was encoded in this datagram
     ///
-    /// Populated on platforms: Windows, Linux, Android, FreeBSD, OpenBSD, macOS, and iOS.
+    /// Populated on platforms: Windows, Linux, Android, FreeBSD, OpenBSD, NetBSD, macOS,
+    /// and iOS.
     pub dst_ip: Option<IpAddr>,
 }
 

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -119,12 +119,7 @@ impl UdpSocketState {
                 )?;
             }
         }
-        #[cfg(any(
-            target_os = "freebsd",
-            target_os = "openbsd",
-            target_os = "macos",
-            target_os = "ios"
-        ))]
+        #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "ios"))]
         {
             if is_ipv4 {
                 // Set `may_fragment` to `true` if this option is not supported on the platform.

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
 use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::{
     io::IoSliceMut,
@@ -51,7 +51,7 @@ fn ecn_v6() {
 }
 
 #[test]
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
 fn ecn_v4() {
     let send = Socket::from(UdpSocket::bind("127.0.0.1:0").unwrap());
     let recv = Socket::from(UdpSocket::bind("127.0.0.1:0").unwrap());
@@ -71,7 +71,7 @@ fn ecn_v4() {
 }
 
 #[test]
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
 fn ecn_v6_dualstack() {
     let recv = socket2::Socket::new(
         socket2::Domain::IPV6,
@@ -114,7 +114,7 @@ fn ecn_v6_dualstack() {
 }
 
 #[test]
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
 fn ecn_v4_mapped_v6() {
     let send = socket2::Socket::new(
         socket2::Domain::IPV6,

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -533,6 +533,7 @@ fn run_echo(args: EchoArgs) {
             if cfg!(target_os = "linux")
                 || cfg!(target_os = "freebsd")
                 || cfg!(target_os = "openbsd")
+                || cfg!(target_os = "netbsd")
                 || cfg!(target_os = "macos")
                 || cfg!(target_os = "windows")
             {


### PR DESCRIPTION
This adds support for NetBSD.  As mentioned in the commit, it does not support DONTFRAG or ECN for IPv4, but does for IPv6.  It has recvmmsg so I implemented that recv branch.

Also included is a fix for OpenBSD which also does not have IP_DONTFRAG for IPv4.  Not sure how that slipped into #1863 / 98d8513e656467b32898402a372e33ea2108c478.

I have tested this on all of OpenBSD, NetBSD and FreeBSD and all pass the test suite now.