### PR TITLE
Resolve stopped/received_reset futures on lost connections

### DIFF
--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -309,6 +309,9 @@ impl RecvStream {
                     Poll::Ready(Ok(Some(error_code)))
                 }
                 Ok(None) => {
+                    if let Some(e) = &conn.error {
+                        return Poll::Ready(Err(e.clone().into()));
+                    }
                     // Resets always notify readers, since a reset is an immediate read error. We
                     // could introduce a dedicated channel to reduce the risk of spurious wakeups,
                     // but that increased complexity is probably not justified, as an application

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -212,6 +212,9 @@ impl SendStream {
             Err(_) => Poll::Ready(Ok(None)),
             Ok(Some(error_code)) => Poll::Ready(Ok(Some(error_code))),
             Ok(None) => {
+                if let Some(e) = &conn.error {
+                    return Poll::Ready(Err(e.clone().into()));
+                }
                 conn.stopped.insert(self.stream, cx.waker().clone());
                 Poll::Pending
             }


### PR DESCRIPTION
If a connection is lost before a stream becomes closed, these would otherwise never complete.