### PR TITLE
fix: remove debug assert that requires ordered acks for non mtu probe acks

### DIFF
--- a/quinn-proto/src/connection/mtud.rs
+++ b/quinn-proto/src/connection/mtud.rs
@@ -389,10 +389,6 @@ impl BlackHoleDetector {
     }
 
     fn on_non_probe_acked(&mut self, pn: u64, len: u16) {
-        debug_assert!(
-            pn >= self.largest_post_loss_packet,
-            "ACKs are delivered in order"
-        );
         if len <= self.acked_mtu {
             // We've already seen a larger packet since the most recent suspicious loss burst;
             // nothing to do.


### PR DESCRIPTION
Non-probe acks can be out of order. As of my understanding the ordering is only given for probe acks.

To confirm: Should it also be removed for probe acks?

fixes #1889