### PR TITLE
docs(quinn): Clarify effects of setting AckFrequencyConfig

### DIFF
--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -213,7 +213,9 @@ impl TransportConfig {
     /// The provided configuration will be ignored if the peer does not support the acknowledgement
     /// frequency QUIC extension.
     ///
-    /// Defaults to `None`, which disables the ACK frequency feature.
+    /// Defaults to `None`, which disables controlling the peer's acknowledgement frequency. Even
+    /// if set to `None`, the local side still supports the acknowledgement frequency QUIC
+    /// extension and may use it in other ways.
     pub fn ack_frequency_config(&mut self, value: Option<AckFrequencyConfig>) -> &mut Self {
         self.ack_frequency_config = value;
         self


### PR DESCRIPTION
Per discussion in Discord [[link]](https://discord.com/channels/976380008299917365/1063547094863978677/1249100084117770272), the actual extent to which setting ack_frequency_config to `None` disables the acknowledgement frequency extension is less than the documentation seems to imply. An endpoint with the ack frequency config set to `None` will still:

- advertise support for the extension by populating the `min_ack_delay` field of its transport parameters with `Some`
- process ACK_FREQUENCY and IMMEDIATE_ACK frames if it receives them
- send IMMEDIATE_ACK frames if the peer advertises support for the extension

The only thing it will not do is send the peer an ACK_FREQUENCY frame.

This PR updates the docs to reflect the behavior more closely.
