### PR TITLE
Only send MAX_STREAMS when >1/8 of flow control window is consumed 

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1311,6 +1311,10 @@ impl Connection {
     /// `count`s increase both minimum and worst-case memory consumption.
     pub fn set_max_concurrent_streams(&mut self, dir: Dir, count: VarInt) {
         self.streams.set_max_concurrent(dir, count);
+        // If the limit was reduced, then a flow control update previously deemed insignificant may
+        // now be significant.
+        let pending = &mut self.spaces[SpaceId::Data].pending;
+        self.streams.queue_max_stream_id(pending);
     }
 
     /// Current number of remotely initiated streams that may be concurrently open


### PR DESCRIPTION
Minor optimization to reduce outgoing traffic when receiving large numbers of streams. Mirrors existing logic for data flow control, e.g.

https://github.com/quinn-rs/quinn/blob/7b97a3fbd875903568249862f6d2ef4b7d30cfe8/quinn-proto/src/connection/streams/state.rs#L849-L855