### PR TITLE
Endpoint stats interface

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -919,7 +919,7 @@ impl Endpoint {
     pub fn open_connections(&self) -> usize {
         self.connections.len()
     }
-    
+
     /// Counter for the number of bytes currently used
     /// in the buffers for Initial and 0-RTT messages for pending incoming connections
     pub fn incoming_buffer_bytes(&self) -> u64 {

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -920,7 +920,7 @@ impl Endpoint {
         self.connections.len()
     }
 
-    pub fn incoming_buffers_total_bytes(&self) -> u64 {
+    pub fn incoming_buffer_bytes(&self) -> u64 {
         self.all_incoming_buffers_total_bytes
     }
 

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -920,6 +920,10 @@ impl Endpoint {
         self.connections.len()
     }
 
+    pub fn incoming_buffers_total_bytes(&self) -> u64 {
+        self.all_incoming_buffers_total_bytes
+    }
+
     #[cfg(test)]
     pub(crate) fn known_connections(&self) -> usize {
         let x = self.connections.len();

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -919,7 +919,9 @@ impl Endpoint {
     pub fn open_connections(&self) -> usize {
         self.connections.len()
     }
-
+    
+    /// Counter for the number of bytes currently used
+    /// in the buffers for Initial and 0-RTT messages for pending incoming connections
     pub fn incoming_buffer_bytes(&self) -> u64 {
         self.all_incoming_buffers_total_bytes
     }

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -332,15 +332,21 @@ impl Endpoint {
     }
 }
 
-/// Struct for holding the stats returned from Endpoint::stats
+/// Statistics on [Endpoint] activity
 #[non_exhaustive]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct EndpointStats {
+    /// Number of open connecctions on this [Endpoint]
     pub open_connections: u64,
+    /// Cummulative number of Quic handshakes accepted by this [Endpoint]
     pub accepted_handshakes: u64,
+    /// Cummulative number of Quic handshakees sent from this [Endpoint]
     pub outgoing_handshakes: u64,
+    /// Cummulative number of Quic handshakes refused on this [Endpoint]
     pub refused_handshakes: u64,
+    /// Cummulative number of Quic handshakes ignored on this [Endpoint]
     pub ignored_handshakes: u64,
+    /// Number of bytes used in all incoming buffers on this [Endpoint]
     pub incoming_buffer_bytes: u64,
 }
 

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -85,8 +85,7 @@ impl Endpoint {
         )
     }
 
-    // Returns relevant stats from this Endpoint
-    //
+    /// Returns relevant stats from this Endpoint
     pub fn stats(&self) -> EndpointStats {
         let state = self.inner.state.lock().unwrap();
         let open_connections = state.inner.open_connections() as u64;

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -88,19 +88,13 @@ impl Endpoint {
     /// Returns relevant stats from this Endpoint
     pub fn stats(&self) -> EndpointStats {
         let state = self.inner.state.lock().unwrap();
-        let open_connections = state.inner.open_connections() as u64;
-        let incoming_handshakes = state.incoming_handshakes;
-        let outgoing_handshakes = state.outgoing_handshakes;
-        let refused_handshakes = state.refused_handshakes;
-        let ignored_handshakes = state.ignored_handshakes;
-        let incoming_buffer_bytes = state.inner.incoming_buffer_bytes();
         EndpointStats {
-            open_connections,
-            incoming_handshakes,
-            outgoing_handshakes,
-            refused_handshakes,
-            ignored_handshakes,
-            incoming_buffer_bytes,
+            open_connections: state.inner.open_connections() as u64,
+            accepted_handshakes: state.accepted_handshakes,
+            outgoing_handshakes: state.outgoing_handshakes,
+            refused_handshakes: state.refused_handshakes,
+            ignored_handshakes: state.ignored_handshakes,
+            incoming_buffer_bytes: state.inner.incoming_buffer_bytes(),
         }
     }
 
@@ -344,7 +338,7 @@ impl Endpoint {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct EndpointStats {
     pub open_connections: u64,
-    pub incoming_handshakes: u64,
+    pub accepted_handshakes: u64,
     pub outgoing_handshakes: u64,
     pub refused_handshakes: u64,
     pub ignored_handshakes: u64,
@@ -430,7 +424,7 @@ impl EndpointInner {
             .accept(incoming, now, &mut response_buffer, server_config)
         {
             Ok((handle, conn)) => {
-                state.incoming_handshakes += 1;
+                state.accepted_handshakes += 1;
                 let socket = state.socket.clone();
                 let runtime = state.runtime.clone();
                 Ok(state
@@ -449,7 +443,6 @@ impl EndpointInner {
 
     pub(crate) fn refuse(&self, incoming: proto::Incoming) {
         let mut state = self.state.lock().unwrap();
-        state.incoming_handshakes += 1;
         state.refused_handshakes += 1;
         let mut response_buffer = Vec::new();
         let transmit = state.inner.refuse(incoming, &mut response_buffer);
@@ -466,7 +459,6 @@ impl EndpointInner {
 
     pub(crate) fn ignore(&self, incoming: proto::Incoming) {
         let mut state = self.state.lock().unwrap();
-        state.incoming_handshakes += 1;
         state.ignored_handshakes += 1;
         state.inner.ignore(incoming);
     }
@@ -487,7 +479,7 @@ pub(crate) struct State {
     ref_count: usize,
     driver_lost: bool,
     runtime: Arc<dyn Runtime>,
-    incoming_handshakes: u64,
+    accepted_handshakes: u64,
     outgoing_handshakes: u64,
     refused_handshakes: u64,
     ignored_handshakes: u64,
@@ -708,7 +700,7 @@ impl EndpointRef {
                 driver_lost: false,
                 recv_state,
                 runtime,
-                incoming_handshakes: 0,
+                accepted_handshakes: 0,
                 outgoing_handshakes: 0,
                 refused_handshakes: 0,
                 ignored_handshakes: 0,

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -341,6 +341,7 @@ impl Endpoint {
 
 // Struct for holding the stats returned from Endpoint::stats
 //
+#[non_exhaustive]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct EndpointStats {
     pub open_connections: u64,

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -47,7 +47,7 @@ pub struct Endpoint {
     pub(crate) default_client_config: Option<ClientConfig>,
     runtime: Arc<dyn Runtime>,
 }
-
+#[derive(Debug, Default, Copy, Clone)]
 pub struct EndpointStats {
     pub open_connections: usize,
     pub incoming_handshakes_since_last_sample: usize,

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -49,11 +49,11 @@ pub struct Endpoint {
 }
 
 pub struct EndpointStats {
-    open_connections: usize,
-    incoming_handshakes_since_last_sample: usize,
-    total_incoming_handshakes: usize,
-    total_outgoing_handshakes: usize,
-    outgoing_handshakes_since_last_sample: usize,
+    pub open_connections: usize,
+    pub incoming_handshakes_since_last_sample: usize,
+    pub total_incoming_handshakes: usize,
+    pub total_outgoing_handshakes: usize,
+    pub outgoing_handshakes_since_last_sample: usize,
 }
 
 impl Endpoint {

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -332,8 +332,7 @@ impl Endpoint {
     }
 }
 
-// Struct for holding the stats returned from Endpoint::stats
-//
+/// Struct for holding the stats returned from Endpoint::stats
 #[non_exhaustive]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct EndpointStats {

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -92,10 +92,12 @@ impl Endpoint {
         let open_connections = state.inner.open_connections() as u64;
         let total_incoming_handshakes = state.total_incoming_handshakes;
         let total_outgoing_handshakes = state.total_outgoing_handshakes;
+        let incoming_buffers_total_bytes = state.inner.incoming_buffers_total_bytes();
         EndpointStats {
             open_connections,
             total_incoming_handshakes,
             total_outgoing_handshakes,
+            incoming_buffers_total_bytes,
         }
     }
 
@@ -340,6 +342,7 @@ pub struct EndpointStats {
     pub open_connections: u64,
     pub total_incoming_handshakes: u64,
     pub total_outgoing_handshakes: u64,
+    pub incoming_buffers_total_bytes: u64,
 }
 
 /// A future that drives IO on an endpoint


### PR DESCRIPTION
In Anza, we need to get more insight into the resources being used by quinn in servicing quic handshakes. This PR seeks to add an initial interface to the Endpoint struct to allow for getting more detailed stats than just the open connections, and some initial data relevant to the handshakes. On a side note to the Quinn devs, if there is a good way to support getting the current number of open handshakes, we would be interested in know it. Currently, it seems that the Endpoint is not signaled when a Connecting future finishes, and to add such an event would require some refactoring, not to mention handling an extra event, locking, etc.