### PR TITLE
fix: remove unused dependency tracing-attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ members = ["quinn", "quinn-proto", "quinn-udp", "bench", "perf", "fuzz"]
 default-members = ["quinn", "quinn-proto", "quinn-udp", "bench", "perf"]
 resolver = "2"
 
+[workspace.dependencies]
+tracing = { version = "0.1.10", default-features = false, features = ["std"] }
+tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
+
 [profile.bench]
 debug = true
 

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -14,5 +14,5 @@ rcgen = "0.13"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["rt", "sync"] }
-tracing = "0.1.10"
+tracing = { version = "0.1.10", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -14,5 +14,5 @@ rcgen = "0.13"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["rt", "sync"] }
-tracing = { version = "0.1.10", default-features = false, features = ["std"] }
-tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -23,6 +23,6 @@ serde_json = { version = "1.0", optional = true }
 socket2 = "0.5"
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["rt", "macros", "signal", "net", "sync"] }
-tracing = "0.1.10"
+tracing = { version = "0.1.10", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
 bytes = "1"

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -23,6 +23,6 @@ serde_json = { version = "1.0", optional = true }
 socket2 = "0.5"
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["rt", "macros", "signal", "net", "sync"] }
-tracing = { version = "0.1.10", default-features = false, features = ["std"] }
-tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 bytes = "1"

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -34,7 +34,7 @@ rustls-platform-verifier = { version = "0.3", optional = true }
 slab = "0.4"
 thiserror = "1.0.21"
 tinyvec = { version = "1.1", features = ["alloc"] }
-tracing = "0.1.10"
+tracing = { version = "0.1.10", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -34,11 +34,11 @@ rustls-platform-verifier = { version = "0.3", optional = true }
 slab = "0.4"
 thiserror = "1.0.21"
 tinyvec = { version = "1.1", features = ["alloc"] }
-tracing = { version = "0.1.10", default-features = false, features = ["std"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
 assert_matches = "1.1"
 hex-literal = "0.4.0"
 rcgen = "0.13"
-tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
+tracing-subscriber = { workspace = true }
 lazy_static = "1"

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -21,7 +21,7 @@ log = ["tracing/log"]
 [dependencies]
 libc = "0.2.113"
 socket2 = "0.5"
-tracing = { version = "0.1.10", default-features = false, features = ["std"] }
+tracing = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52.0", features = ["Win32_Foundation", "Win32_System_IO", "Win32_Networking_WinSock"] }

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -21,7 +21,7 @@ log = ["tracing/log"]
 [dependencies]
 libc = "0.2.113"
 socket2 = "0.5"
-tracing = "0.1.10"
+tracing = { version = "0.1.10", default-features = false, features = ["std"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52.0", features = ["Win32_Foundation", "Win32_System_IO", "Win32_Networking_WinSock"] }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -42,7 +42,7 @@ proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.11.2", 
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"], optional = true }
 smol = { version = "2", optional = true }
 thiserror = "1.0.21"
-tracing = "0.1.10"
+tracing = { version = "0.1.10", default-features = false, features = ["std"] }
 tokio = { version = "1.28.1", features = ["sync"] }
 udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.5", default-features = false }
 

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -42,7 +42,7 @@ proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.11.2", 
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"], optional = true }
 smol = { version = "2", optional = true }
 thiserror = "1.0.21"
-tracing = { version = "0.1.10", default-features = false, features = ["std"] }
+tracing =  { workspace = true }
 tokio = { version = "1.28.1", features = ["sync"] }
 udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.5", default-features = false }
 
@@ -56,7 +56,7 @@ rcgen = "0.13"
 rustls-pemfile = "2"
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.28.1", features = ["rt", "rt-multi-thread", "time", "macros", "sync"] }
-tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
+tracing-subscriber = { workspace = true }
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }
 url = "2"
 


### PR DESCRIPTION
Various `quinn*` crates depend on `tracing`. `tracing` in its default feature set includes `tracing-attributes` in order to expose `#[instrument]` procedural macro in `tracing::instrument`.

None of `quinn*` make use of the `#[instrument]` macro. Thus the `tracing-attributes` dependency is unused.

To remove the dependency from the tree, this commit:

1. Restricts `tracing`'s `features` to `std`, effectively removing the `attributes` feature.
2. Consolidates the various `tracing*` imports across `quinn*` crates into workspace dependencies.

Let me know if you don't want to use workspace dependencies?

---

Context:

- Mozilla is currently using NSPR to send and receive QUIC datagrams.
- There is an ongoing effort to replace NSPR with `quinn-udp`, see https://github.com/quinn-rs/quinn/issues/1749.
- This effort is becoming more concrete, see [working implementation in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1901295) and corresponding [tracking issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1901295).
- Each new Rust dependency needs to be audited. The less dependencies (e.g. here `tracing-attributes`) the better.

As always, thank you for this project!

