### PR TITLE
Upgrade to rustc-hash 2

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -26,7 +26,7 @@ log = ["tracing/log"]
 [dependencies]
 arbitrary = { version = "1.0.1", features = ["derive"], optional = true }
 bytes = "1"
-rustc-hash = "1.1"
+rustc-hash = "2"
 rand = "0.8"
 ring = { version = "0.17", optional = true }
 rustls = { version = "0.23.5", default-features = false, features = ["ring", "std"], optional = true }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -36,7 +36,7 @@ async-std = { version = "1.11", optional = true }
 bytes = "1"
 # Enables futures::io::{AsyncRead, AsyncWrite} support for streams
 futures-io = { version = "0.3.19", optional = true }
-rustc-hash = "1.1"
+rustc-hash = "2"
 pin-project-lite = "0.2"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.11.2", default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"], optional = true }


### PR DESCRIPTION
I checked all uses and I don't think this appear in our public API at all.