### PR TITLE
Add rtt estimator snapshots, if more accurate rtt analysis is demanded

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -60,7 +60,8 @@ mod packet_crypto;
 use packet_crypto::{PrevCrypto, ZeroRttCrypto};
 
 mod paths;
-pub use paths::RttEstimator;
+pub use paths::{RttEstimator, RttEstimatorSnapshot};
+
 use paths::{PathData, PathResponses};
 
 mod send_buffer;
@@ -1298,6 +1299,12 @@ impl Connection {
     /// Current best estimate of this connection's latency (round-trip-time)
     pub fn rtt(&self) -> Duration {
         self.path.rtt.get()
+    }
+
+    /// A snapshot of the RTT estimator, which contains information
+    /// about this connection's latency.
+    pub fn rtt_estimator_snapshot(&self) -> RttEstimatorSnapshot {
+        self.path.rtt.snapshot()
     }
 
     /// Current state of this connection's congestion controller, for debugging purposes

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -146,6 +146,19 @@ impl PathData {
     }
 }
 
+/// A snapshot of a [`RttEstimator`] with no additional logic.
+#[derive(Debug, Copy, Clone)]
+pub struct RttEstimatorSnapshot {
+    /// The most recent RTT measurement made when receiving an ack for a previously unacked packet
+    pub latest: Duration,
+    /// The smoothed RTT of the connection, computed as described in RFC6298
+    pub smoothed: Option<Duration>,
+    /// The RTT variance, computed as described in RFC6298
+    pub var: Duration,
+    /// The minimum RTT seen in the connection, ignoring ack delay.
+    pub min: Duration,
+}
+
 /// RTT estimation for a particular network path
 #[derive(Copy, Clone)]
 pub struct RttEstimator {
@@ -185,6 +198,16 @@ impl RttEstimator {
     /// Minimum RTT registered so far for this estimator.
     pub fn min(&self) -> Duration {
         self.min
+    }
+
+    /// Get a snapshot of this RTT estimator.
+    pub fn snapshot(&self) -> RttEstimatorSnapshot {
+        RttEstimatorSnapshot {
+            latest: self.latest,
+            smoothed: self.smoothed,
+            var: self.var,
+            min: self.min,
+        }
     }
 
     // PTO computed as described in RFC9002#6.2.1

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -43,8 +43,8 @@ mod connection;
 pub use crate::connection::{
     BytesSource, Chunk, Chunks, ClosedStream, Connection, ConnectionError, ConnectionStats,
     Datagrams, Event, FinishError, FrameStats, PathStats, ReadError, ReadableError, RecvStream,
-    RttEstimator, SendDatagramError, SendStream, StreamEvent, Streams, UdpStats, WriteError,
-    Written,
+    RttEstimator, RttEstimatorSnapshot, SendDatagramError, SendStream, StreamEvent, Streams,
+    UdpStats, WriteError, Written,
 };
 
 mod config;

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 use proto::{
     congestion::Controller, ConnectionError, ConnectionHandle, ConnectionStats, Dir, EndpointEvent,
-    StreamEvent, StreamId,
+    RttEstimatorSnapshot, StreamEvent, StreamId,
 };
 
 /// In-progress connection attempt future
@@ -481,6 +481,16 @@ impl Connection {
     /// Current best estimate of this connection's latency (round-trip-time)
     pub fn rtt(&self) -> Duration {
         self.0.state.lock("rtt").inner.rtt()
+    }
+
+    /// A snapshot of the RTT estimator, which contains information
+    /// about this connection's latency.
+    pub fn rtt_estimator_snapshot(&self) -> RttEstimatorSnapshot {
+        self.0
+            .state
+            .lock("rtt_estimator_snapshot")
+            .inner
+            .rtt_estimator_snapshot()
     }
 
     /// Returns connection statistics


### PR DESCRIPTION
Motivation:

This would allow users to get more accurate RTT information for specific needs like the range of jitter in the rtt. Additionally it was not possible to request the other member variables of the rtt estimator before.
(https://github.com/quinn-rs/quinn/issues/931#issuecomment-2185200803)

This can be useful for more accurate timer tracking between server & client on less stable connections (or a dos attack on the server or similar things)

For example here, we see that the smoothed is _kinda_ outdated
```
[quinn/examples/client.rs:147:5] conn.rtt_estimator_snapshot() = RttEstimatorSnapshot {
    latest: 126.72µs,
    smoothed: Some(
        391.996µs,
    ),
    var: 237.002µs,
    min: 126.72µs,
}
```

On linux you can also use:
`sudo tc qdisc add dev lo root netem delay 300ms 300ms`

to simulate a massive lag, and then the smooth rtt value will only provide a rough estimate of the average latency, not about the range of the rtts.

If you think a whole snapshot is too much, I'd already be happy to get access to just the `latest` member of the rtt estimator, so I could at least fire up my own logic without applying a custom congestion controller.