### PR TITLE
quinn: Make `Endpoint::client` dual-stack V6 by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ default-members = ["quinn", "quinn-proto", "quinn-udp", "bench", "perf"]
 resolver = "2"
 
 [workspace.dependencies]
+socket2 = "0.5"
 tracing = { version = "0.1.10", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
 

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -20,7 +20,7 @@ log = ["tracing/log"]
 
 [dependencies]
 libc = "0.2.113"
-socket2 = "0.5"
+socket2 = { workspace = true }
 tracing = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -41,6 +41,7 @@ pin-project-lite = "0.2"
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.11.2", default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"], optional = true }
 smol = { version = "2", optional = true }
+socket2 = { workspace = true }
 thiserror = "1.0.21"
 tracing =  { workspace = true }
 tokio = { version = "1.28.1", features = ["sync"] }

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -406,7 +406,6 @@ fn echo_v4() {
 }
 
 #[test]
-#[cfg(any(target_os = "linux", target_os = "macos"))] // Dual-stack sockets aren't the default anywhere else.
 fn echo_dualstack() {
     run_echo(EchoArgs {
         client_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),


### PR DESCRIPTION
Following a conversation in the crate discord [[link]](https://discord.com/channels/976380008299917365/1063547094863978677/1230352131924688926) in which @Ralith mentioned:

> maybe `Endpoint::client` should do this by default? I suspect real applications inevitably need to use a lower level constructor, but it's one less footgun

This PR makes makes `quinn::Endpoint::client` use `socket2` to automatically try to set `IPV6_V6ONLY` to false if binding to a V6 address. Modifies the documentation to match. If the call to `set_only_v6` errors, it logs the error as a warning, but proceeds with the rest of the `client` method anyways.

Removes the OS-based gating from `quinn`'s `tests::echo_dualstack` test. Unfortunately(?), that tests seems to work on main for me anyways on my current system, so I'm leaning on the CI to make sure that there's not some common system where dual-stack conversion is always impossible. 