### PR TITLE
Allows build on Solaris (#1877)

### DIFF
--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -20,7 +20,7 @@ log = ["tracing/log"]
 direct-log = ["dep:log"]
 
 [dependencies]
-libc = "0.2.113"
+libc = "0.2.158"
 log = { workspace = true, optional = true }
 socket2 = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
+#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", target_os = "solaris")))]
 use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::{
     io::IoSliceMut,
@@ -51,7 +51,7 @@ fn ecn_v6() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
+#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", target_os = "solaris")))]
 fn ecn_v4() {
     let send = Socket::from(UdpSocket::bind("127.0.0.1:0").unwrap());
     let recv = Socket::from(UdpSocket::bind("127.0.0.1:0").unwrap());
@@ -71,7 +71,7 @@ fn ecn_v4() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
+#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", target_os = "solaris")))]
 fn ecn_v6_dualstack() {
     let recv = socket2::Socket::new(
         socket2::Domain::IPV6,
@@ -114,7 +114,7 @@ fn ecn_v6_dualstack() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
+#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", target_os = "solaris")))]
 fn ecn_v4_mapped_v6() {
     let send = socket2::Socket::new(
         socket2::Domain::IPV6,


### PR DESCRIPTION
This allows build on Solaris. Unfortunately at this moment tests are failing like this:
```
     Running unittests src/lib.rs (target/debug/deps/quinn-94a8797a83ab1c78)

running 18 tests
test work_limiter::tests::limit_work ... ok
test tests::local_addr ... ok
test tests::close_endpoint ... ok
test tests::handshake_timeout ... ok
test tests::zero_rtt ... FAILED
test tests::export_keying_material ... FAILED
test tests::rebind_recv ... FAILED
test tests::stress_stream_receive_window ... FAILED
test tests::echo_v4 ... FAILED
test tests::stress_both_windows ... FAILED
test tests::read_after_close ... FAILED
test tests::echo_v6 ... FAILED
test tests::stress_receive_window ... FAILED
test tests::echo_dualstack ... FAILED
test tests::ip_blocking ... FAILED
test tests::multiple_conns_with_zero_length_cids ... FAILED
test tests::stream_id_flow_control has been running for over 60 seconds
test tests::two_datagram_readers has been running for over 60 seconds
^C
``` 