### PR TITLE
Fix lack of reexport of ConnectionStats and ResetError

### DIFF
--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -63,8 +63,8 @@ mod work_limiter;
 
 pub use proto::{
     congestion, crypto, AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ClosedStream,
-    ConfigError, ConnectError, ConnectionClose, ConnectionError, EndpointConfig, IdleTimeout,
-    MtuDiscoveryConfig, ServerConfig, StreamId, Transmit, TransportConfig, VarInt, ConnectionStats
+    ConfigError, ConnectError, ConnectionClose, ConnectionError, ConnectionStats, EndpointConfig,
+    IdleTimeout, MtuDiscoveryConfig, ServerConfig, StreamId, Transmit, TransportConfig, VarInt,
 };
 #[cfg(feature = "rustls")]
 pub use rustls;

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -64,7 +64,7 @@ mod work_limiter;
 pub use proto::{
     congestion, crypto, AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ClosedStream,
     ConfigError, ConnectError, ConnectionClose, ConnectionError, EndpointConfig, IdleTimeout,
-    MtuDiscoveryConfig, ServerConfig, StreamId, Transmit, TransportConfig, VarInt,
+    MtuDiscoveryConfig, ServerConfig, StreamId, Transmit, TransportConfig, VarInt, ConnectionStats
 };
 #[cfg(feature = "rustls")]
 pub use rustls;
@@ -76,7 +76,7 @@ pub use crate::connection::{
 };
 pub use crate::endpoint::{Accept, Endpoint};
 pub use crate::incoming::{Incoming, IncomingFuture, RetryError};
-pub use crate::recv_stream::{ReadError, ReadExactError, ReadToEndError, RecvStream};
+pub use crate::recv_stream::{ReadError, ReadExactError, ReadToEndError, RecvStream, ResetError};
 #[cfg(feature = "runtime-async-std")]
 pub use crate::runtime::AsyncStdRuntime;
 #[cfg(feature = "runtime-smol")]


### PR DESCRIPTION
ConnectionStats and ResetError are now reexported for use with the public interface, they weren't before.

Respecfully, please take better care of your libeary. I encountered these issues and thought I had something wrong because surley something as obvious as not reexporting your own types would have been cought and fixed before publishing the latest release of quinn, but I guess not. But regaurdless, there it is, it's fixed.