### PR TITLE
[breaking] deps(udp): make tracing optional and add optional log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ futures-io = "0.3.19"
 hdrhistogram = { version = "7.2", default-features = false }
 hex-literal = "0.4"
 lazy_static = "1"
+log = "0.4"
 once_cell = "1.19"
 pin-project-lite = "0.2"
 rand = "0.8"

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.66"
 license = "MIT OR Apache-2.0"

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -14,14 +14,14 @@ workspace = ".."
 all-features = true
 
 [features]
-default = ["log"]
-# Write logs via the `log` crate when no `tracing` subscriber exists
-log = ["tracing/log"]
+default = ["tracing-log"]
+tracing-log = ["tracing", "tracing/log"]
 
 [dependencies]
 libc = "0.2.113"
+log = { workspace = true, optional = true }
 socket2 = { workspace = true }
-tracing = { workspace = true }
+tracing = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 once_cell = { workspace = true }

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -37,6 +37,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(all(feature = "log", not(feature = "tracing")))]
+use log::warn;
+#[cfg(feature = "tracing")]
 use tracing::warn;
 
 #[cfg(any(unix, windows))]
@@ -126,6 +129,7 @@ const IO_ERROR_LOG_INTERVAL: Duration = std::time::Duration::from_secs(60);
 ///
 /// Logging will only be performed if at least [`IO_ERROR_LOG_INTERVAL`]
 /// has elapsed since the last error was logged.
+#[cfg(any(feature = "tracing", feature = "log"))]
 fn log_sendmsg_error(
     last_send_error: &Mutex<Instant>,
     err: impl core::fmt::Debug,
@@ -140,6 +144,10 @@ fn log_sendmsg_error(
             err, transmit.destination, transmit.src_ip, transmit.ecn, transmit.contents.len(), transmit.segment_size);
     }
 }
+
+// No-op
+#[cfg(not(any(feature = "tracing", feature = "log")))]
+fn log_sendmsg_error(_: &Mutex<Instant>, _: impl core::fmt::Debug, _: &Transmit) {}
 
 /// A borrowed UDP socket
 ///

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 use socket2::SockRef;
+use tracing::{debug, error};
 
 use super::{
     cmsg, log_sendmsg_error, EcnCodepoint, RecvMeta, Transmit, UdpSockRef, IO_ERROR_LOG_INTERVAL,
@@ -87,7 +88,7 @@ impl UdpSocketState {
         if is_ipv4 || !io.only_v6()? {
             if let Err(err) = set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_RECVTOS, OPTION_ON)
             {
-                tracing::debug!("Ignoring error setting IP_RECVTOS on socket: {err:?}",);
+                debug!("Ignoring error setting IP_RECVTOS on socket: {err:?}",);
             }
         }
 
@@ -283,7 +284,7 @@ fn send(
                         // Prevent new transmits from being scheduled using GSO. Existing GSO transmits
                         // may already be in the pipeline, so we need to tolerate additional failures.
                         if state.max_gso_segments() > 1 {
-                            tracing::error!("got transmit error, halting segmentation offload");
+                            error!("got transmit error, halting segmentation offload");
                             state
                                 .max_gso_segments
                                 .store(1, std::sync::atomic::Ordering::Relaxed);

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -12,7 +12,10 @@ use std::{
     time::Instant,
 };
 
+#[cfg(all(feature = "log", not(feature = "tracing")))]
+use log::{debug, error};
 use socket2::SockRef;
+#[cfg(feature = "tracing")]
 use tracing::{debug, error};
 
 use super::{
@@ -86,9 +89,11 @@ impl UdpSocketState {
         // older macos versions also don't have the flag and will error out if we don't ignore it
         #[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
         if is_ipv4 || !io.only_v6()? {
+            #[allow(unused_variables)]
             if let Err(err) = set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_RECVTOS, OPTION_ON)
             {
-                debug!("Ignoring error setting IP_RECVTOS on socket: {err:?}",);
+                #[cfg(any(feature = "tracing", feature = "log"))]
+                debug!("Ignoring error setting IP_RECVTOS on socket: {err:?}");
             }
         }
 
@@ -284,6 +289,7 @@ fn send(
                         // Prevent new transmits from being scheduled using GSO. Existing GSO transmits
                         // may already be in the pipeline, so we need to tolerate additional failures.
                         if state.max_gso_segments() > 1 {
+                            #[cfg(any(feature = "tracing", feature = "log"))]
                             error!("got transmit error, halting segmentation offload");
                             state
                                 .max_gso_segments

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -45,7 +45,7 @@ socket2 = { workspace = true }
 thiserror = { workspace = true }
 tracing =  { workspace = true }
 tokio = { workspace = true }
-udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.5", default-features = false, features = ["tracing"] }
+udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.6", default-features = false, features = ["tracing"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -28,7 +28,7 @@ runtime-async-std = ["async-io", "async-std"]
 runtime-smol = ["async-io", "smol"]
 
 # Write logs via the `log` crate when no `tracing` subscriber exists
-log = ["tracing/log", "proto/log", "udp/log"]
+log = ["tracing/log", "proto/log", "udp/tracing-log"]
 
 [dependencies]
 async-io = { workspace = true, optional = true }
@@ -45,7 +45,7 @@ socket2 = { workspace = true }
 thiserror = { workspace = true }
 tracing =  { workspace = true }
 tokio = { workspace = true }
-udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.5", default-features = false }
+udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.5", default-features = false, features = ["tracing"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
This commit makes the `tracing` dependency in `quinn-udp` optional, but enabled by default. If disabled, `log` is used. By adding it to the `default` feature set, this is not a breaking change.

---

Context:
- I am working on integrating `quinn-udp` into Firefox. See [mozilla-central pull request](https://phabricator.services.mozilla.com/D212959).
- Each Rust dependency in Firefox needs to be audited via [`cargo vet`](https://github.com/mozilla/cargo-vet).
    ```
    ➜  mozilla-unified git:(quic-rust-udp-io) ✗ ./mach cargo vet 
    Vetting Failed!
    
    3 unvetted dependencies:
      tracing:0.1.37 missing ["safe-to-deploy"]
      tracing-attributes:0.1.24 missing ["safe-to-deploy"]
      tracing-core:0.1.30 missing ["safe-to-deploy"]
    
    recommended audits for safe-to-deploy:
        Command                                      Publisher  Used By                                   Audit Size
        cargo vet inspect tracing-attributes 0.1.24  hawkw      tracing                                   5025 lines
        cargo vet inspect tracing-core 0.1.30        hawkw      tracing                                   7032 lines
        cargo vet inspect tracing 0.1.34             hawkw      h2, warp, hyper, quinn-udp, and 2 others  11016 lines
    
    estimated audit backlog: 23073 lines
    ```

- `quinn-udp` optionally not depending on `tracing` will safe Mozilla a lot of work auditing all of `tracing`.

Questions:
- Would you be open to making `tracing` optional in `quinn-udp`? 
- If yes, how would you want to proceed with the `log` feature? See inline comment below.

Follow-up to https://github.com/quinn-rs/quinn/pull/1473 and https://github.com/quinn-rs/quinn/pull/1903