### PR TITLE
[non-breaking] deps(udp): make tracing optional and add optional log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ futures-io = "0.3.19"
 hdrhistogram = { version = "7.2", default-features = false }
 hex-literal = "0.4"
 lazy_static = "1"
+log = "0.4"
 once_cell = "1.19"
 pin-project-lite = "0.2"
 rand = "0.8"

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -20,7 +20,7 @@ ring = ["dep:ring"]
 # Enable rustls ring provider and direct ring usage
 # Provides `ClientConfig::with_platform_verifier()` convenience method
 platform-verifier = ["dep:rustls-platform-verifier"]
-# Write logs via the `log` crate when no `tracing` subscriber exists
+# Configure `tracing` to log events via `log` if no `tracing` subscriber exists.
 log = ["tracing/log"]
 
 [dependencies]

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -14,14 +14,16 @@ workspace = ".."
 all-features = true
 
 [features]
-default = ["log"]
-# Write logs via the `log` crate when no `tracing` subscriber exists
+default = ["tracing", "log"]
+# Configure `tracing` to log events via `log` if no `tracing` subscriber exists.
 log = ["tracing/log"]
+direct-log = ["dep:log"]
 
 [dependencies]
 libc = "0.2.113"
+log = { workspace = true, optional = true }
 socket2 = { workspace = true }
-tracing = { workspace = true }
+tracing = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 once_cell = { workspace = true }

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 rust-version = "1.66"
 license = "MIT OR Apache-2.0"

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -37,6 +37,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(all(feature = "direct-log", not(feature = "tracing")))]
+use log::warn;
+#[cfg(feature = "tracing")]
 use tracing::warn;
 
 #[cfg(any(unix, windows))]
@@ -126,6 +129,7 @@ const IO_ERROR_LOG_INTERVAL: Duration = std::time::Duration::from_secs(60);
 ///
 /// Logging will only be performed if at least [`IO_ERROR_LOG_INTERVAL`]
 /// has elapsed since the last error was logged.
+#[cfg(any(feature = "tracing", feature = "direct-log"))]
 fn log_sendmsg_error(
     last_send_error: &Mutex<Instant>,
     err: impl core::fmt::Debug,
@@ -140,6 +144,10 @@ fn log_sendmsg_error(
             err, transmit.destination, transmit.src_ip, transmit.ecn, transmit.contents.len(), transmit.segment_size);
     }
 }
+
+// No-op
+#[cfg(not(any(feature = "tracing", feature = "direct-log")))]
+fn log_sendmsg_error(_: &Mutex<Instant>, _: impl core::fmt::Debug, _: &Transmit) {}
 
 /// A borrowed UDP socket
 ///

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 use socket2::SockRef;
+use tracing::{debug, error};
 
 use super::{
     cmsg, log_sendmsg_error, EcnCodepoint, RecvMeta, Transmit, UdpSockRef, IO_ERROR_LOG_INTERVAL,
@@ -87,7 +88,7 @@ impl UdpSocketState {
         if is_ipv4 || !io.only_v6()? {
             if let Err(err) = set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_RECVTOS, OPTION_ON)
             {
-                tracing::debug!("Ignoring error setting IP_RECVTOS on socket: {err:?}",);
+                debug!("Ignoring error setting IP_RECVTOS on socket: {err:?}",);
             }
         }
 
@@ -283,7 +284,7 @@ fn send(
                         // Prevent new transmits from being scheduled using GSO. Existing GSO transmits
                         // may already be in the pipeline, so we need to tolerate additional failures.
                         if state.max_gso_segments() > 1 {
-                            tracing::error!("got transmit error, halting segmentation offload");
+                            error!("got transmit error, halting segmentation offload");
                             state
                                 .max_gso_segments
                                 .store(1, std::sync::atomic::Ordering::Relaxed);

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -27,7 +27,7 @@ runtime-tokio = ["tokio/time", "tokio/rt", "tokio/net"]
 runtime-async-std = ["async-io", "async-std"]
 runtime-smol = ["async-io", "smol"]
 
-# Write logs via the `log` crate when no `tracing` subscriber exists
+# Configure `tracing` to log events via `log` if no `tracing` subscriber exists.
 log = ["tracing/log", "proto/log", "udp/log"]
 
 [dependencies]
@@ -45,7 +45,7 @@ socket2 = { workspace = true }
 thiserror = { workspace = true }
 tracing =  { workspace = true }
 tokio = { workspace = true }
-udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.5", default-features = false }
+udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.5", default-features = false, features = ["tracing"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
Alternative to https://github.com/quinn-rs/quinn/pull/1921.

Implementation of @Ralith suggestion in https://github.com/quinn-rs/quinn/pull/1921#issuecomment-2237230567.

Not breaking `quinn-udp`. I.e. only bumping patch version to `v0.5.3`.