### PR TITLE
refactor!: rename log feature to tracing-log

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -27,7 +27,7 @@ jobs:
         #       | paste -sd ',' -
         run: |
           cargo llvm-cov \
-            --features="arbitrary,async-io,aws-lc-rs,bloom,direct-log,fast-apple-datapath,futures-io,json-output,lock_tracking,log,platform-verifier,qlog,ring,runtime-smol,runtime-tokio,rustls,rustls-aws-lc-rs,rustls-log,rustls-ring,serde,serde_json,smol,tracing" \
+            --features="arbitrary,async-io,aws-lc-rs,bloom,log,fast-apple-datapath,futures-io,json-output,lock_tracking,tracing-log,platform-verifier,qlog,ring,runtime-smol,runtime-tokio,rustls,rustls-aws-lc-rs,rustls-log,rustls-ring,serde,serde_json,smol,tracing" \
             --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -163,7 +163,7 @@ jobs:
 
       - run: cargo test --locked -p quinn-proto --target wasm32-unknown-unknown --no-run
       - run: cargo check --locked -p quinn-udp --target wasm32-unknown-unknown --no-default-features --features=tracing,log
-      - run: cargo rustc --locked -p quinn --target wasm32-unknown-unknown --no-default-features --features=log,platform-verifier,rustls-ring --crate-type=cdylib
+      - run: cargo rustc --locked -p quinn --target wasm32-unknown-unknown --no-default-features --features=tracing-log,platform-verifier,rustls-ring --crate-type=cdylib
 
       # If the Wasm file contains any 'import "env"' declarations, then
       # some non-Wasm-compatible code made it into the final code.

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -13,7 +13,7 @@ workspace = ".."
 [features]
 # NOTE: Please keep this in sync with the feature list in `.github/workflows/codecov.yml`, see
 # comment in that file for more information.
-default = ["rustls-ring", "log", "bloom"]
+default = ["rustls-ring", "tracing-log", "bloom"]
 aws-lc-rs = ["dep:aws-lc-rs", "aws-lc-rs?/aws-lc-sys", "aws-lc-rs?/prebuilt-nasm"]
 aws-lc-rs-fips = ["aws-lc-rs", "aws-lc-rs?/fips"]
 # Enables BloomTokenLog, and uses it by default
@@ -30,7 +30,7 @@ ring = ["dep:ring"]
 # Provides `ClientConfig::with_platform_verifier()` convenience method
 platform-verifier = ["dep:rustls-platform-verifier"]
 # Configure `tracing` to log events via `log` if no `tracing` subscriber exists.
-log = ["tracing/log"]
+tracing-log = ["tracing/log"]
 # Enable rustls logging
 rustls-log = ["rustls?/logging"]
 # Enable qlog support

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -13,10 +13,10 @@ workspace = ".."
 [features]
 # NOTE: Please keep this in sync with the feature list in `.github/workflows/codecov.yml`, see
 # comment in that file for more information.
-default = ["tracing", "log"]
+default = ["tracing", "tracing-log"]
 # Configure `tracing` to log events via `log` if no `tracing` subscriber exists.
-log = ["tracing/log"]
-direct-log = ["dep:log"]
+tracing-log = ["tracing/log"]
+log = ["dep:log"]
 # Use private Apple APIs to send multiple packets in a single syscall.
 fast-apple-datapath = []
 

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -56,13 +56,13 @@ mod imp;
 
 #[allow(unused_imports, unused_macros)]
 mod log {
-    #[cfg(all(feature = "direct-log", not(feature = "tracing")))]
+    #[cfg(all(feature = "log", not(feature = "tracing-log")))]
     pub(crate) use log::{debug, error, info, trace, warn};
 
-    #[cfg(feature = "tracing")]
+    #[cfg(feature = "tracing-log")]
     pub(crate) use tracing::{debug, error, info, trace, warn};
 
-    #[cfg(not(any(feature = "direct-log", feature = "tracing")))]
+    #[cfg(not(any(feature = "log", feature = "tracing-log")))]
     mod no_op {
         macro_rules! trace    ( ($($tt:tt)*) => {{}} );
         macro_rules! debug    ( ($($tt:tt)*) => {{}} );
@@ -73,7 +73,7 @@ mod log {
         pub(crate) use {debug, error, info, log_warn as warn, trace};
     }
 
-    #[cfg(not(any(feature = "direct-log", feature = "tracing")))]
+    #[cfg(not(any(feature = "log", feature = "tracing-log")))]
     pub(crate) use no_op::*;
 }
 
@@ -154,7 +154,7 @@ const IO_ERROR_LOG_INTERVAL: Duration = std::time::Duration::from_secs(60);
 ///
 /// Logging will only be performed if at least [`IO_ERROR_LOG_INTERVAL`]
 /// has elapsed since the last error was logged.
-#[cfg(all(not(wasm_browser), any(feature = "tracing", feature = "direct-log")))]
+#[cfg(all(not(wasm_browser), any(feature = "tracing-log", feature = "log")))]
 fn log_sendmsg_error(
     last_send_error: &Mutex<Instant>,
     err: impl core::fmt::Debug,
@@ -177,7 +177,7 @@ fn log_sendmsg_error(
 }
 
 // No-op
-#[cfg(not(any(wasm_browser, feature = "tracing", feature = "direct-log")))]
+#[cfg(not(any(wasm_browser, feature = "tracing-log", feature = "log")))]
 fn log_sendmsg_error(_: &Mutex<Instant>, _: impl core::fmt::Debug, _: &Transmit) {}
 
 /// A borrowed UDP socket

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 [features]
 # NOTE: Please keep this in sync with the feature list in `.github/workflows/codecov.yml`, see
 # comment in that file for more information.
-default = ["log", "platform-verifier", "runtime-tokio", "rustls-ring", "bloom"]
+default = ["tracing-log", "platform-verifier", "runtime-tokio", "rustls-ring", "bloom"]
 # Enables `Endpoint::client` and `Endpoint::server` conveniences
 aws-lc-rs = ["proto/aws-lc-rs"]
 aws-lc-rs-fips = ["proto/aws-lc-rs-fips"]
@@ -39,7 +39,7 @@ runtime-tokio = ["tokio/time", "tokio/rt", "tokio/net"]
 runtime-smol = ["async-io", "smol"]
 
 # Configure `tracing` to log events via `log` if no `tracing` subscriber exists.
-log = ["tracing/log", "proto/log", "udp/log"]
+tracing-log = ["tracing/log", "proto/tracing-log", "udp/tracing-log"]
 # Enable rustls logging
 rustls-log = ["rustls?/logging"]
 # Enable qlog support
@@ -119,4 +119,4 @@ required-features = ["rustls-ring"]
 
 [package.metadata.docs.rs]
 # all non-default features except fips (cannot build on docs.rs environment)
-features = ["lock_tracking", "rustls-aws-lc-rs", "rustls-ring", "runtime-tokio", "runtime-smol", "log", "rustls-log"]
+features = ["lock_tracking", "rustls-aws-lc-rs", "rustls-ring", "runtime-tokio", "runtime-smol", "tracing-log", "rustls-log"]


### PR DESCRIPTION
Previously `quinn*` would provide the `log` feature to log events via `log` if no `tracing` subscriber exists.

Later https://github.com/quinn-rs/quinn/pull/1923 allowed `quinn-udp` to log via `log` directly, making `tracing` an optional dependency. For that, it introduced the `direct-log` feature, a workaround name in order to not introduce a breaking change.

This commit cleans up the above, renaming the `log` feature to `tracing-log` and the `direct-log` to `log`. This is a breaking change and thus `quinn-udp` is bumped to `v0.6.0`.

See https://github.com/quinn-rs/quinn/pull/1921 for the full history.

---

Only merge before the next breaking change of `quinn`.

I am opening this up early as it is (a) still fresh in my mind, (b) in order to keep track of it and (c) make the next breaking change easier. Feel free to close if you don't think it is useful.