### PR TITLE
fix(udp): feature flag tracing in windows.rs

### DIFF
--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 rust-version = "1.66"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
8712910a made `tracing` optional and added optional `log`, but forgot to update `quinn-udp/src/windows.rs`. This commit fixes the oversight and bumps the `quinn-udp` version to `v0.5.4`.

---

Discovered in https://github.com/mozilla/neqo/pull/2002.

I assume that this is not an issue for most `quinn` users as they don't run `quinn-udp` with `default-features = false"`.

I am sorry for the oversight. I can look into a GitHub CI workflow that prevents this in the future tomorrow.