### PR TITLE
chore(quinn): feature flag socket2 imports

### DIFF
--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -25,6 +25,7 @@ use proto::{
     EndpointEvent, ServerConfig,
 };
 use rustc_hash::FxHashMap;
+#[cfg(feature = "ring")]
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::sync::{futures::Notified, mpsc, Notify};
 use tracing::{Instrument, Span};


### PR DESCRIPTION
The `socket2` imports are only used by the feature flagged `client` function. Feature flag the imports as well.

Avoids the following warning:

```
  --> quinn/src/endpoint.rs:28:15
   |
28 | use socket2::{Domain, Protocol, Socket, Type};
   |               ^^^^^^  ^^^^^^^^  ^^^^^^  ^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```