### PR TITLE
ci(rust.yml): add job testing feature permutations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -149,3 +149,16 @@ jobs:
         api-level: ${{ matrix.api-level }}
         arch: ${{ matrix.emulator-arch }}
         script: .github/workflows/rust-android-run-tests-on-emulator.sh
+
+  features:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      RUSTFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack check --feature-powerset --optional-deps --no-dev-deps --ignore-unknown-features --ignore-private --group-features runtime-async-std,async-io,async-std --group-features runtime-smol,async-io,smol


### PR DESCRIPTION
This pull request adds a GitHub job, testing all feature permutations (including optional dependencies), across all default workspace members. It uses [`cargo hack`](https://github.com/taiki-e/cargo-hack).

This workflow would for example have caught the following recent bugs before landing in `main`:
- https://github.com/quinn-rs/quinn/pull/1932
- https://github.com/quinn-rs/quinn/pull/1933

Right now this job takes 5m 1s on Ubuntu, 4m 42s on MacOS  and 8m 29s Windows. In case you consider that too long, we could drop `--optional-deps` or exclude some features (`--exclude-features`). 