### PR TITLE
refactor(udp): introduce log facade

### DIFF
--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -37,11 +37,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-#[cfg(all(feature = "direct-log", not(feature = "tracing")))]
-use log::warn;
-#[cfg(feature = "tracing")]
-use tracing::warn;
-
 #[cfg(any(unix, windows))]
 mod cmsg;
 
@@ -57,6 +52,29 @@ mod imp;
 #[cfg(not(any(unix, windows)))]
 #[path = "fallback.rs"]
 mod imp;
+
+#[allow(unused_imports, unused_macros)]
+mod log {
+    #[cfg(all(feature = "direct-log", not(feature = "tracing")))]
+    pub(crate) use log::{debug, error, info, trace, warn};
+
+    #[cfg(feature = "tracing")]
+    pub(crate) use tracing::{debug, error, info, trace, warn};
+
+    #[cfg(not(any(feature = "direct-log", feature = "tracing")))]
+    mod no_op {
+        macro_rules! trace    ( ($($tt:tt)*) => {{}} );
+        macro_rules! debug    ( ($($tt:tt)*) => {{}} );
+        macro_rules! info     ( ($($tt:tt)*) => {{}} );
+        macro_rules! log_warn ( ($($tt:tt)*) => {{}} );
+        macro_rules! error    ( ($($tt:tt)*) => {{}} );
+
+        pub(crate) use {debug, error, info, log_warn as warn, trace};
+    }
+
+    #[cfg(not(any(feature = "direct-log", feature = "tracing")))]
+    pub(crate) use no_op::*;
+}
 
 pub use imp::UdpSocketState;
 
@@ -139,7 +157,7 @@ fn log_sendmsg_error(
     let last_send_error = &mut *last_send_error.lock().expect("poisend lock");
     if now.saturating_duration_since(*last_send_error) > IO_ERROR_LOG_INTERVAL {
         *last_send_error = now;
-        warn!(
+        log::warn!(
         "sendmsg error: {:?}, Transmit: {{ destination: {:?}, src_ip: {:?}, enc: {:?}, len: {:?}, segment_size: {:?} }}",
             err, transmit.destination, transmit.src_ip, transmit.ecn, transmit.contents.len(), transmit.segment_size);
     }

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -12,14 +12,11 @@ use std::{
     time::Instant,
 };
 
-#[cfg(all(feature = "direct-log", not(feature = "tracing")))]
-use log::{debug, error};
 use socket2::SockRef;
-#[cfg(feature = "tracing")]
-use tracing::{debug, error};
 
 use super::{
-    cmsg, log_sendmsg_error, EcnCodepoint, RecvMeta, Transmit, UdpSockRef, IO_ERROR_LOG_INTERVAL,
+    cmsg, log::debug, log_sendmsg_error, EcnCodepoint, RecvMeta, Transmit, UdpSockRef,
+    IO_ERROR_LOG_INTERVAL,
 };
 
 // Defined in netinet6/in6.h on OpenBSD, this is not yet exported by the libc crate
@@ -89,11 +86,10 @@ impl UdpSocketState {
         // older macos versions also don't have the flag and will error out if we don't ignore it
         #[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
         if is_ipv4 || !io.only_v6()? {
-            #[allow(unused_variables)]
-            if let Err(err) = set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_RECVTOS, OPTION_ON)
+            if let Err(_err) =
+                set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_RECVTOS, OPTION_ON)
             {
-                #[cfg(any(feature = "tracing", feature = "direct-log"))]
-                debug!("Ignoring error setting IP_RECVTOS on socket: {err:?}");
+                debug!("Ignoring error setting IP_RECVTOS on socket: {_err:?}");
             }
         }
 
@@ -289,8 +285,7 @@ fn send(
                         // Prevent new transmits from being scheduled using GSO. Existing GSO transmits
                         // may already be in the pipeline, so we need to tolerate additional failures.
                         if state.max_gso_segments() > 1 {
-                            #[cfg(any(feature = "tracing", feature = "direct-log"))]
-                            error!("got transmit error, halting segmentation offload");
+                            crate::log::error!("got transmit error, halting segmentation offload");
                             state
                                 .max_gso_segments
                                 .store(1, std::sync::atomic::Ordering::Relaxed);


### PR DESCRIPTION
Add `log` facade that either dispatches to `tracing` or `log`, or to a no-op implementation.

As suggested in https://github.com/quinn-rs/quinn/pull/1932#pullrequestreview-2192415008.