### PR TITLE
refactor: move rust-version to workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ members = ["quinn", "quinn-proto", "quinn-udp", "bench", "perf", "fuzz"]
 default-members = ["quinn", "quinn-proto", "quinn-udp", "bench", "perf"]
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.70.0"
+
 [workspace.dependencies]
 anyhow = "1.0.22"
 arbitrary = { version = "1.0.1", features = ["derive"] }

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quinn-proto"
 version = "0.11.4"
 edition = "2021"
-rust-version = "1.70"
+rust-version.workspace = true
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/quinn-rs/quinn"
 description = "State machine for the QUIC transport protocol"

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quinn-udp"
 version = "0.5.4"
 edition = "2021"
-rust-version = "1.70"
+rust-version.workspace = true
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/quinn-rs/quinn"
 description = "UDP sockets with ECN information for the QUIC transport protocol"

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["quic"]
 categories = [ "network-programming", "asynchronous" ]
 workspace = ".."
 edition = "2021"
-rust-version = "1.70"
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Follow-up to suggestion in https://github.com/quinn-rs/quinn/pull/1939#discussion_r1690309715. //CC @Ralith

Feel free to close if not needed.