### PR TITLE
Expose the Handshake Confirmed state

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2475,6 +2475,9 @@ impl Connection {
                 }
 
                 self.events.push_back(Event::Connected);
+                if self.side.is_server() {
+                    self.events.push_back(Event::HandshakeConfirmed);
+                }
                 self.state = State::Established;
                 trace!("established");
                 Ok(())
@@ -2884,6 +2887,7 @@ impl Connection {
                         ));
                     }
                     if self.spaces[SpaceId::Handshake].crypto.is_some() {
+                        self.events.push_back(Event::HandshakeConfirmed);
                         self.discard_space(now, SpaceId::Handshake);
                     }
                 }
@@ -3726,6 +3730,8 @@ pub enum Event {
     HandshakeDataReady,
     /// The connection was successfully established
     Connected,
+    /// The handshake was [`confirmed`](https://www.rfc-editor.org/rfc/rfc9001#name-handshake-confirmed)
+    HandshakeConfirmed,
     /// The connection was lost
     ///
     /// Emitted if the peer closes the connection or an error is encountered.

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -578,6 +578,10 @@ fn zero_rtt_happypath() {
     );
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
+        Some(Event::HandshakeConfirmed)
+    );
+    assert_matches!(
+        pair.server_conn_mut(server_ch).poll(),
         Some(Event::Stream(StreamEvent::Opened { dir: Dir::Uni }))
     );
 
@@ -613,6 +617,10 @@ fn zero_rtt_rejection() {
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
         Some(Event::Connected)
+    );
+    assert_matches!(
+        pair.server_conn_mut(server_ch).poll(),
+        Some(Event::HandshakeConfirmed)
     );
     assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
     pair.client
@@ -654,6 +662,10 @@ fn zero_rtt_rejection() {
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
         Some(Event::Connected)
+    );
+    assert_matches!(
+        pair.server_conn_mut(server_ch).poll(),
+        Some(Event::HandshakeConfirmed)
     );
     assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
     let s2 = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
@@ -731,6 +743,10 @@ fn test_zero_rtt_incoming_limit<F: FnOnce(&mut ServerConfig)>(configure_server: 
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
         Some(Event::Connected)
+    );
+    assert_matches!(
+        pair.server_conn_mut(server_ch).poll(),
+        Some(Event::HandshakeConfirmed)
     );
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -228,12 +228,20 @@ impl Pair {
             Some(Event::Connected { .. })
         );
         assert_matches!(
+            self.client_conn_mut(client_ch).poll(),
+            Some(Event::HandshakeConfirmed)
+        );
+        assert_matches!(
             self.server_conn_mut(server_ch).poll(),
             Some(Event::HandshakeDataReady)
         );
         assert_matches!(
             self.server_conn_mut(server_ch).poll(),
             Some(Event::Connected { .. })
+        );
+        assert_matches!(
+            self.server_conn_mut(server_ch).poll(),
+            Some(Event::HandshakeConfirmed)
         );
     }
 


### PR DESCRIPTION
This is convenient for some client authentication use cases, and for tests to know when it's safe to force a key update.