### PR TITLE
Fix incorrect initial DCID indexing on retried connections

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -531,7 +531,7 @@ impl Endpoint {
 
         let incoming_idx = self.incoming_buffers.insert(IncomingBuffer::default());
         self.index
-            .insert_initial_incoming(orig_dst_cid, incoming_idx);
+            .insert_initial_incoming(header.dst_cid, incoming_idx);
 
         Some(DatagramEvent::NewConnection(Incoming {
             addresses,

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -172,7 +172,17 @@ fn stateless_retry() {
     let _guard = subscribe();
     let mut pair = Pair::default();
     pair.server.incoming_connection_behavior = IncomingConnectionBehavior::Validate;
-    pair.connect();
+    let (client_ch, _server_ch) = pair.connect();
+    pair.client
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .close(pair.time, VarInt(42), Bytes::new());
+    pair.drive();
+    assert_eq!(pair.client.known_connections(), 0);
+    assert_eq!(pair.client.known_cids(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
 }
 
 #[test]


### PR DESCRIPTION
This could also cause other packets received before the server accepts the connection to be lost.

Noticed while checking some unrelated assumptions.