### PR TITLE
refactor(fuzz): add `#[cfg(fuzzing)]`

### DIFF
--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(fuzzing)");
+}

--- a/fuzz/fuzz_targets/packet.rs
+++ b/fuzz/fuzz_targets/packet.rs
@@ -2,12 +2,15 @@
 
 extern crate proto;
 
+#[cfg(fuzzing)]
 use libfuzzer_sys::fuzz_target;
+#[cfg(fuzzing)]
 use proto::{
     fuzzing::{PacketParams, PartialDecode},
     FixedLengthConnectionIdParser, DEFAULT_SUPPORTED_VERSIONS,
 };
 
+#[cfg(fuzzing)]
 fuzz_target!(|data: PacketParams| {
     let len = data.buf.len();
     let supported_versions = DEFAULT_SUPPORTED_VERSIONS.to_vec();

--- a/fuzz/fuzz_targets/streamid.rs
+++ b/fuzz/fuzz_targets/streamid.rs
@@ -1,10 +1,14 @@
 #![no_main]
+#[cfg(fuzzing)]
 use arbitrary::Arbitrary;
+#[cfg(fuzzing)]
 use libfuzzer_sys::fuzz_target;
 
 extern crate proto;
+#[cfg(fuzzing)]
 use proto::{Dir, Side, StreamId};
 
+#[cfg(fuzzing)]
 #[derive(Arbitrary, Debug)]
 struct StreamIdParams {
     side: Side,
@@ -12,6 +16,7 @@ struct StreamIdParams {
     index: u64,
 }
 
+#[cfg(fuzzing)]
 fuzz_target!(|data: StreamIdParams| {
     let s = StreamId::new(data.side, data.dir, data.index);
     assert_eq!(s.initiator(), data.side);

--- a/fuzz/fuzz_targets/streams.rs
+++ b/fuzz/fuzz_targets/streams.rs
@@ -1,13 +1,19 @@
 #![no_main]
 
+#[cfg(fuzzing)]
 use arbitrary::Arbitrary;
+#[cfg(fuzzing)]
 use libfuzzer_sys::fuzz_target;
 
 extern crate proto;
+#[cfg(fuzzing)]
 use proto::fuzzing::{ConnectionState, ResetStream, Retransmits, StreamsState};
+#[cfg(fuzzing)]
 use proto::{Dir, Side, StreamId, VarInt};
+#[cfg(fuzzing)]
 use proto::{SendStream, Streams};
 
+#[cfg(fuzzing)]
 #[derive(Arbitrary, Debug)]
 struct StreamParams {
     side: Side,
@@ -19,6 +25,7 @@ struct StreamParams {
     dir: Dir,
 }
 
+#[cfg(fuzzing)]
 #[derive(Arbitrary, Debug)]
 enum Operation {
     Open,
@@ -29,6 +36,7 @@ enum Operation {
     Reset(StreamId),
 }
 
+#[cfg(fuzzing)]
 fuzz_target!(|input: (StreamParams, Vec<Operation>)| {
     let (params, operations) = input;
     let (mut pending, conn_state) = (Retransmits::default(), ConnectionState::Established);


### PR DESCRIPTION
`quinn-proto` exposes some hooks for fuzzing only. These are behind a `#[cfg(fuzzing)]`.

The `fuzz` crate imports these hooks, but without the `#[cfg(fuzzing)]`.

Running `cargo check --workspace` thus fails importing each of these hooks. For example:

```
error[E0432]: unresolved import `proto::fuzzing`
  --> fuzz/fuzz_targets/packet.rs:7:5
   |
7  |     fuzzing::{PacketParams, PartialDecode},
   |     ^^^^^^^ could not find `fuzzing` in `proto`
```

This commit adds the various `#[cfg(fuzzing)]` to `fuzz/`, preventing the above errors.

---

Needed for https://github.com/quinn-rs/quinn/pull/1934.

