### PR TITLE
ci: add Android job

### DIFF
--- a/.github/workflows/rust-android-run-tests-on-emulator.sh
+++ b/.github/workflows/rust-android-run-tests-on-emulator.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+adb wait-for-device
+while [[ -z "$(adb shell getprop sys.boot_completed | tr -d '\r')" ]]; do sleep 1; done
+
+any_failures=0
+for test in $(find target/${{ matrix.target }}/debug/deps/ -type f -executable ! -name "*.so" -name "*-*"); do
+    adb push "$test" /data/local/tmp/
+    adb shell chmod +x /data/local/tmp/$(basename "$test")
+    adb shell /data/local/tmp/$(basename "$test") || any_failures=1
+done
+
+exit $any_failures

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,3 +91,61 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: EmbarkStudios/cargo-deny-action@v2
+
+  test-android:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-linux-android
+            emulator-arch: x86_64
+            # Note that x86_64 image is only available for API 21+. See
+            # https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#configurations.
+            api-level: 21
+          - target: i686-linux-android
+            emulator-arch: x86
+            api-level: 19
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'zulu'
+        java-version: '21'
+
+    - name: Install Android SDK
+      uses: android-actions/setup-android@v2
+
+    - name: Install Android NDK
+      run: sdkmanager --install "ndk;25.2.9519653"
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        target: ${{ matrix.target }}
+
+    - uses: Swatinem/rust-cache@v2
+
+    - name: Install cargo-ndk
+      run: cargo install cargo-ndk
+
+    - name: Build unit tests for Android
+      run: cargo ndk -t ${{ matrix.target }} test --no-run
+
+    - name: Enable KVM group perms
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
+    - name: Set up Android Emulator and run tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ matrix.api-level }}
+        arch: ${{ matrix.emulator-arch }}
+        script: .github/workflows/rust-android-run-tests-on-emulator.sh

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -523,6 +523,7 @@ fn run_echo(args: EchoArgs) {
             // requires modifying this test - please update the list of supported
             // platforms in the doc comment of `quinn_udp::RecvMeta::dst_ip`.
             if cfg!(target_os = "linux")
+                || cfg!(target_os = "android")
                 || cfg!(target_os = "freebsd")
                 || cfg!(target_os = "openbsd")
                 || cfg!(target_os = "netbsd")


### PR DESCRIPTION
Runs unit tests on Android emulator for both `x86` and `x86_64`.

---

Tracking issue: https://github.com/quinn-rs/quinn/issues/1778

Foundation to test https://github.com/quinn-rs/quinn/issues/1947.