### PR TITLE
Add expect message to unwrap in PacketBuilder

### DIFF
--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -138,7 +138,9 @@ impl PacketBuilder {
                 crypto.packet.local.tag_len(),
             )
         } else if space_id == SpaceId::Data {
-            let zero_rtt = conn.zero_rtt_crypto.as_ref().unwrap();
+            let zero_rtt = conn.zero_rtt_crypto.as_ref().expect(
+                "sending packets in the application data space requires known 0-RTT or 1-RTT keys",
+            );
             (zero_rtt.header.sample_size(), zero_rtt.packet.tag_len())
         } else {
             unreachable!("tried to send {:?} packet without keys", space_id);


### PR DESCRIPTION
This unwrap can be hit by a bad custom `Session` implementation. Add the message suggested in #1928 give a hint as to what went wrong.

Fixes #1928.