### PR TITLE
Revert "proto: yield transport error for Initial packets with no CRYPTO"

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1907,21 +1907,6 @@ impl Connection {
         if let Some(data) = remaining {
             self.handle_coalesced(now, remote, ecn, data);
         }
-
-        if self.highest_space == SpaceId::Initial && self.state.is_handshake() {
-            // "The first packet sent by a client always includes a CRYPTO frame that contains the
-            // start or all of the first cryptographic handshake message. The first CRYPTO frame
-            // sent always begins at an offset of 0; see Section 7."
-            // https://www.rfc-editor.org/rfc/rfc9000.html#section-17.2.2
-            let space = &self.spaces[SpaceId::Initial];
-            if space.crypto_stream.bytes_read() == 0 {
-                return Err(TransportError::PROTOCOL_VIOLATION(
-                    "received initial packet without CRYPTO frames",
-                )
-                .into());
-            }
-        }
-
         Ok(())
     }
 


### PR DESCRIPTION
This condition can arise due to packet loss or reordering.

This reverts commit 470b2134c4cb54c18f6ae858de2a25005a97c255.