### PR TITLE
No workspace lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,3 @@ debug = true
 
 [profile.release]
 debug = true
-
-[workspace.lints.rust]
-# https://rust-fuzz.github.io/book/cargo-fuzz/guide.html#cfgfuzzing
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -43,5 +43,6 @@ rcgen = { workspace = true }
 tracing-subscriber = { workspace = true }
 lazy_static = "1"
 
-[lints]
-workspace = true
+[lints.rust]
+# https://rust-fuzz.github.io/book/cargo-fuzz/guide.html#cfgfuzzing
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-proto"
-version = "0.11.4"
+version = "0.11.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -35,6 +35,3 @@ criterion = "0.5"
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.bench]
 name = "throughput"
 harness = false
-
-[lints]
-workspace = true

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -85,6 +85,3 @@ required-features = ["rustls"]
 name = "bench"
 harness = false
 required-features = ["rustls"]
-
-[lints]
-workspace = true


### PR DESCRIPTION
After publishing quinn-proto 0.11.4, building downstream crates (even quinn itself) fails with:

```
error: failed to download `quinn-proto v0.11.4`

Caused by:
  unable to get packages from source

Caused by:
  failed to parse manifest at `/home/ralith/.cargo/registry/src/index.crates.io-6f17d22bba15001f/quinn-proto-0.11.4/Cargo.toml`

Caused by:
  error inheriting `lints` from workspace root manifest's `workspace.lints`

Caused by:
  failed to find a workspace root
```

This reproduces on cargo nightly, 1.80, and 1.79. quinn-proto 0.11.4 has been yanked.