### PR TITLE
Bump quinn -> quinn-proto version requirement

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -38,7 +38,7 @@ bytes = { workspace = true }
 futures-io = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 pin-project-lite = { workspace = true }
-proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.11.2", default-features = false }
+proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.11.5", default-features = false }
 rustls = { workspace = true, optional = true }
 smol = { workspace = true, optional = true }
 socket2 = { workspace = true }


### PR DESCRIPTION
Needed for e.g. the HandshakeConfirmed event.

Noticed this *just* before publishing.