### PR TITLE
Revert "Expose the Handshake Confirmed state"

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-proto"
-version = "0.11.5"
+version = "0.11.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2460,9 +2460,6 @@ impl Connection {
                 }
 
                 self.events.push_back(Event::Connected);
-                if self.side.is_server() {
-                    self.events.push_back(Event::HandshakeConfirmed);
-                }
                 self.state = State::Established;
                 trace!("established");
                 Ok(())
@@ -2872,7 +2869,6 @@ impl Connection {
                         ));
                     }
                     if self.spaces[SpaceId::Handshake].crypto.is_some() {
-                        self.events.push_back(Event::HandshakeConfirmed);
                         self.discard_space(now, SpaceId::Handshake);
                     }
                 }
@@ -3715,8 +3711,6 @@ pub enum Event {
     HandshakeDataReady,
     /// The connection was successfully established
     Connected,
-    /// The handshake was [`confirmed`](https://www.rfc-editor.org/rfc/rfc9001#name-handshake-confirmed)
-    HandshakeConfirmed,
     /// The connection was lost
     ///
     /// Emitted if the peer closes the connection or an error is encountered.

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -588,10 +588,6 @@ fn zero_rtt_happypath() {
     );
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
-        Some(Event::HandshakeConfirmed)
-    );
-    assert_matches!(
-        pair.server_conn_mut(server_ch).poll(),
         Some(Event::Stream(StreamEvent::Opened { dir: Dir::Uni }))
     );
 
@@ -627,10 +623,6 @@ fn zero_rtt_rejection() {
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
         Some(Event::Connected)
-    );
-    assert_matches!(
-        pair.server_conn_mut(server_ch).poll(),
-        Some(Event::HandshakeConfirmed)
     );
     assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
     pair.client
@@ -672,10 +664,6 @@ fn zero_rtt_rejection() {
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
         Some(Event::Connected)
-    );
-    assert_matches!(
-        pair.server_conn_mut(server_ch).poll(),
-        Some(Event::HandshakeConfirmed)
     );
     assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
     let s2 = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
@@ -753,10 +741,6 @@ fn test_zero_rtt_incoming_limit<F: FnOnce(&mut ServerConfig)>(configure_server: 
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),
         Some(Event::Connected)
-    );
-    assert_matches!(
-        pair.server_conn_mut(server_ch).poll(),
-        Some(Event::HandshakeConfirmed)
     );
     assert_matches!(
         pair.server_conn_mut(server_ch).poll(),

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -228,20 +228,12 @@ impl Pair {
             Some(Event::Connected { .. })
         );
         assert_matches!(
-            self.client_conn_mut(client_ch).poll(),
-            Some(Event::HandshakeConfirmed)
-        );
-        assert_matches!(
             self.server_conn_mut(server_ch).poll(),
             Some(Event::HandshakeDataReady)
         );
         assert_matches!(
             self.server_conn_mut(server_ch).poll(),
             Some(Event::Connected { .. })
-        );
-        assert_matches!(
-            self.server_conn_mut(server_ch).poll(),
-            Some(Event::HandshakeConfirmed)
         );
     }
 

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -349,22 +349,6 @@ impl Connection {
         }
     }
 
-    /// Wait for the connection to enter the [`Handshake
-    /// Confirmed`](https://www.rfc-editor.org/rfc/rfc9001#name-handshake-confirmed) state
-    ///
-    /// For servers, this is the same as the time the connection becomes established. For clients,
-    /// this is the earliest time at which a client can know that the server has accepted client
-    /// authentication, typically one round-trip after the connection becomes established.
-    pub async fn handshake_confirmed(&self) -> Result<(), ConnectionError> {
-        self.0.shared.handshake_confirmed.notified().await;
-        self.0
-            .state
-            .lock("handshake_confirmed")
-            .error
-            .as_ref()
-            .map_or(Ok(()), |err| Err(err.clone()))
-    }
-
     /// Wait for the connection to be closed for any reason
     ///
     /// Despite the return type's name, closed connections are often not an error condition at the
@@ -571,8 +555,7 @@ impl Connection {
         self.0.stable_id()
     }
 
-    // Update traffic keys spontaneously for testing purposes. Must not be called before the
-    // handshake is confirmed.
+    // Update traffic keys spontaneously for testing purposes.
     #[doc(hidden)]
     pub fn force_key_update(&self) {
         self.0
@@ -944,7 +927,6 @@ pub(crate) struct Shared {
     datagram_received: Notify,
     datagrams_unblocked: Notify,
     closed: Notify,
-    handshake_confirmed: Notify,
 }
 
 pub(crate) struct State {
@@ -1102,9 +1084,6 @@ impl State {
                         wake_all(&mut self.stopped);
                     }
                 }
-                HandshakeConfirmed => {
-                    shared.handshake_confirmed.notify_waiters();
-                }
                 ConnectionLost { reason } => {
                     self.terminate(reason, shared);
                 }
@@ -1206,7 +1185,6 @@ impl State {
         shared.stream_incoming[Dir::Bi as usize].notify_waiters();
         shared.datagram_received.notify_waiters();
         shared.datagrams_unblocked.notify_waiters();
-        shared.handshake_confirmed.notify_waiters();
         if let Some(x) = self.on_connected.take() {
             let _ = x.send(false);
         }


### PR DESCRIPTION
This was an unintended breaking change. We can bring it back in the next major release, but there's some bugfixes I'd like to get into 0.11 first. Alternatively, we could branch 0.11 off before this was committed and cherry-pick everything into it.

This reverts commit 391824b9df07973b0ce4f90794820406c0717c81.