### PR TITLE
read remaining data before deciding to send STOP_SENDING frames

### DIFF
--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -30,6 +30,8 @@ runtime-smol = ["async-io", "smol"]
 # Configure `tracing` to log events via `log` if no `tracing` subscriber exists.
 log = ["tracing/log", "proto/log", "udp/log"]
 
+futures-io = ["dep:futures-io"]
+
 [dependencies]
 async-io = { workspace = true, optional = true }
 async-std = { workspace = true, optional = true }
@@ -43,9 +45,11 @@ rustls = { workspace = true, optional = true }
 smol = { workspace = true, optional = true }
 socket2 = { workspace = true }
 thiserror = { workspace = true }
-tracing =  { workspace = true }
+tracing = { workspace = true }
 tokio = { workspace = true }
-udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.5", default-features = false, features = ["tracing"] }
+udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.5", default-features = false, features = [
+    "tracing",
+] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -56,7 +60,12 @@ rand = { workspace = true }
 rcgen = { workspace = true }
 rustls-pemfile = { workspace = true }
 clap = { workspace = true }
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time", "macros"] }
+tokio = { workspace = true, features = [
+    "rt",
+    "rt-multi-thread",
+    "time",
+    "macros",
+] }
 tracing-subscriber = { workspace = true }
 tracing-futures = { workspace = true }
 url = { workspace = true }


### PR DESCRIPTION
The [h3](https://github.com/hyperium/h3) repository uses [the h3spec tool](https://github.com/kazu-yamamoto/h3spec) to test the codebase.

After I tried out some stuff in https://github.com/hyperium/h3/pull/244 I noticed that h3spec is failing:
https://github.com/hyperium/h3/actions/runs/10340143789/job/28620383129#step:6:1210

I think this is because h3 drops the stream before all data is read. But the error didn't occur every time.

This fixes the problem by reading and ignoring all stream data before the stream gets dropped.

If you consider merging this, please review carefully because I am not familiar with the internals of quinn or quic.
