### PR TITLE
Revert "Implement fallback for `sendmmsg` and `recvmmsg`"

### DIFF
--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.5.4"
+version = "0.5.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
This reverts commit e6f184489e703bcf70850f99373c88746c250662.

e6f18448 called `sendmmsg` and `recvmmsg` through `libc::syscall` instead of `libc::sendmmsg` and `libc::recvmmsg`, thus preventing linking issues on old Android systems where `libc::sendmmsg` and `libc::recvmmsg` isn't available.

In https://github.com/quinn-rs/quinn/issues/1503#issuecomment-2285962727 the suggestion was made to no longer support these old Android systems (API level 16).

This commit reverts e6f18448. Given that `sendmmsg` support was previously dropped in ee088265, only the `recvmmsg` calls are reverted.

---

Alternative to https://github.com/quinn-rs/quinn/pull/1964. Given the additional simplicity, my preference is for this change.