### PR TITLE
exposes current path MTU discovered in connection stats

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1207,6 +1207,7 @@ impl Connection {
         let mut stats = self.stats;
         stats.path.rtt = self.path.rtt.get();
         stats.path.cwnd = self.path.congestion.window();
+        stats.path.current_mtu = self.path.mtud.current_mtu();
 
         stats
     }

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -152,6 +152,8 @@ pub struct PathStats {
     pub lost_plpmtud_probes: u64,
     /// The number of times a black hole was detected in the path
     pub black_holes_detected: u64,
+    /// Largest UDP payload size the path currently supports
+    pub current_mtu: u16,
 }
 
 /// Connection statistics


### PR DESCRIPTION
* For debugging and performance analysis purposes we need to inspect path MTU discovered by the connection.
* The commit exposes current path MTU discovered in connection stats. 