### PR TITLE
Require slab `0.4.6` or higher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rustls-pemfile = "2"
 rustls-platform-verifier = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-slab = "0.4"
+slab = "0.4.6"
 smol = "2"
 socket2 = "0.5"
 thiserror = "1.0.21"


### PR DESCRIPTION
It's required for the `vacant_key` function to exist.

See https://github.com/quinn-rs/quinn/blob/1e48a703d5a7d7c7594acca2068cd6bd68e224c5/quinn-proto/src/endpoint.rs#L407
See https://github.com/tokio-rs/slab/blob/f7b621f6cf2bc84f32214029b32d587d18277e3d/CHANGELOG.md?plain=1#L16-L18