### PR TITLE
fix(.github/android): pass matrix.target and increase api to v26 

### DIFF
--- a/.github/workflows/rust-android-run-tests-on-emulator.sh
+++ b/.github/workflows/rust-android-run-tests-on-emulator.sh
@@ -5,7 +5,7 @@ adb wait-for-device
 while [[ -z "$(adb shell getprop sys.boot_completed | tr -d '\r')" ]]; do sleep 1; done
 
 any_failures=0
-for test in $(find target/${{ matrix.target }}/debug/deps/ -type f -executable ! -name "*.so" -name "*-*"); do
+for test in $(find target/$TARGET/debug/deps/ -type f -executable ! -name "*.so" -name "*-*"); do
     adb push "$test" /data/local/tmp/
     adb shell chmod +x /data/local/tmp/$(basename "$test")
     adb shell /data/local/tmp/$(basename "$test") || any_failures=1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -144,6 +144,8 @@ jobs:
         sudo udevadm trigger --name-match=kvm
 
     - name: Set up Android Emulator and run tests
+      env:
+        TARGET: ${{ matrix.target }}
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: ${{ matrix.api-level }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,10 +102,10 @@ jobs:
             emulator-arch: x86_64
             # Note that x86_64 image is only available for API 21+. See
             # https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#configurations.
-            api-level: 21
+            api-level: 26
           - target: i686-linux-android
             emulator-arch: x86
-            api-level: 19
+            api-level: 26
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
When extracting the emulator script into a separate file, the `matrix.target` substitution wasn't replaced with an environment variable.

Follow-up to https://github.com/quinn-rs/quinn/pull/1950.

Also the `ecn_*` unit tests are failing with any Android API version < v26 with:

```
2024-08-22T14:41:30.636494Z  WARN quinn_udp: sendmsg error: Os { code: 22, kind: InvalidInput, message: "Invalid argument" }, Transmit: { destination: 127.0.0.1:50196, src_ip: None, enc: Some(Ect0), len: 5, segment_size: None }
```