### PR TITLE
Android API level <= 25 fails sendmsg ECN with InvalidInput

### DIFF
--- a/.github/workflows/rust-android-run-tests-on-emulator.sh
+++ b/.github/workflows/rust-android-run-tests-on-emulator.sh
@@ -7,8 +7,7 @@ while [[ -z "$(adb shell getprop sys.boot_completed | tr -d '\r')" ]]; do sleep 
 any_failures=0
 for test in $(find target/$TARGET/debug/deps/ -type f -executable ! -name "*.so" -name "*-*"); do
     adb push "$test" /data/local/tmp/
-    adb shell chmod +x /data/local/tmp/$(basename "$test")
-    adb shell /data/local/tmp/$(basename "$test") || any_failures=1
+    adb shell RUST_LOG=debug /data/local/tmp/$(basename "$test") --nocapture || any_failures=1
 done
 
 exit $any_failures

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,10 +102,10 @@ jobs:
             emulator-arch: x86_64
             # Note that x86_64 image is only available for API 21+. See
             # https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#configurations.
-            api-level: 26
+            api-level: 25
           - target: i686-linux-android
             emulator-arch: x86
-            api-level: 26
+            api-level: 25
 
     steps:
     - name: Checkout code
@@ -135,7 +135,7 @@ jobs:
       run: cargo install cargo-ndk
 
     - name: Build unit tests for Android
-      run: cargo ndk -t ${{ matrix.target }} test --no-run
+      run: cargo ndk -t ${{ matrix.target }} test -p quinn-udp --no-run
 
     - name: Enable KVM group perms
       run: |

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -31,6 +31,7 @@ windows-sys = { workspace = true }
 
 [dev-dependencies]
 criterion = "0.5"
+tracing-subscriber = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.bench]
 name = "throughput"

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -33,6 +33,7 @@ fn basic() {
 
 #[test]
 fn ecn_v6() {
+    let _ = tracing_subscriber::fmt::try_init();
     let send = Socket::from(UdpSocket::bind("[::1]:0").unwrap());
     let recv = Socket::from(UdpSocket::bind("[::1]:0").unwrap());
     for codepoint in [EcnCodepoint::Ect0, EcnCodepoint::Ect1] {
@@ -53,6 +54,7 @@ fn ecn_v6() {
 #[test]
 #[cfg(not(any(target_os = "openbsd", target_os = "netbsd", target_os = "solaris")))]
 fn ecn_v4() {
+    let _ = tracing_subscriber::fmt::try_init();
     let send = Socket::from(UdpSocket::bind("127.0.0.1:0").unwrap());
     let recv = Socket::from(UdpSocket::bind("127.0.0.1:0").unwrap());
     for codepoint in [EcnCodepoint::Ect0, EcnCodepoint::Ect1] {
@@ -73,6 +75,7 @@ fn ecn_v4() {
 #[test]
 #[cfg(not(any(target_os = "openbsd", target_os = "netbsd", target_os = "solaris")))]
 fn ecn_v6_dualstack() {
+    let _ = tracing_subscriber::fmt::try_init();
     let recv = socket2::Socket::new(
         socket2::Domain::IPV6,
         socket2::Type::DGRAM,


### PR DESCRIPTION
When running the `quinn-udp` `ecn_*` unit tests `sendmsg` fails with:

```
2024-08-22T14:41:30.636494Z  WARN quinn_udp: sendmsg error: Os { code: 22, kind: InvalidInput, message: "Invalid argument" }, Transmit: { destination: 127.0.0.1:50196, src_ip: None, enc: Some(Ect0), len: 5, segment_size: None }
```

https://github.com/quinn-rs/quinn/blob/cef42cccef6fb6f02527ae4b2f42d7f7da878f62/quinn-udp/tests/tests.rs#L34-L153

---

I don't have a fix (yet). Opening this early to publish the reproducer. See failing CI.

Any ideas anyone?

Depends on https://github.com/quinn-rs/quinn/pull/1973.