### PR TITLE
feat: Faster UDP/IO on Apple platforms

### DIFF
--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -18,6 +18,8 @@ default = ["tracing", "log"]
 # Configure `tracing` to log events via `log` if no `tracing` subscriber exists.
 log = ["tracing/log"]
 direct-log = ["dep:log"]
+# Use private Apple APIs to send multiple packets in a single syscall.
+fast-apple-datapath = []
 
 [dependencies]
 libc = "0.2.158"
@@ -32,6 +34,9 @@ windows-sys = { workspace = true }
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["async_tokio"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "net"] }
+
+[build-dependencies]
+cfg_aliases = "0.2"
 
 [lib]
 # See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/quinn-udp/benches/throughput.rs
+++ b/quinn-udp/benches/throughput.rs
@@ -23,7 +23,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let mut permutations = vec![];
     for gso_enabled in [
         false,
-        #[cfg(any(target_os = "linux", target_os = "windows"))]
+        #[cfg(any(target_os = "linux", target_os = "windows", apple))]
         true,
     ] {
         for gro_enabled in [false, true] {

--- a/quinn-udp/build.rs
+++ b/quinn-udp/build.rs
@@ -1,0 +1,26 @@
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    // Setup cfg aliases
+    cfg_aliases! {
+        // Platforms
+        apple: {
+            any(
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "tvos",
+                target_os = "visionos"
+            )
+        },
+        bsd: {
+            any(
+                target_os = "freebsd",
+                target_os = "openbsd",
+                target_os = "netbsd"
+            )
+        },
+        // Convenience aliases
+        apple_fast: { all(apple, feature = "fast-apple-datapath") },
+        apple_slow: { all(apple, not(feature = "fast-apple-datapath")) },
+    }
+}

--- a/quinn-udp/src/cmsg/unix.rs
+++ b/quinn-udp/src/cmsg/unix.rs
@@ -32,6 +32,29 @@ impl MsgHdr for libc::msghdr {
     }
 }
 
+#[cfg(apple_fast)]
+impl MsgHdr for crate::imp::msghdr_x {
+    type ControlMessage = libc::cmsghdr;
+
+    fn cmsg_first_hdr(&self) -> *mut Self::ControlMessage {
+        let selfp = self as *const _ as *mut libc::msghdr;
+        unsafe { libc::CMSG_FIRSTHDR(selfp) }
+    }
+
+    fn cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage {
+        let selfp = self as *const _ as *mut libc::msghdr;
+        unsafe { libc::CMSG_NXTHDR(selfp, cmsg) }
+    }
+
+    fn set_control_len(&mut self, len: usize) {
+        self.msg_controllen = len as _;
+    }
+
+    fn control_len(&self) -> usize {
+        self.msg_controllen as _
+    }
+}
+
 /// Helpers for [`libc::cmsghdr`]
 impl CMsgHdr for libc::cmsghdr {
     fn cmsg_len(length: usize) -> usize {


### PR DESCRIPTION
This uses Apple's private [`sendmsg_x`](https://github.com/apple-oss-distributions/xnu/blob/94d3b452840153a99b38a3a9659680b2a006908e/bsd/sys/socket.h#L1457-L1487) and [`recvmsg_x`](https://github.com/apple-oss-distributions/xnu/blob/94d3b452840153a99b38a3a9659680b2a006908e/bsd/sys/socket.h#L1425-L1455) system calls for multi-packet UDP I/O.

CC @mxinden 