### PR TITLE
Expose orignial dest cid

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -1156,6 +1156,11 @@ impl Incoming {
     pub fn remote_address_validated(&self) -> bool {
         self.retry_src_cid.is_some()
     }
+
+    /// The original destination connection ID sent by the client
+    pub fn orig_dst_cid(&self) -> &ConnectionId {
+        &self.orig_dst_cid
+    }
 }
 
 impl fmt::Debug for Incoming {

--- a/quinn/src/incoming.rs
+++ b/quinn/src/incoming.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use proto::{ConnectionError, ServerConfig};
+use proto::{ConnectionError, ConnectionId, ServerConfig};
 use thiserror::Error;
 
 use crate::{
@@ -84,6 +84,11 @@ impl Incoming {
     /// sent to `self.remote_address()`.
     pub fn remote_address_validated(&self) -> bool {
         self.0.as_ref().unwrap().inner.remote_address_validated()
+    }
+
+    /// The original destination CID when initiating the connection
+    pub fn orig_dst_cid(&self) -> ConnectionId {
+        *self.0.as_ref().unwrap().inner.orig_dst_cid()
     }
 }
 


### PR DESCRIPTION
Expose the original dest cid, which is generated by client when connecting.

The use case is described in #1896, and it would be convenient to expose it for logging and e2e testing.