### PR TITLE
feat(quinn-proto): Make compilable in wasm32-unknown-unknown and run wasm tests in CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = "wasm-bindgen-test-runner"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,6 +69,50 @@ jobs:
       - run: RUST_BACKTRACE=1 cargo test --manifest-path quinn-proto/Cargo.toml --no-default-features --features rustls-aws-lc-rs-fips
       - run: RUST_BACKTRACE=1 cargo test --manifest-path quinn/Cargo.toml --no-default-features --features rustls-aws-lc-rs-fips,runtime-tokio
 
+  wasm_test:
+    name: test wasm32-unknown-unknown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add wasm target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Install nodejs v20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup `wasm-tools`
+        uses: bytecodealliance/actions/wasm-tools/setup@v1
+
+      - name: Install cargo binstall
+        uses: cargo-bins/cargo-binstall@main
+      
+      # We need to downgrade cc to version 1.1.31 for ring Wasm compilation to work.
+      # See the upstream issue https://github.com/rust-lang/cc-rs/issues/1275
+      - name: Use working `cc` version 1.1.31
+        run: cargo update -p cc --precise 1.1.31
+
+      - name: build wasm32 tests (quinn-proto)
+        run: cargo test -p quinn-proto --target wasm32-unknown-unknown --no-run
+
+      # If the Wasm file contains any 'import "env"' declarations, then
+      # some non-Wasm-compatible code made it into the final code.
+      - name: Check for 'import "env"' in Wasm
+        run: |
+          ! wasm-tools print --skeleton target/wasm32-unknown-unknown/debug/deps/quinn_proto-*.wasm | grep 'import "env"'
+
+      - name: Install wasm-bindgen-test-runner
+        run: cargo binstall wasm-bindgen-cli --locked --no-confirm
+
+      - name: wasm32 test (quinn-proto)
+        run: cargo test -p quinn-proto --target wasm32-unknown-unknown
+
   msrv:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ clap = { version = "4", features = ["derive"] }
 crc = "3"
 directories-next = "2"
 futures-io = "0.3.19"
+getrandom = { version = "0.2", default-features = false }
 hdrhistogram = { version = "7.2", default-features = false }
 hex-literal = "0.4"
 lazy_static = "1"
@@ -37,6 +38,7 @@ rustc-hash = "2"
 rustls = { version = "0.23.5", default-features = false, features = ["std"] }
 rustls-pemfile = "2"
 rustls-platform-verifier = "0.4"
+rustls-pki-types = "1.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 slab = "0.4.6"
@@ -49,6 +51,8 @@ tracing = { version = "0.1.10", default-features = false, features = ["std"] }
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
 url = "2"
+wasm-bindgen-test = { version = "0.3.45" }
+web-time = "1"
 windows-sys = { version = ">=0.52, <=0.59", features = ["Win32_Foundation", "Win32_System_IO", "Win32_Networking_WinSock"] }
 
 [profile.bench]

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -45,12 +45,21 @@ thiserror = { workspace = true }
 tinyvec = { workspace = true, features = ["alloc"] }
 tracing = { workspace = true }
 
+# Feature flags & dependencies for wasm
+# wasm-bindgen is assumed for a wasm*-*-unknown target
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+ring = { workspace = true, features = ["wasm32_unknown_unknown_js"] }
+getrandom = { workspace = true, features = ["js"] }
+rustls-pki-types = { workspace = true, features = ["web"] } # only added as dependency to enforce the `web` feature for this target
+web-time = { workspace = true }
+
 [dev-dependencies]
 assert_matches = { workspace = true }
 hex-literal = { workspace = true  }
 rcgen = { workspace = true }
 tracing-subscriber = { workspace = true }
 lazy_static = "1"
+wasm-bindgen-test = { workspace = true }
 
 [lints.rust]
 # https://rust-fuzz.github.io/book/cargo-fuzz/guide.html#cfgfuzzing

--- a/quinn-proto/src/cid_generator.rs
+++ b/quinn-proto/src/cid_generator.rs
@@ -1,8 +1,9 @@
-use std::{hash::Hasher, time::Duration};
+use std::hash::Hasher;
 
 use rand::{Rng, RngCore};
 
 use crate::shared::ConnectionId;
+use crate::Duration;
 use crate::MAX_CID_SIZE;
 
 /// Generates connection IDs for incoming connections

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -3,7 +3,6 @@ use std::{
     net::{SocketAddrV4, SocketAddrV6},
     num::TryFromIntError,
     sync::Arc,
-    time::Duration,
 };
 
 #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
@@ -19,8 +18,8 @@ use crate::{
     congestion,
     crypto::{self, HandshakeTokenKey, HmacKey},
     shared::ConnectionId,
-    RandomConnectionIdGenerator, VarInt, VarIntBoundsExceeded, DEFAULT_SUPPORTED_VERSIONS,
-    INITIAL_MTU, MAX_CID_SIZE, MAX_UDP_PAYLOAD,
+    Duration, RandomConnectionIdGenerator, VarInt, VarIntBoundsExceeded,
+    DEFAULT_SUPPORTED_VERSIONS, INITIAL_MTU, MAX_CID_SIZE, MAX_UDP_PAYLOAD,
 };
 
 /// Parameters governing the core QUIC state machine

--- a/quinn-proto/src/congestion.rs
+++ b/quinn-proto/src/congestion.rs
@@ -1,9 +1,9 @@
 //! Logic for controlling the rate at which data is sent
 
 use crate::connection::RttEstimator;
+use crate::Instant;
 use std::any::Any;
 use std::sync::Arc;
-use std::time::Instant;
 
 mod bbr;
 mod cubic;

--- a/quinn-proto/src/congestion/bbr/bw_estimation.rs
+++ b/quinn-proto/src/congestion/bbr/bw_estimation.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display, Formatter};
-use std::time::{Duration, Instant};
 
 use super::min_max::MinMax;
+use crate::{Duration, Instant};
 
 #[derive(Clone, Debug)]
 pub(crate) struct BandwidthEstimation {

--- a/quinn-proto/src/congestion/bbr/mod.rs
+++ b/quinn-proto/src/congestion/bbr/mod.rs
@@ -1,13 +1,13 @@
 use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use rand::{Rng, SeedableRng};
 
 use crate::congestion::bbr::bw_estimation::BandwidthEstimation;
 use crate::congestion::bbr::min_max::MinMax;
 use crate::connection::RttEstimator;
+use crate::{Duration, Instant};
 
 use super::{Controller, ControllerFactory, BASE_DATAGRAM_SIZE};
 

--- a/quinn-proto/src/congestion/cubic.rs
+++ b/quinn-proto/src/congestion/cubic.rs
@@ -1,10 +1,10 @@
 use std::any::Any;
+use std::cmp;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use super::{Controller, ControllerFactory, BASE_DATAGRAM_SIZE};
 use crate::connection::RttEstimator;
-use std::cmp;
+use crate::{Duration, Instant};
 
 /// CUBIC Constants.
 ///

--- a/quinn-proto/src/congestion/new_reno.rs
+++ b/quinn-proto/src/congestion/new_reno.rs
@@ -1,9 +1,9 @@
 use std::any::Any;
 use std::sync::Arc;
-use std::time::Instant;
 
 use super::{Controller, ControllerFactory, BASE_DATAGRAM_SIZE};
 use crate::connection::RttEstimator;
+use crate::Instant;
 
 /// A simple, standard congestion controller
 #[derive(Debug, Clone)]

--- a/quinn-proto/src/connection/ack_frequency.rs
+++ b/quinn-proto/src/connection/ack_frequency.rs
@@ -1,8 +1,8 @@
 use crate::connection::spaces::PendingAcks;
 use crate::frame::AckFrequency;
 use crate::transport_parameters::TransportParameters;
+use crate::Duration;
 use crate::{AckFrequencyConfig, TransportError, VarInt, TIMER_GRANULARITY};
-use std::time::Duration;
 
 /// State associated to ACK frequency
 pub(super) struct AckFrequencyState {

--- a/quinn-proto/src/connection/cid_state.rs
+++ b/quinn-proto/src/connection/cid_state.rs
@@ -1,13 +1,10 @@
 //! Maintain the state of local connection IDs
-use std::{
-    collections::VecDeque,
-    time::{Duration, Instant},
-};
+use std::collections::VecDeque;
 
 use rustc_hash::FxHashSet;
 use tracing::{debug, trace};
 
-use crate::{shared::IssuedCid, TransportError};
+use crate::{shared::IssuedCid, Duration, Instant, TransportError};
 
 /// Local connection ID management
 pub(super) struct CidState {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -5,7 +5,6 @@ use std::{
     fmt, io, mem,
     net::{IpAddr, SocketAddr},
     sync::Arc,
-    time::{Duration, Instant},
 };
 
 use bytes::{Bytes, BytesMut};
@@ -32,8 +31,9 @@ use crate::{
     },
     token::ResetToken,
     transport_parameters::TransportParameters,
-    Dir, EndpointConfig, Frame, Side, StreamId, Transmit, TransportError, TransportErrorCode,
-    VarInt, MAX_CID_SIZE, MAX_STREAM_COUNT, MIN_INITIAL_SIZE, TIMER_GRANULARITY,
+    Dir, Duration, EndpointConfig, Frame, Instant, Side, StreamId, Transmit, TransportError,
+    TransportErrorCode, VarInt, MAX_CID_SIZE, MAX_STREAM_COUNT, MIN_INITIAL_SIZE,
+    TIMER_GRANULARITY,
 };
 
 mod ack_frequency;

--- a/quinn-proto/src/connection/mtud.rs
+++ b/quinn-proto/src/connection/mtud.rs
@@ -1,5 +1,5 @@
-use crate::{packet::SpaceId, MtuDiscoveryConfig, MAX_UDP_PAYLOAD};
-use std::{cmp, time::Instant};
+use crate::{packet::SpaceId, Instant, MtuDiscoveryConfig, MAX_UDP_PAYLOAD};
+use std::cmp;
 use tracing::trace;
 
 /// Implements Datagram Packetization Layer Path Maximum Transmission Unit Discovery
@@ -519,9 +519,9 @@ const BLACK_HOLE_THRESHOLD: usize = 3;
 mod tests {
     use super::*;
     use crate::packet::SpaceId;
+    use crate::Duration;
     use crate::MAX_UDP_PAYLOAD;
     use assert_matches::assert_matches;
-    use std::time::Duration;
 
     fn default_mtud() -> MtuDiscovery {
         let config = MtuDiscoveryConfig::default();

--- a/quinn-proto/src/connection/pacing.rs
+++ b/quinn-proto/src/connection/pacing.rs
@@ -1,6 +1,6 @@
 //! Pacing of packet transmissions.
 
-use std::time::{Duration, Instant};
+use crate::{Duration, Instant};
 
 use tracing::warn;
 

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -1,4 +1,4 @@
-use std::{cmp, time::Instant};
+use std::cmp;
 
 use bytes::Bytes;
 use rand::Rng;
@@ -8,7 +8,7 @@ use super::{spaces::SentPacket, Connection, SentFrames};
 use crate::{
     frame::{self, Close},
     packet::{Header, InitialHeader, LongType, PacketNumber, PartialEncode, SpaceId, FIXED_BIT},
-    ConnectionId, TransportError, TransportErrorCode, INITIAL_MTU,
+    ConnectionId, Instant, TransportError, TransportErrorCode, INITIAL_MTU,
 };
 
 pub(super) struct PacketBuilder {

--- a/quinn-proto/src/connection/packet_crypto.rs
+++ b/quinn-proto/src/connection/packet_crypto.rs
@@ -1,10 +1,10 @@
-use std::time::Instant;
 use tracing::{debug, trace};
 
 use crate::connection::spaces::PacketSpace;
 use crate::crypto::{HeaderKey, KeyPair, PacketKey};
 use crate::packet::{Packet, PartialDecode, SpaceId};
 use crate::token::ResetToken;
+use crate::Instant;
 use crate::{TransportError, RESET_TOKEN_SIZE};
 
 /// Removes header protection of a packet, or returns `None` if the packet was dropped

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -1,4 +1,4 @@
-use std::{cmp, net::SocketAddr, time::Duration, time::Instant};
+use std::{cmp, net::SocketAddr};
 
 use tracing::trace;
 
@@ -7,7 +7,7 @@ use super::{
     pacing::Pacer,
     spaces::{PacketSpace, SentPacket},
 };
-use crate::{congestion, packet::SpaceId, TransportConfig, TIMER_GRANULARITY};
+use crate::{congestion, packet::SpaceId, Duration, Instant, TransportConfig, TIMER_GRANULARITY};
 
 /// Description of a particular network path
 pub(super) struct PathData {

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -3,7 +3,6 @@ use std::{
     collections::{BTreeMap, VecDeque},
     mem,
     ops::{Bound, Index, IndexMut},
-    time::{Duration, Instant},
 };
 
 use rand::Rng;
@@ -13,7 +12,7 @@ use tracing::trace;
 use super::assembler::Assembler;
 use crate::{
     connection::StreamsState, crypto::Keys, frame, packet::SpaceId, range_set::ArrayRangeSet,
-    shared::IssuedCid, Dir, StreamId, TransportError, VarInt,
+    shared::IssuedCid, Dir, Duration, Instant, StreamId, TransportError, VarInt,
 };
 
 pub(super) struct PacketSpace {

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -1,7 +1,6 @@
 //! Connection statistics
 
-use crate::{frame::Frame, Dir};
-use std::time::Duration;
+use crate::{frame::Frame, Dir, Duration};
 
 /// Statistics about UDP datagrams transmitted or received on a connection
 #[derive(Default, Debug, Copy, Clone)]

--- a/quinn-proto/src/connection/timer.rs
+++ b/quinn-proto/src/connection/timer.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use crate::Instant;
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub(crate) enum Timer {

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -5,7 +5,6 @@ use std::{
     net::{IpAddr, SocketAddr},
     ops::{Index, IndexMut},
     sync::Arc,
-    time::{Instant, SystemTime},
 };
 
 use bytes::{BufMut, Bytes, BytesMut};
@@ -32,8 +31,8 @@ use crate::{
     },
     token::TokenDecodeError,
     transport_parameters::{PreferredAddress, TransportParameters},
-    ResetToken, RetryToken, Side, Transmit, TransportConfig, TransportError, INITIAL_MTU,
-    MAX_CID_SIZE, MIN_INITIAL_SIZE, RESET_TOKEN_SIZE,
+    Instant, ResetToken, RetryToken, Side, SystemTime, Transmit, TransportConfig, TransportError,
+    INITIAL_MTU, MAX_CID_SIZE, MIN_INITIAL_SIZE, RESET_TOKEN_SIZE,
 };
 
 /// The main entry point to the library

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -24,7 +24,6 @@ use std::{
     fmt,
     net::{IpAddr, SocketAddr},
     ops,
-    time::Duration,
 };
 
 mod cid_queue;
@@ -88,6 +87,12 @@ use token::{ResetToken, RetryToken};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
+
+// Deal with time
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub(crate) use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub(crate) use web_time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 #[doc(hidden)]
 #[cfg(fuzzing)]

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -1,8 +1,8 @@
-use std::{fmt, net::SocketAddr, time::Instant};
+use std::{fmt, net::SocketAddr};
 
 use bytes::{Buf, BufMut, BytesMut};
 
-use crate::{coding::BufExt, packet::PartialDecode, ResetToken, MAX_CID_SIZE};
+use crate::{coding::BufExt, packet::PartialDecode, Instant, ResetToken, MAX_CID_SIZE};
 
 /// Events sent from an Endpoint to a Connection
 #[derive(Debug)]

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -3,7 +3,6 @@ use std::{
     mem,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
-    time::{Duration, Instant},
 };
 
 use assert_matches::assert_matches;
@@ -31,9 +30,18 @@ use crate::{
     crypto::rustls::QuicServerConfig,
     frame::FrameStruct,
     transport_parameters::TransportParameters,
+    Duration, Instant,
 };
 mod util;
 use util::*;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+// Enable this if you want to run these tests in the browser.
+// Unfortunately it's either-or: Enable this and you can run in the browser, disable to run in nodejs.
+// #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+// wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]
 fn version_negotiate_server() {

--- a/quinn-proto/src/token.rs
+++ b/quinn-proto/src/token.rs
@@ -1,7 +1,6 @@
 use std::{
     fmt, io,
     net::{IpAddr, SocketAddr},
-    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use bytes::{Buf, BufMut};
@@ -10,7 +9,7 @@ use crate::{
     coding::{BufExt, BufMutExt},
     crypto::{CryptoError, HandshakeTokenKey, HmacKey},
     shared::ConnectionId,
-    RESET_TOKEN_SIZE,
+    Duration, SystemTime, RESET_TOKEN_SIZE, UNIX_EPOCH,
 };
 
 pub(crate) struct RetryToken {
@@ -176,12 +175,10 @@ mod test {
         use super::*;
         use crate::cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator};
         use crate::MAX_CID_SIZE;
+        use crate::{Duration, UNIX_EPOCH};
 
         use rand::RngCore;
-        use std::{
-            net::Ipv6Addr,
-            time::{Duration, UNIX_EPOCH},
-        };
+        use std::net::Ipv6Addr;
 
         let rng = &mut rand::thread_rng();
 


### PR DESCRIPTION
### Summary of Changes

- Use `web_time` dependency instead of `std::time` & re-export `Instant`, `Duration`, `SystemTime` and `UNIX_EPOCH` in `lib.rs` so imports are simpler
- Adjust imports to use `crate::{Instant, Duration, ...}` instead of `std::time::{Instant, Duration, ...}`
- Added `wasm-bindgen-test` to enable running tests from a Wasm build
- Added a CI task to test quinn-proto tests in Wasm with node.js

### Running `quinn-proto` tests in Wasm

```sh
# install wasm-bindgen-test-runner
$ cargo install wasm-bindgen-cli
# run tests
$ cargo test -p quinn-proto --target wasm32-unknown-unknown
```

<details>
<summary>Old open questions, now resolved</summary>

- Should the added code/dependencies additionally be feature-gated?
  
  I personally don't think so. As far as I know, there's practically no one asking for wasm32-unknown-unknown compilability who isn't targeting nodejs/browsers/cloudflare workers/etc. and in all of these cases wasm-bindgen is the de-facto standard.
  There's also targeting wasmtime and other runtimes, but IMO those needs are met by `wasm32-wasi-*` targets, not `wasm32-unknown-unknown`.
  
  That said, for my intents and purposes that's mostly a cosmetic question, I don't mind having to enable another feature flag. Other concerns could be "what non-web `wasm32-unknown-unknown` becomes a thing and we need to break compatibility by introducing features?".
- Should the `Duration`, `Instant`, etc. re-exports live in `lib.rs`?
  
  They're `pub(crate)` only, so I don't think it matters much. I can move them into a file if you want, or we keep them here.
- Should we just depend on `web_time` instead of `std::time` everywhere instead of cfg-gating & re-exporting?
  
  `web_time` itself already multiplexes between `std::time` and a web-based implementation. So in a way, we're doing it twice here. What we gain is not depending on `web_time` most of the time.
  However, once we work on Wasm support for e.g. `quinn` itself, we'd need to do this whole re-export dance, again. So perhaps it'd be better to just depend on `web_time` everywhere?
  
</details>