### PR TITLE
Export SendDatagram struct to the public API

### DIFF
--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -71,8 +71,8 @@ pub use rustls;
 pub use udp;
 
 pub use crate::connection::{
-    AcceptBi, AcceptUni, Connecting, Connection, OpenBi, OpenUni, ReadDatagram, SendDatagramError,
-    ZeroRttAccepted,
+    AcceptBi, AcceptUni, Connecting, Connection, OpenBi, OpenUni, ReadDatagram, SendDatagram,
+    SendDatagramError, ZeroRttAccepted,
 };
 pub use crate::endpoint::{Accept, Endpoint, EndpointStats};
 pub use crate::incoming::{Incoming, IncomingFuture, RetryError};


### PR DESCRIPTION
This is retunred by the public API but was not being provided.  This export this publicly.

Normally the compiler catches these kinds of errors, possibly it is confused by pin_project.