### PR TITLE
Reduce memory allocations on servers that process a large number of streams

### DIFF
--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -29,6 +29,14 @@ impl Assembler {
         Self::default()
     }
 
+    /// Reset to the initial state
+    pub(super) fn reinit(&mut self) {
+        let old_data = mem::take(&mut self.data);
+        *self = Self::default();
+        self.data = old_data;
+        self.data.clear();
+    }
+
     pub(super) fn ensure_ordering(&mut self, ordered: bool) -> Result<(), IllegalOrderedRead> {
         if ordered && !self.state.is_ordered() {
             return Err(IllegalOrderedRead);


### PR DESCRIPTION
The solana blockchain uses uni streams to deliver transactions. A transaction can be up to 1232 bytes, each transaction is a stream. A validator accepts thousands of connections and each connection sends millions of streams.

The Solana validator Agave uses Quinn for transaction processing, with jemalloc as the global allocator. We're encountering an issue where, due to the high volume of allocations while ingesting transactions, jemalloc struggles during network spikes. It blows out the tcache, spends excessive time managing arenas, allocating large amounts of memory, and then attempting to free it during decay. This results in a significant amount of time spent on syscalls and arena locking, leading to contention and random stalls in other threads.

Quinn is one of the largest source of allocations, so I've been working on improving things.

This is a profile of a single node validator ingesting 100k transactions with master, with a 512 streams receive window:

![image](https://github.com/user-attachments/assets/87bc664c-b674-4a11-a376-df2e66ba4949)
 
And this is with the PR applied:

![image](https://github.com/user-attachments/assets/c6014f92-b7b4-4087-bd19-890858ab5beb)

As you can see with master we get 2 allocations for each stream _ingested_. With the PR we get 2 allocations for each stream _in the window_. 

The PR essentially introduces a free list of Recvs. When it's time to create a new Recv, it tries to pop one from the free list. 

This approach works great for us, but it relies on a few key assumptions: that there will be a large number of streams, the stream receive window will generally be fully utilized, and each stream will receive a similar amount of data. If these assumptions aren't met, this PR may lead to some memory inefficiency. 

I'm wondering whether you'd be interested in merging something like this, otherwise happy to keep in our fork. Also this is just a first pass, if you're interested I could try to make this behavior opt-in, or tunable somehow to limit the amount of spare memory allocated. I'm open to ideas!