### PR TITLE
crypto: expose negotiated_cipher_suite in the hadshake data

### DIFF
--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -64,6 +64,11 @@ impl crypto::Session for TlsSession {
                 Connection::Client(_) => None,
                 Connection::Server(ref session) => session.server_name().map(|x| x.into()),
             },
+            negotiated_cipher_suite: self
+                .inner
+                .negotiated_cipher_suite()
+                .expect("cipher is negotiated")
+                .suite(),
         }))
     }
 
@@ -256,6 +261,8 @@ pub struct HandshakeData {
     ///
     /// Always `None` for outgoing connections
     pub server_name: Option<String>,
+    /// The ciphersuite negotiated with the peer
+    pub negotiated_cipher_suite: CipherSuite,
 }
 
 /// A QUIC-compatible TLS client configuration


### PR DESCRIPTION
As title.

I am not totally convinced by that `.expect("cipher is negotiated")`. 

It makes sense to me: as AFAIK reaching that point always implies the cipher is negotiated, but I might have missed a edge scenario