### PR TITLE
Add alternative - unfair but lower latency - send stream scheduling strategy

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3213,7 +3213,9 @@ impl Connection {
 
         // STREAM
         if space_id == SpaceId::Data {
-            sent.stream_frames = self.streams.write_stream_frames(buf, max_size);
+            sent.stream_frames =
+                self.streams
+                    .write_stream_frames(buf, max_size, self.config.send_fairness);
             self.stats.frame_tx.stream += sent.stream_frames.len() as u64;
         }
 

--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -391,6 +391,23 @@ impl PendingStreamsQueue {
             id,
         });
     }
+
+    fn pop(&mut self) -> Option<PendingStream> {
+        self.streams.pop()
+    }
+
+    fn clear(&mut self) {
+        self.streams.clear();
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &PendingStream> {
+        self.streams.iter()
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.streams.len()
+    }
 }
 
 /// The [`StreamId`] of a stream with pending data queued, ordered by its priority and recency


### PR DESCRIPTION
Solana leader slots are 400ms. When sending and ingesting transactions, minimizing latency is therefore key. Quinn currently tries to implement fairness when writing out send streams, which is a good default, but not great for our use case.

We want to pack as many transactions in a datagram as possible, without any fragmentation if not at the very end if a transaction doesn't fit in the remaining space. In that case, we want the end (fin) of the transaction to come _immediately after_ in order to minimize latency. The current round-robin algorithm doesn't allow this, and in fact leads to very high latency if the stream receive window is large.  

This PR tries to address this problem. It introduces a `TransportConfig::send_fairness(bool)` config. When set to false, streams are still scheduled based on priority, but once a chunk of a stream has been written out, we'll try to complete the stream instead of trying to round-robin balance it among the streams with the same priority.

This gets rid of fragmentation, and effectively allows API clients to precisely control the order in which streams are written out. 

Here's a server log without the patch:

```
[2024-10-07T13:51:43.960817939Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 7460 offset=0 len=255 fin=true
[2024-10-07T13:51:43.960824640Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T13:51:43.960829630Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 7461 offset=0 len=255 fin=true
[2024-10-07T13:51:43.960836460Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T13:51:43.960841420Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 7462 offset=0 len=110 fin=false
[2024-10-07T13:51:43.960849560Z TRACE quinn_proto::connection] got Data packet (1452 bytes) from 127.0.0.1:8014 using id f7b061311008438f
[2024-10-07T13:51:43.960859210Z TRACE quinn_proto::connection] recv; space=Data pn=1258
[2024-10-07T13:51:43.960865050Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T13:51:43.960869920Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 7463 offset=0 len=255 fin=true

[snip]

[2024-10-07T13:51:44.352021247Z TRACE quinn_proto::connection] recv; space=Data pn=7175
[2024-10-07T13:51:44.352024037Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T13:51:44.352026447Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 7420 offset=110 len=145 fin=true
[2024-10-07T13:51:44.352029877Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T13:51:44.352032267Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 7426 offset=110 len=145 fin=true
[2024-10-07T13:51:44.352036647Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T13:51:44.352039017Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 7432 offset=110 len=145 fin=true
[2024-10-07T13:51:44.352042398Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T13:51:44.352044778Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 7438 offset=110 len=145 fin=true
[2024-10-07T13:51:44.352048378Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T13:51:44.352050758Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 7444 offset=110 len=145 fin=true
[2024-10-07T13:51:44.352055058Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T13:51:44.352057518Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 7450 offset=110 len=145 fin=true
[2024-10-07T13:51:44.352061078Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T13:51:44.352063438Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 7456 offset=110 len=145 fin=true
[2024-10-07T13:51:44.352067018Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T13:51:44.352069528Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 7462 offset=110 len=145 fin=true
[2024-10-07T13:51:44.352073708Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T13:51:44.352076208Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 7468 offset=110 len=145 fin=true
[2024-10-07T13:51:44.352079558Z TRACE quinn_proto::connection] frame; ty=STREAM
```

Take a look at stream `7462`. It starts at `2024-10-07T13:51:43.960` `(pn=1257)`, and it's completed at `2024-10-07T13:51:44.352` `(pn=7175)` together with a bunch of other segmented transactions (note this is on localhost, so over the internet would be even worse). 

Here's a log with the PR instead:

```
2024-10-07T14:06:53.171353122Z TRACE quinn_proto::connection] recv; space=Data pn=1894
[2024-10-07T14:06:53.171356272Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T14:06:53.171358852Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 10179 offset=0 len=255 fin=true
[2024-10-07T14:06:53.171362262Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T14:06:53.171365652Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 10180 offset=0 len=255 fin=true
[2024-10-07T14:06:53.171369062Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T14:06:53.171371622Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 10181 offset=0 len=255 fin=true
[2024-10-07T14:06:53.171375192Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T14:06:53.171378072Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 10182 offset=0 len=255 fin=true
[2024-10-07T14:06:53.171382332Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T14:06:53.171384892Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 10183 offset=0 len=255 fin=true
[2024-10-07T14:06:53.171390133Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T14:06:53.171392773Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 10184 offset=0 len=110 fin=false
[2024-10-07T14:06:53.171397623Z TRACE quinn_proto::connection] got Data packet (1452 bytes) from 127.0.0.1:8004 using id 01dfdefc072f6a67
[2024-10-07T14:06:53.171401733Z TRACE quinn_proto::connection] recv; space=Data pn=1895
[2024-10-07T14:06:53.171404703Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T14:06:53.171407263Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 10184 offset=110 len=145 fin=true
[2024-10-07T14:06:53.171414553Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T14:06:53.171417323Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 10185 offset=0 len=255 fin=true
[2024-10-07T14:06:53.171420713Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T14:06:53.171423283Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 10186 offset=0 len=255 fin=true
[2024-10-07T14:06:53.171428433Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T14:06:53.171432083Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 10187 offset=0 len=255 fin=true
[2024-10-07T14:06:53.171435713Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T14:06:53.171438304Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 10188 offset=0 len=255 fin=true
[2024-10-07T14:06:53.171441674Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T14:06:53.171445274Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 10189 offset=0 len=218 fin=false
[2024-10-07T14:06:53.171449364Z TRACE quinn_proto::connection] got Data packet (1452 bytes) from 127.0.0.1:8004 using id 01dfdefc072f6a67
[2024-10-07T14:06:53.171453354Z TRACE quinn_proto::connection] recv; space=Data pn=1896
[2024-10-07T14:06:53.171456324Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T14:06:53.171460384Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 10189 offset=218 len=37 fin=true
[2024-10-07T14:06:53.171464434Z TRACE quinn_proto::connection] frame; ty=STREAM
[2024-10-07T14:06:53.171467174Z TRACE quinn_proto::connection] got stream frame id=client unidirectional stream 10190 offset=0 len=255 fin=true
```

As you can see the fin=false transactions get completed immediately in the next packet. 
