### PR TITLE
bench(udp): run GSO, GRO and recvmmsg permutations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
             $HOME/.cargo/bin/rustc --version
             echo "~~~~ freebsd-version ~~~~"
             freebsd-version
-          run: $HOME/.cargo/bin/cargo build --all-targets && $HOME/.cargo/bin/cargo test && $HOME/.cargo/bin/cargo test --manifest-path fuzz/Cargo.toml
+          run: $HOME/.cargo/bin/cargo build --all-targets && $HOME/.cargo/bin/cargo test && $HOME/.cargo/bin/cargo test --manifest-path fuzz/Cargo.toml && $HOME/.cargo/bin/cargo test -p quinn-udp --benches
   test:
     strategy:
       matrix:
@@ -54,6 +54,7 @@ jobs:
       - run: cargo test
       - run: cargo test --manifest-path fuzz/Cargo.toml
         if: ${{ matrix.rust }} == "stable"
+      - run: cargo test -p quinn-udp --benches
 
   test-aws-lc-rs:
     runs-on: ubuntu-latest

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -30,8 +30,13 @@ once_cell = { workspace = true }
 windows-sys = { workspace = true }
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = { version = "0.5", default-features = false, features = ["async_tokio"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "net"] }
 
-[target.'cfg(any(target_os = "linux", target_os = "windows"))'.bench]
+[lib]
+# See https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
+
+[[bench]]
 name = "throughput"
 harness = false

--- a/quinn-udp/benches/throughput.rs
+++ b/quinn-udp/benches/throughput.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::min,
     io::{ErrorKind, IoSliceMut},
     net::{Ipv4Addr, Ipv6Addr, UdpSocket},
 };
@@ -51,7 +52,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         } else {
             1
         };
-        let msg = vec![0xAB; SEGMENT_SIZE * gso_segments];
+        let msg = vec![0xAB; min(MAX_DATAGRAM_SIZE, SEGMENT_SIZE * gso_segments)];
         let transmit = Transmit {
             destination: dst_addr,
             ecn: None,
@@ -117,3 +118,6 @@ fn new_socket() -> (UdpSocketState, tokio::net::UdpSocket) {
 
 criterion_group!(benches, criterion_benchmark);
 criterion_main!(benches);
+
+const MAX_IP_UDP_HEADER_SIZE: usize = 48;
+const MAX_DATAGRAM_SIZE: usize = u16::MAX as usize - MAX_IP_UDP_HEADER_SIZE;


### PR DESCRIPTION
- Benchmark all permutations of GSO, GRO and `recvmmsg`.
- Add support for all platforms.
- Add test-run (i.e. `cargo test --benches`, single execution in debug mode) to CI.