### PR TITLE
fix `rustls-aws-lc-rs` feature

### DIFF
--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -15,7 +15,7 @@ all-features = true
 
 [features]
 default = ["rustls-ring", "log"]
-aws-lc-rs = ["dep:aws-lc-rs", "aws-lc-rs/aws-lc-sys", "aws-lc-rs/prebuilt-nasm"]
+aws-lc-rs = ["dep:aws-lc-rs", "aws-lc-rs?/aws-lc-sys", "aws-lc-rs?/prebuilt-nasm"]
 aws-lc-rs-fips = ["aws-lc-rs", "aws-lc-rs?/fips"]
 # For backwards compatibility, `rustls` forwards to `rustls-ring`
 rustls = ["rustls-ring"]

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -20,10 +20,10 @@ aws-lc-rs-fips = ["aws-lc-rs", "aws-lc-rs?/fips"]
 # For backwards compatibility, `rustls` forwards to `rustls-ring`
 rustls = ["rustls-ring"]
 # Enable rustls with the `aws-lc-rs` crypto provider
-rustls-aws-lc-rs = ["dep:rustls", "rustls/aws-lc-rs", "aws-lc-rs"]
+rustls-aws-lc-rs = ["dep:rustls", "rustls?/aws-lc-rs", "aws-lc-rs"]
 rustls-aws-lc-rs-fips = ["rustls-aws-lc-rs", "aws-lc-rs-fips"]
 # Enable rustls with the `ring` crypto provider
-rustls-ring = ["dep:rustls", "rustls/ring", "ring"]
+rustls-ring = ["dep:rustls", "rustls?/ring", "ring"]
 ring = ["dep:ring"]
 # Enable rustls ring provider and direct ring usage
 # Provides `ClientConfig::with_platform_verifier()` convenience method

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -549,9 +549,9 @@ pub(crate) fn initial_suite_from_provider(
 }
 
 pub(crate) fn configured_provider() -> Arc<rustls::crypto::CryptoProvider> {
-    #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
+    #[cfg(all(feature = "rustls-aws-lc-rs", not(feature = "rustls-ring")))]
     let provider = rustls::crypto::aws_lc_rs::default_provider();
-    #[cfg(feature = "ring")]
+    #[cfg(feature = "rustls-ring")]
     let provider = rustls::crypto::ring::default_provider();
     Arc::new(provider)
 }

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -939,6 +939,9 @@ mod tests {
     fn header_encoding() {
         use crate::crypto::rustls::{initial_keys, initial_suite_from_provider};
         use crate::Side;
+        #[cfg(all(feature = "rustls-aws-lc-rs", not(feature = "rustls-ring")))]
+        use rustls::crypto::aws_lc_rs::default_provider;
+        #[cfg(feature = "rustls-ring")]
         use rustls::crypto::ring::default_provider;
         use rustls::quic::Version;
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -14,6 +14,10 @@ use hex_literal::hex;
 use rand::RngCore;
 #[cfg(feature = "ring")]
 use ring::hmac;
+#[cfg(all(feature = "rustls-aws-lc-rs", not(feature = "rustls-ring")))]
+use rustls::crypto::aws_lc_rs::default_provider;
+#[cfg(feature = "rustls-ring")]
+use rustls::crypto::ring::default_provider;
 use rustls::{
     pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
     server::WebPkiClientVerifier,
@@ -458,7 +462,7 @@ fn reject_missing_client_cert() {
     let key = PrivatePkcs8KeyDer::from(CERTIFIED_KEY.key_pair.serialize_der());
     let cert = CERTIFIED_KEY.cert.der().clone();
 
-    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let provider = Arc::new(default_provider());
     let config = rustls::ServerConfig::builder_with_provider(provider.clone())
         .with_protocol_versions(&[&rustls::version::TLS13])
         .unwrap()

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -72,25 +72,25 @@ url = { workspace = true }
 
 [[example]]
 name = "server"
-required-features = ["rustls"]
+required-features = ["rustls-ring"]
 
 [[example]]
 name = "client"
-required-features = ["rustls"]
+required-features = ["rustls-ring"]
 
 [[example]]
 name = "insecure_connection"
-required-features = ["rustls"]
+required-features = ["rustls-ring"]
 
 [[example]]
 name = "single_socket"
-required-features = ["rustls"]
+required-features = ["rustls-ring"]
 
 [[example]]
 name = "connection"
-required-features = ["rustls"]
+required-features = ["rustls-ring"]
 
 [[bench]]
 name = "bench"
 harness = false
-required-features = ["rustls"]
+required-features = ["rustls-ring"]

--- a/quinn/examples/connection.rs
+++ b/quinn/examples/connection.rs
@@ -2,14 +2,17 @@
 //!
 //! Checkout the `README.md` for guidance.
 
-use std::error::Error;
+use std::{
+    error::Error,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
 
 mod common;
 use common::{make_client_endpoint, make_server_endpoint};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let server_addr = (Ipv4Addr::LOCALHOST, 5000).parse().unwrap();
+    let server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 5000);
     let (endpoint, server_cert) = make_server_endpoint(server_addr)?;
     // accept a single connection
     let endpoint2 = endpoint.clone();

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -2,7 +2,11 @@
 //!
 //! Checkout the `README.md` for guidance.
 
-use std::{error::Error, net::SocketAddr, sync::Arc};
+use std::{
+    error::Error,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
 
 use proto::crypto::rustls::QuicClientConfig;
 use quinn::{ClientConfig, Endpoint};
@@ -14,7 +18,7 @@ use common::make_server_endpoint;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // server and client are running on the same thread asynchronously
-    let addr = (Ipv4Addr::LOCALHOST, 5000).parse().unwrap();
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
     tokio::spawn(run_server(addr));
     run_client(addr).await?;
     Ok(())
@@ -33,7 +37,7 @@ async fn run_server(addr: SocketAddr) {
 }
 
 async fn run_client(server_addr: SocketAddr) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let mut endpoint = Endpoint::client((Ipv4Addr::LOCALHOST, 0).parse().unwrap())?;
+    let mut endpoint = Endpoint::client(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))?;
 
     endpoint.set_default_client_config(ClientConfig::new(Arc::new(QuicClientConfig::try_from(
         rustls::ClientConfig::builder()

--- a/quinn/examples/single_socket.rs
+++ b/quinn/examples/single_socket.rs
@@ -2,7 +2,10 @@
 //!
 //! Checkout the `README.md` for guidance.
 
-use std::{error::Error, net::SocketAddr};
+use std::{
+    error::Error,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
 
 use quinn::Endpoint;
 
@@ -12,15 +15,15 @@ use rustls::pki_types::CertificateDer;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let addr1 = (Ipv4Addr::LOCALHOST, 5000).parse().unwrap();
-    let addr2 = (Ipv4Addr::LOCALHOST, 5001).parse().unwrap();
-    let addr3 = (Ipv4Addr::LOCALHOST, 5002).parse().unwrap();
+    let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 5000);
+    let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 5001);
+    let addr3 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 5002);
     let server1_cert = run_server(addr1)?;
     let server2_cert = run_server(addr2)?;
     let server3_cert = run_server(addr3)?;
 
     let client = make_client_endpoint(
-        (Ipv4Addr::LOCALHOST, 0).parse().unwrap(),
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         &[&server1_cert, &server2_cert, &server3_cert],
     )?;
 

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -1,5 +1,10 @@
 #![cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
 
+#[cfg(all(feature = "rustls-aws-lc-rs", not(feature = "rustls-ring")))]
+use rustls::crypto::aws_lc_rs::default_provider;
+#[cfg(feature = "rustls-ring")]
+use rustls::crypto::ring::default_provider;
+
 use std::{
     convert::TryInto,
     io,
@@ -496,13 +501,12 @@ fn run_echo(args: EchoArgs) {
 
         let mut roots = rustls::RootCertStore::empty();
         roots.add(cert).unwrap();
-        let mut client_crypto = rustls::ClientConfig::builder_with_provider(
-            rustls::crypto::ring::default_provider().into(),
-        )
-        .with_safe_default_protocol_versions()
-        .unwrap()
-        .with_root_certificates(roots)
-        .with_no_client_auth();
+        let mut client_crypto =
+            rustls::ClientConfig::builder_with_provider(default_provider().into())
+                .with_safe_default_protocol_versions()
+                .unwrap()
+                .with_root_certificates(roots)
+                .with_no_client_auth();
         client_crypto.key_log = Arc::new(rustls::KeyLogFile::new());
 
         let mut client = {


### PR DESCRIPTION
In the current Rust editions, if a dependency is declared as optional and it also exists a feature with the same name, `dep:name` will activate both the feature and the optional dependency.

That is the case for the `rustls` feature, so sadly 
```toml
rustls-aws-lc-rs = ["dep:rustls", "rustls/aws-lc-rs", "aws-lc-rs"]
```
will also activate the `rustls` feature, which also activates `ring`.

There is a zulip discussion about this surprising behavior [here](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/Odd.20cargo.20resolver.20behavior/near/449102225).

Hopefully, in Rust 2024 edition, with [this change](https://doc.rust-lang.org/edition-guide/rust-2024/cargo-remove-implicit-features.html), the behavior will be less surprising.

The PR introduce a breaking change, but as far as I know, there is no other way to fix this


Edit: I misunderstood the `zulip` thread; it's the `crate/feature` syntax that activates both the optional dependency and the feature if there is one with the same name. Not the `dep:crate` one. We can just use the `crate?/feature` syntax here and it should be non-breaking.