### PR TITLE
feat(quinn-udp): support both windows-sys v0.52 and v0.59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tracing = { version = "0.1.10", default-features = false, features = ["std"] }
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "ansi", "time", "local-time"] }
 url = "2"
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_IO", "Win32_Networking_WinSock"] }
+windows-sys = { version = ">=0.52, <=0.59", features = ["Win32_Foundation", "Win32_System_IO", "Win32_Networking_WinSock"] }
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
`quinn-udp` depends on the `windows-sys` crate, more specifically `windows_sys::Win32::Networking::WinSock`:

https://github.com/quinn-rs/quinn/blob/a5d9bd1154b7644ff22b75191a89db9687546fdb/quinn-udp/src/cmsg/windows.rs#L6

https://github.com/quinn-rs/quinn/blob/a5d9bd1154b7644ff22b75191a89db9687546fdb/quinn-udp/src/windows.rs#L13

Previously `quinn-udp` was using `windows-sys` `v0.52`. https://github.com/quinn-rs/quinn/pull/1960 updated `quinn-udp` to `v0.59`. Note that `windows-sys` went straight from `v0.52` to `v0.59`. There are no versions in between.

`quinn-udp` does not depend on any `windows-sys` `v0.59` features. In other words, it can support both `windows-sys` `v0.52` and `v0.59`.

https://github.com/microsoft/windows-rs/releases/tag/0.59.0

This commit allows downstream users of `quinn-udp` to explicitly use `quinn-udp` with `windows-sys` `v0.52`.

For other users not explicitly demanding `windows-sys` `v0.52`, cargo will choose `windows-sys` `v0.59`:

> It also attempts to use the greatest version currently available within that compatibility range.

https://doc.rust-lang.org/cargo/reference/resolver.html#semver-compatibility

---

Additional context:

- Mozilla tries to use a single version of a crate only.
- Currently [13 crates used to build Firefox](https://searchfox.org/mozilla-central/search?q=windows-sys&path=%5ECargo.lock%24&case=true&regexp=false) use `windows-sys` `v0.52.0`.
- Updating each crate to `windows-sys` `v0.59` is a large undertaking. E.g. `socket2` exposes `windows-sys` in its public interface, thus upgrading to `windows-sys` `v0.59` is a breaking change, see https://github.com/rust-lang/socket2/issues/526.
- In the meantime, `quinn-udp` supporting `windows-sys` `v0.52` AND `v0.59` allows Firefox to use `quinn-udp` `v0.5.5` today already and thus make use of e.g. https://github.com/quinn-rs/quinn/pull/1966.

Note that the ask is to support `windows-sys` `v0.52` only while `quinn-udp` does not depend on any `windows-sys` features  `>= v0.59`. As soon as `quinn-udp` needs any `windows-sys` `>=v0.59` features, it should naturally drop `windows-sys` `v0.52` support.