### PR TITLE
chore(quinn-udp): increase crate patch version to v0.5.6

### DIFF
--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.5.5"
+version = "0.5.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Would you mind cutting a new release of `quinn-udp`?

In addition to https://github.com/quinn-rs/quinn/pull/2021/, a patch release would allow us to easily experiment with https://github.com/quinn-rs/quinn/pull/1993.

