### PR TITLE
fix(.github/codecov): Ignore aws-lc-rs-fips for codecov

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,7 +14,21 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-llvm-cov
-      - run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - shell: bash
+        # Run llvm-cov _without_ the "aws-lc-rs-fips" or "rustls-aws-lc-rs-fips" features, since
+        # they have complex build requirements:
+        #     https://github.com/aws/aws-lc/blob/3263ce2a553e4e917217fb487f8c6f488fcb1866/BUILDING.md#build-prerequisites
+        #
+        # This list of features was determined using:
+        #     cargo metadata --format-version 1 --no-deps \
+        #       | jq -r ' .packages[].features | keys[]' \
+        #       | sort -u \
+        #       | grep -vFx -e 'default' -e 'aws-lc-rs-fips' -e 'rustls-aws-lc-rs-fips' \
+        #       | paste -sd ',' -
+        run: |
+          cargo llvm-cov \
+            --features="arbitrary,async-io,async-std,aws-lc-rs,direct-log,fast-apple-datapath,futures-io,json-output,lock_tracking,log,platform-verifier,ring,runtime-async-std,runtime-smol,runtime-tokio,rustls,rustls-aws-lc-rs,rustls-log,rustls-ring,serde,serde_json,smol,tracing" \
+            --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -6,6 +6,8 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [features]
+# NOTE: Please keep this in sync with the feature list in `.github/workflows/codecov.yml`, see
+# comment in that file for more information.
 default = ["json-output"]
 # Allow for json output from the perf client
 json-output = ["serde", "serde_json"]

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -11,6 +11,8 @@ categories.workspace = true
 workspace = ".."
 
 [features]
+# NOTE: Please keep this in sync with the feature list in `.github/workflows/codecov.yml`, see
+# comment in that file for more information.
 default = ["rustls-ring", "log"]
 aws-lc-rs = ["dep:aws-lc-rs", "aws-lc-rs?/aws-lc-sys", "aws-lc-rs?/prebuilt-nasm"]
 aws-lc-rs-fips = ["aws-lc-rs", "aws-lc-rs?/fips"]

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -11,6 +11,8 @@ categories.workspace = true
 workspace = ".."
 
 [features]
+# NOTE: Please keep this in sync with the feature list in `.github/workflows/codecov.yml`, see
+# comment in that file for more information.
 default = ["tracing", "log"]
 # Configure `tracing` to log events via `log` if no `tracing` subscriber exists.
 log = ["tracing/log"]

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -11,7 +11,10 @@ workspace = ".."
 edition.workspace = true
 rust-version.workspace = true
 
+
 [features]
+# NOTE: Please keep this in sync with the feature list in `.github/workflows/codecov.yml`, see
+# comment in that file for more information.
 default = ["log", "platform-verifier", "runtime-tokio", "rustls-ring"]
 # Enables `Endpoint::client` and `Endpoint::server` conveniences
 aws-lc-rs = ["proto/aws-lc-rs"]


### PR DESCRIPTION
An attempt to fix https://github.com/quinn-rs/quinn/actions/runs/11562272211/job/32183071070 on `main` and (unreleased) `0.5.6`