### PR TITLE
Fix missing re-exports

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -501,7 +501,7 @@ impl Connection {
                     self,
                 )?;
                 trace!("validating previous path with PATH_CHALLENGE {:08x}", token);
-                buf.write(frame::Type::PATH_CHALLENGE);
+                buf.write(frame::FrameType::PATH_CHALLENGE);
                 buf.write(token);
                 self.stats.frame_tx.path_challenge += 1;
 
@@ -883,7 +883,7 @@ impl Connection {
                     // above.
                     let mut builder = builder_storage.take().unwrap();
                     trace!("PATH_RESPONSE {:08x} (off-path)", token);
-                    buf.write(frame::Type::PATH_RESPONSE);
+                    buf.write(frame::FrameType::PATH_RESPONSE);
                     buf.write(token);
                     self.stats.frame_tx.path_response += 1;
                     builder.pad_to(MIN_INITIAL_SIZE);
@@ -979,12 +979,12 @@ impl Connection {
             )?;
 
             // We implement MTU probes as ping packets padded up to the probe size
-            buf.write(frame::Type::PING);
+            buf.write(frame::FrameType::PING);
             self.stats.frame_tx.ping += 1;
 
             // If supported by the peer, we want no delays to the probe's ACK
             if self.peer_supports_ack_frequency() {
-                buf.write(frame::Type::IMMEDIATE_ACK);
+                buf.write(frame::FrameType::IMMEDIATE_ACK);
                 self.stats.frame_tx.immediate_ack += 1;
             }
 
@@ -3037,7 +3037,7 @@ impl Connection {
 
         // HANDSHAKE_DONE
         if !is_0rtt && mem::replace(&mut space.pending.handshake_done, false) {
-            buf.write(frame::Type::HANDSHAKE_DONE);
+            buf.write(frame::FrameType::HANDSHAKE_DONE);
             sent.retransmits.get_or_create().handshake_done = true;
             // This is just a u8 counter and the frame is typically just sent once
             self.stats.frame_tx.handshake_done =
@@ -3047,7 +3047,7 @@ impl Connection {
         // PING
         if mem::replace(&mut space.ping_pending, false) {
             trace!("PING");
-            buf.write(frame::Type::PING);
+            buf.write(frame::FrameType::PING);
             sent.non_retransmits = true;
             self.stats.frame_tx.ping += 1;
         }
@@ -3055,7 +3055,7 @@ impl Connection {
         // IMMEDIATE_ACK
         if mem::replace(&mut space.immediate_ack_pending, false) {
             trace!("IMMEDIATE_ACK");
-            buf.write(frame::Type::IMMEDIATE_ACK);
+            buf.write(frame::FrameType::IMMEDIATE_ACK);
             sent.non_retransmits = true;
             self.stats.frame_tx.immediate_ack += 1;
         }
@@ -3111,7 +3111,7 @@ impl Connection {
                 sent.non_retransmits = true;
                 sent.requires_padding = true;
                 trace!("PATH_CHALLENGE {:08x}", token);
-                buf.write(frame::Type::PATH_CHALLENGE);
+                buf.write(frame::FrameType::PATH_CHALLENGE);
                 buf.write(token);
                 self.stats.frame_tx.path_challenge += 1;
             }
@@ -3123,7 +3123,7 @@ impl Connection {
                 sent.non_retransmits = true;
                 sent.requires_padding = true;
                 trace!("PATH_RESPONSE {:08x}", token);
-                buf.write(frame::Type::PATH_RESPONSE);
+                buf.write(frame::FrameType::PATH_RESPONSE);
                 buf.write(token);
                 self.stats.frame_tx.path_response += 1;
             }
@@ -3210,7 +3210,7 @@ impl Connection {
                 None => break,
             };
             trace!(sequence = seq, "RETIRE_CONNECTION_ID");
-            buf.write(frame::Type::RETIRE_CONNECTION_ID);
+            buf.write(frame::FrameType::RETIRE_CONNECTION_ID);
             buf.write_var(seq);
             sent.retransmits.get_or_create().retire_cids.push(seq);
             self.stats.frame_tx.retire_connection_id += 1;

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -478,7 +478,7 @@ impl StreamsState {
             }
 
             retransmits.get_or_create().max_data = true;
-            buf.write(frame::Type::MAX_DATA);
+            buf.write(frame::FrameType::MAX_DATA);
             buf.write(max);
             stats.max_data += 1;
         }
@@ -508,7 +508,7 @@ impl StreamsState {
             rs.record_sent_max_stream_data(max);
 
             trace!(stream = %id, max = max, "MAX_STREAM_DATA");
-            buf.write(frame::Type::MAX_STREAM_DATA);
+            buf.write(frame::FrameType::MAX_STREAM_DATA);
             buf.write(id);
             buf.write_var(max);
             stats.max_stream_data += 1;
@@ -529,8 +529,8 @@ impl StreamsState {
                 dir
             );
             buf.write(match dir {
-                Dir::Uni => frame::Type::MAX_STREAMS_UNI,
-                Dir::Bi => frame::Type::MAX_STREAMS_BIDI,
+                Dir::Uni => frame::FrameType::MAX_STREAMS_UNI,
+                Dir::Bi => frame::FrameType::MAX_STREAMS_BIDI,
             });
             buf.write_var(self.max_remote[dir as usize]);
             match dir {

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -18,6 +18,7 @@ use crate::{
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+/// A QUIC frame type
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct FrameType(u64);
 
@@ -55,7 +56,7 @@ pub(crate) trait FrameStruct {
 macro_rules! frame_types {
     {$($name:ident = $val:expr,)*} => {
         impl FrameType {
-            $(pub const $name: FrameType = FrameType($val);)*
+            $(pub(crate) const $name: FrameType = FrameType($val);)*
         }
 
         impl fmt::Debug for FrameType {

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -19,9 +19,9 @@ use crate::{
 use arbitrary::Arbitrary;
 
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct Type(u64);
+pub struct FrameType(u64);
 
-impl Type {
+impl FrameType {
     fn stream(self) -> Option<StreamInfo> {
         if STREAM_TYS.contains(&self.0) {
             Some(StreamInfo(self.0 as u8))
@@ -38,7 +38,7 @@ impl Type {
     }
 }
 
-impl coding::Codec for Type {
+impl coding::Codec for FrameType {
     fn decode<B: Buf>(buf: &mut B) -> coding::Result<Self> {
         Ok(Self(buf.get_var()?))
     }
@@ -54,11 +54,11 @@ pub(crate) trait FrameStruct {
 
 macro_rules! frame_types {
     {$($name:ident = $val:expr,)*} => {
-        impl Type {
-            $(pub const $name: Type = Type($val);)*
+        impl FrameType {
+            $(pub const $name: FrameType = FrameType($val);)*
         }
 
-        impl fmt::Debug for Type {
+        impl fmt::Debug for FrameType {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match self.0 {
                     $($val => f.write_str(stringify!($name)),)*
@@ -67,7 +67,7 @@ macro_rules! frame_types {
             }
         }
 
-        impl fmt::Display for Type {
+        impl fmt::Display for FrameType {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match self.0 {
                     $($val => f.write_str(stringify!($name)),)*
@@ -166,25 +166,25 @@ pub(crate) enum Frame {
 }
 
 impl Frame {
-    pub(crate) fn ty(&self) -> Type {
+    pub(crate) fn ty(&self) -> FrameType {
         use self::Frame::*;
         match *self {
-            Padding => Type::PADDING,
-            ResetStream(_) => Type::RESET_STREAM,
-            Close(self::Close::Connection(_)) => Type::CONNECTION_CLOSE,
-            Close(self::Close::Application(_)) => Type::APPLICATION_CLOSE,
-            MaxData(_) => Type::MAX_DATA,
-            MaxStreamData { .. } => Type::MAX_STREAM_DATA,
-            MaxStreams { dir: Dir::Bi, .. } => Type::MAX_STREAMS_BIDI,
-            MaxStreams { dir: Dir::Uni, .. } => Type::MAX_STREAMS_UNI,
-            Ping => Type::PING,
-            DataBlocked { .. } => Type::DATA_BLOCKED,
-            StreamDataBlocked { .. } => Type::STREAM_DATA_BLOCKED,
-            StreamsBlocked { dir: Dir::Bi, .. } => Type::STREAMS_BLOCKED_BIDI,
-            StreamsBlocked { dir: Dir::Uni, .. } => Type::STREAMS_BLOCKED_UNI,
-            StopSending { .. } => Type::STOP_SENDING,
-            RetireConnectionId { .. } => Type::RETIRE_CONNECTION_ID,
-            Ack(_) => Type::ACK,
+            Padding => FrameType::PADDING,
+            ResetStream(_) => FrameType::RESET_STREAM,
+            Close(self::Close::Connection(_)) => FrameType::CONNECTION_CLOSE,
+            Close(self::Close::Application(_)) => FrameType::APPLICATION_CLOSE,
+            MaxData(_) => FrameType::MAX_DATA,
+            MaxStreamData { .. } => FrameType::MAX_STREAM_DATA,
+            MaxStreams { dir: Dir::Bi, .. } => FrameType::MAX_STREAMS_BIDI,
+            MaxStreams { dir: Dir::Uni, .. } => FrameType::MAX_STREAMS_UNI,
+            Ping => FrameType::PING,
+            DataBlocked { .. } => FrameType::DATA_BLOCKED,
+            StreamDataBlocked { .. } => FrameType::STREAM_DATA_BLOCKED,
+            StreamsBlocked { dir: Dir::Bi, .. } => FrameType::STREAMS_BLOCKED_BIDI,
+            StreamsBlocked { dir: Dir::Uni, .. } => FrameType::STREAMS_BLOCKED_UNI,
+            StopSending { .. } => FrameType::STOP_SENDING,
+            RetireConnectionId { .. } => FrameType::RETIRE_CONNECTION_ID,
+            Ack(_) => FrameType::ACK,
             Stream(ref x) => {
                 let mut ty = *STREAM_TYS.start();
                 if x.fin {
@@ -193,17 +193,17 @@ impl Frame {
                 if x.offset != 0 {
                     ty |= 0x04;
                 }
-                Type(ty)
+                FrameType(ty)
             }
-            PathChallenge(_) => Type::PATH_CHALLENGE,
-            PathResponse(_) => Type::PATH_RESPONSE,
-            NewConnectionId { .. } => Type::NEW_CONNECTION_ID,
-            Crypto(_) => Type::CRYPTO,
-            NewToken { .. } => Type::NEW_TOKEN,
-            Datagram(_) => Type(*DATAGRAM_TYS.start()),
-            AckFrequency(_) => Type::ACK_FREQUENCY,
-            ImmediateAck => Type::IMMEDIATE_ACK,
-            HandshakeDone => Type::HANDSHAKE_DONE,
+            PathChallenge(_) => FrameType::PATH_CHALLENGE,
+            PathResponse(_) => FrameType::PATH_RESPONSE,
+            NewConnectionId { .. } => FrameType::NEW_CONNECTION_ID,
+            Crypto(_) => FrameType::CRYPTO,
+            NewToken { .. } => FrameType::NEW_TOKEN,
+            Datagram(_) => FrameType(*DATAGRAM_TYS.start()),
+            AckFrequency(_) => FrameType::ACK_FREQUENCY,
+            ImmediateAck => FrameType::IMMEDIATE_ACK,
+            HandshakeDone => FrameType::HANDSHAKE_DONE,
         }
     }
 
@@ -253,7 +253,7 @@ pub struct ConnectionClose {
     /// Class of error as encoded in the specification
     pub error_code: TransportErrorCode,
     /// Type of frame that caused the close
-    pub frame_type: Option<Type>,
+    pub frame_type: Option<FrameType>,
     /// Human-readable reason for the close
     pub reason: Bytes,
 }
@@ -285,7 +285,7 @@ impl FrameStruct for ConnectionClose {
 
 impl ConnectionClose {
     pub(crate) fn encode<W: BufMut>(&self, out: &mut W, max_len: usize) {
-        out.write(Type::CONNECTION_CLOSE); // 1 byte
+        out.write(FrameType::CONNECTION_CLOSE); // 1 byte
         out.write(self.error_code); // <= 8 bytes
         let ty = self.frame_type.map_or(0, |x| x.0);
         out.write_var(ty); // <= 8 bytes
@@ -328,7 +328,7 @@ impl FrameStruct for ApplicationClose {
 
 impl ApplicationClose {
     pub(crate) fn encode<W: BufMut>(&self, out: &mut W, max_len: usize) {
-        out.write(Type::APPLICATION_CLOSE); // 1 byte
+        out.write(FrameType::APPLICATION_CLOSE); // 1 byte
         out.write(self.error_code); // <= 8 bytes
         let max_len = max_len - 3 - VarInt::from_u64(self.reason.len() as u64).unwrap().size();
         let actual_len = self.reason.len().min(max_len);
@@ -388,9 +388,9 @@ impl Ack {
         let largest = first.end - 1;
         let first_size = first.end - first.start;
         buf.write(if ecn.is_some() {
-            Type::ACK_ECN
+            FrameType::ACK_ECN
         } else {
-            Type::ACK
+            FrameType::ACK
         });
         buf.write_var(largest);
         buf.write_var(delay);
@@ -517,7 +517,7 @@ impl Crypto {
     pub(crate) const SIZE_BOUND: usize = 17;
 
     pub(crate) fn encode<W: BufMut>(&self, out: &mut W) {
-        out.write(Type::CRYPTO);
+        out.write(FrameType::CRYPTO);
         out.write_var(self.offset);
         out.write_var(self.data.len() as u64);
         out.put_slice(&self.data);
@@ -527,7 +527,7 @@ impl Crypto {
 pub(crate) struct Iter {
     // TODO: ditch io::Cursor after bytes 0.5
     bytes: io::Cursor<Bytes>,
-    last_ty: Option<Type>,
+    last_ty: Option<FrameType>,
 }
 
 impl Iter {
@@ -558,68 +558,68 @@ impl Iter {
     }
 
     fn try_next(&mut self) -> Result<Frame, IterErr> {
-        let ty = self.bytes.get::<Type>()?;
+        let ty = self.bytes.get::<FrameType>()?;
         self.last_ty = Some(ty);
         Ok(match ty {
-            Type::PADDING => Frame::Padding,
-            Type::RESET_STREAM => Frame::ResetStream(ResetStream {
+            FrameType::PADDING => Frame::Padding,
+            FrameType::RESET_STREAM => Frame::ResetStream(ResetStream {
                 id: self.bytes.get()?,
                 error_code: self.bytes.get()?,
                 final_offset: self.bytes.get()?,
             }),
-            Type::CONNECTION_CLOSE => Frame::Close(Close::Connection(ConnectionClose {
+            FrameType::CONNECTION_CLOSE => Frame::Close(Close::Connection(ConnectionClose {
                 error_code: self.bytes.get()?,
                 frame_type: {
                     let x = self.bytes.get_var()?;
                     if x == 0 {
                         None
                     } else {
-                        Some(Type(x))
+                        Some(FrameType(x))
                     }
                 },
                 reason: self.take_len()?,
             })),
-            Type::APPLICATION_CLOSE => Frame::Close(Close::Application(ApplicationClose {
+            FrameType::APPLICATION_CLOSE => Frame::Close(Close::Application(ApplicationClose {
                 error_code: self.bytes.get()?,
                 reason: self.take_len()?,
             })),
-            Type::MAX_DATA => Frame::MaxData(self.bytes.get()?),
-            Type::MAX_STREAM_DATA => Frame::MaxStreamData {
+            FrameType::MAX_DATA => Frame::MaxData(self.bytes.get()?),
+            FrameType::MAX_STREAM_DATA => Frame::MaxStreamData {
                 id: self.bytes.get()?,
                 offset: self.bytes.get_var()?,
             },
-            Type::MAX_STREAMS_BIDI => Frame::MaxStreams {
+            FrameType::MAX_STREAMS_BIDI => Frame::MaxStreams {
                 dir: Dir::Bi,
                 count: self.bytes.get_var()?,
             },
-            Type::MAX_STREAMS_UNI => Frame::MaxStreams {
+            FrameType::MAX_STREAMS_UNI => Frame::MaxStreams {
                 dir: Dir::Uni,
                 count: self.bytes.get_var()?,
             },
-            Type::PING => Frame::Ping,
-            Type::DATA_BLOCKED => Frame::DataBlocked {
+            FrameType::PING => Frame::Ping,
+            FrameType::DATA_BLOCKED => Frame::DataBlocked {
                 offset: self.bytes.get_var()?,
             },
-            Type::STREAM_DATA_BLOCKED => Frame::StreamDataBlocked {
+            FrameType::STREAM_DATA_BLOCKED => Frame::StreamDataBlocked {
                 id: self.bytes.get()?,
                 offset: self.bytes.get_var()?,
             },
-            Type::STREAMS_BLOCKED_BIDI => Frame::StreamsBlocked {
+            FrameType::STREAMS_BLOCKED_BIDI => Frame::StreamsBlocked {
                 dir: Dir::Bi,
                 limit: self.bytes.get_var()?,
             },
-            Type::STREAMS_BLOCKED_UNI => Frame::StreamsBlocked {
+            FrameType::STREAMS_BLOCKED_UNI => Frame::StreamsBlocked {
                 dir: Dir::Uni,
                 limit: self.bytes.get_var()?,
             },
-            Type::STOP_SENDING => Frame::StopSending(StopSending {
+            FrameType::STOP_SENDING => Frame::StopSending(StopSending {
                 id: self.bytes.get()?,
                 error_code: self.bytes.get()?,
             }),
-            Type::RETIRE_CONNECTION_ID => Frame::RetireConnectionId {
+            FrameType::RETIRE_CONNECTION_ID => Frame::RetireConnectionId {
                 sequence: self.bytes.get_var()?,
             },
-            Type::ACK | Type::ACK_ECN => {
+            FrameType::ACK | FrameType::ACK_ECN => {
                 let largest = self.bytes.get_var()?;
                 let delay = self.bytes.get_var()?;
                 let extra_blocks = self.bytes.get_var()? as usize;
@@ -630,7 +630,7 @@ impl Iter {
                     delay,
                     largest,
                     additional: self.bytes.get_ref().slice(start..end),
-                    ecn: if ty != Type::ACK_ECN {
+                    ecn: if ty != FrameType::ACK_ECN {
                         None
                     } else {
                         Some(EcnCounts {
@@ -641,9 +641,9 @@ impl Iter {
                     },
                 })
             }
-            Type::PATH_CHALLENGE => Frame::PathChallenge(self.bytes.get()?),
-            Type::PATH_RESPONSE => Frame::PathResponse(self.bytes.get()?),
-            Type::NEW_CONNECTION_ID => {
+            FrameType::PATH_CHALLENGE => Frame::PathChallenge(self.bytes.get()?),
+            FrameType::PATH_RESPONSE => Frame::PathResponse(self.bytes.get()?),
+            FrameType::NEW_CONNECTION_ID => {
                 let sequence = self.bytes.get_var()?;
                 let retire_prior_to = self.bytes.get_var()?;
                 if retire_prior_to > sequence {
@@ -671,21 +671,21 @@ impl Iter {
                     reset_token: reset_token.into(),
                 })
             }
-            Type::CRYPTO => Frame::Crypto(Crypto {
+            FrameType::CRYPTO => Frame::Crypto(Crypto {
                 offset: self.bytes.get_var()?,
                 data: self.take_len()?,
             }),
-            Type::NEW_TOKEN => Frame::NewToken {
+            FrameType::NEW_TOKEN => Frame::NewToken {
                 token: self.take_len()?,
             },
-            Type::HANDSHAKE_DONE => Frame::HandshakeDone,
-            Type::ACK_FREQUENCY => Frame::AckFrequency(AckFrequency {
+            FrameType::HANDSHAKE_DONE => Frame::HandshakeDone,
+            FrameType::ACK_FREQUENCY => Frame::AckFrequency(AckFrequency {
                 sequence: self.bytes.get()?,
                 ack_eliciting_threshold: self.bytes.get()?,
                 request_max_ack_delay: self.bytes.get()?,
                 reordering_threshold: self.bytes.get()?,
             }),
-            Type::IMMEDIATE_ACK => Frame::ImmediateAck,
+            FrameType::IMMEDIATE_ACK => Frame::ImmediateAck,
             _ => {
                 if let Some(s) = ty.stream() {
                     Frame::Stream(Stream {
@@ -743,7 +743,7 @@ impl Iterator for Iter {
 
 #[derive(Debug)]
 pub(crate) struct InvalidFrame {
-    pub(crate) ty: Option<Type>,
+    pub(crate) ty: Option<FrameType>,
     pub(crate) reason: &'static str,
 }
 
@@ -833,7 +833,7 @@ impl FrameStruct for ResetStream {
 
 impl ResetStream {
     pub(crate) fn encode<W: BufMut>(&self, out: &mut W) {
-        out.write(Type::RESET_STREAM); // 1 byte
+        out.write(FrameType::RESET_STREAM); // 1 byte
         out.write(self.id); // <= 8 bytes
         out.write(self.error_code); // <= 8 bytes
         out.write(self.final_offset); // <= 8 bytes
@@ -852,7 +852,7 @@ impl FrameStruct for StopSending {
 
 impl StopSending {
     pub(crate) fn encode<W: BufMut>(&self, out: &mut W) {
-        out.write(Type::STOP_SENDING); // 1 byte
+        out.write(FrameType::STOP_SENDING); // 1 byte
         out.write(self.id); // <= 8 bytes
         out.write(self.error_code) // <= 8 bytes
     }
@@ -868,7 +868,7 @@ pub(crate) struct NewConnectionId {
 
 impl NewConnectionId {
     pub(crate) fn encode<W: BufMut>(&self, out: &mut W) {
-        out.write(Type::NEW_CONNECTION_ID);
+        out.write(FrameType::NEW_CONNECTION_ID);
         out.write_var(self.sequence);
         out.write_var(self.retire_prior_to);
         out.write(self.id.len() as u8);
@@ -893,7 +893,7 @@ impl FrameStruct for Datagram {
 
 impl Datagram {
     pub(crate) fn encode(&self, length: bool, out: &mut Vec<u8>) {
-        out.write(Type(*DATAGRAM_TYS.start() | u64::from(length))); // 1 byte
+        out.write(FrameType(*DATAGRAM_TYS.start() | u64::from(length))); // 1 byte
         if length {
             // Safe to unwrap because we check length sanity before queueing datagrams
             out.write(VarInt::from_u64(self.data.len() as u64).unwrap()); // <= 8 bytes
@@ -920,7 +920,7 @@ pub(crate) struct AckFrequency {
 
 impl AckFrequency {
     pub(crate) fn encode<W: BufMut>(&self, buf: &mut W) {
-        buf.write(Type::ACK_FREQUENCY);
+        buf.write(FrameType::ACK_FREQUENCY);
         buf.write(self.sequence);
         buf.write(self.ack_eliciting_threshold);
         buf.write(self.request_max_ack_delay);
@@ -990,7 +990,7 @@ mod test {
     #[test]
     fn immediate_ack_coding() {
         let mut buf = Vec::new();
-        Type::IMMEDIATE_ACK.encode(&mut buf);
+        FrameType::IMMEDIATE_ACK.encode(&mut buf);
         let frames = frames(buf);
         assert_eq!(frames.len(), 1);
         assert_matches!(&frames[0], Frame::ImmediateAck);

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -46,6 +46,9 @@ pub use crate::connection::{
     WriteError, Written,
 };
 
+#[cfg(feature = "rustls")]
+pub use rustls;
+
 mod config;
 pub use config::{
     AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig,
@@ -56,7 +59,7 @@ pub mod crypto;
 
 mod frame;
 use crate::frame::Frame;
-pub use crate::frame::{ApplicationClose, ConnectionClose, Datagram};
+pub use crate::frame::{ApplicationClose, ConnectionClose, Datagram, FrameType};
 
 mod endpoint;
 pub use crate::endpoint::{

--- a/quinn-proto/src/transport_error.rs
+++ b/quinn-proto/src/transport_error.rs
@@ -13,7 +13,7 @@ pub struct Error {
     /// Type of error
     pub code: Code,
     /// Frame type that triggered the error
-    pub frame: Option<frame::Type>,
+    pub frame: Option<frame::FrameType>,
     /// Human-readable explanation of the reason
     pub reason: String,
 }

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -63,8 +63,10 @@ mod work_limiter;
 
 pub use proto::{
     congestion, crypto, AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ClosedStream,
-    ConfigError, ConnectError, ConnectionClose, ConnectionError, ConnectionStats, EndpointConfig,
-    IdleTimeout, MtuDiscoveryConfig, ServerConfig, StreamId, Transmit, TransportConfig, VarInt,
+    ConfigError, ConnectError, ConnectionClose, ConnectionError, ConnectionId,
+    ConnectionIdGenerator, ConnectionStats, Dir, EcnCodepoint, EndpointConfig, FrameStats,
+    FrameType, IdleTimeout, MtuDiscoveryConfig, PathStats, ServerConfig, Side, StreamId, Transmit,
+    TransportConfig, TransportErrorCode, UdpStats, VarInt, VarIntBoundsExceeded, Written,
 };
 #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
 pub use rustls;


### PR DESCRIPTION
Closes #2012 

In that issue, we noted that there doesn't seem to exists any automated tooling to automatically detect types from external crates which are visible in a crate's public API but which the crate does not re-export. So I went ahead and attempted to create such a tool: [[cargo should-be-public-checker]](https://github.com/gretchenfrage/cargo-should-be-public-checker). It's still pretty crude right now but it was enough to detect a handful of items that I confirmed were missing reexports in Quinn and proto. That said, it's possible that there are some things it missed.

should-be-public-checker output for quinn-proto (on main):

```
visible but not importable:
- quinn_proto::Chunk::bytes::Bytes
- quinn_proto::ClientConfig::with_root_certificates::RootCertStore
- quinn_proto::ClientConfig::with_root_certificates::VerifierBuilderError
- quinn_proto::ConnectionClose::frame_type::Type
- quinn_proto::ConnectionHandle::`<_ as Index<Some(AngleBracketed { args: [Type(ResolvedPath(Path { name: "ConnectionHandle", id: Id(4627), args: Some(AngleBracketed { args: [], constraints: [] }) }))], constraints: [] })>>`::Output::ConnectionMeta
- quinn_proto::ConnectionId::from_buf::Buf
- quinn_proto::PartialDecode::new::BytesMut
- quinn_proto::ServerConfig::with_single_cert::CertificateDer
- quinn_proto::ServerConfig::with_single_cert::PrivateKeyDer
- quinn_proto::crypto::rustls::HandshakeData::negotiated_cipher_suite::CipherSuite
- quinn_proto::crypto::rustls::QuicClientConfig::with_initial::ClientConfig
- quinn_proto::crypto::rustls::QuicServerConfig::with_initial::ServerConfig
- quinn_proto::crypto::rustls::QuicServerConfig::with_initial::Suite
- quinn_proto::crypto::rustls::TlsSession::`<_ as VZip<Some(AngleBracketed { args: [Type(Generic("V"))], constraints: [] })>>`::MultiLane
- quinn_proto::transport_parameters::TransportParameters::write::BufMut
```

should-be-public-checker output for quinn (on main):

```
visible but not importable:
- quinn::ApplicationClose::reason::Bytes
- quinn::ClientConfig::initial_dst_cid_provider::ConnectionId
- quinn::ClientConfig::initial_dst_cid_provider::ConnectionId::from_buf::Buf
- quinn::ConnectionClose::error_code::Code
- quinn::ConnectionClose::frame_type::Type
- quinn::ConnectionStats::frame_tx::FrameStats
- quinn::ConnectionStats::path::PathStats
- quinn::ConnectionStats::udp_tx::UdpStats
- quinn::EndpointConfig::cid_generator::ConnectionIdGenerator
- quinn::SendStream::write_chunks::Written
- quinn::StreamId::new::Dir
- quinn::StreamId::new::Side
- quinn::Transmit::ecn::EcnCodepoint
- quinn::VarInt::from_u64::VarIntBoundsExceeded
- quinn::crypto::CryptoError::`<_ as VZip<Some(AngleBracketed { args: [Type(Generic("V"))], constraints: [] })>>`::MultiLane
- quinn::rustls::ConfigSide::Sealed
- quinn::rustls::RootCertStore::roots::TrustAnchor
- quinn::rustls::client::EchConfig::new::EchConfigListBytes
- quinn::rustls::client::ServerCertVerifierBuilder::with_crls::CertificateRevocationListDer
- quinn::rustls::client::Tls13ClientSessionValue::`<_ as Deref<Some(AngleBracketed { args: [], constraints: [] })>>`::Target::ClientSessionCommon
- quinn::rustls::client::verify_server_cert_signed_by_trust_anchor::CertificateDer
- quinn::rustls::client::verify_server_cert_signed_by_trust_anchor::SignatureVerificationAlgorithm
- quinn::rustls::client::verify_server_cert_signed_by_trust_anchor::UnixTime
- quinn::rustls::client::verify_server_name::ServerName
- quinn::rustls::crypto::cipher::OutboundOpaqueMessage::read::MessageError
- quinn::rustls::crypto::cipher::OutboundOpaqueMessage::read::Reader
- quinn::rustls::crypto::cipher::PlainMessage::payload::Payload
- quinn::rustls::crypto::hpke::HpkeSuite::kem::HpkeKem
- quinn::rustls::crypto::hpke::HpkeSuite::sym::HpkeSymmetricCipherSuite
- quinn::rustls::crypto::hpke::HpkeSuite::sym::HpkeSymmetricCipherSuite::aead_id::HpkeAead
- quinn::rustls::crypto::hpke::HpkeSuite::sym::HpkeSymmetricCipherSuite::kdf_id::HpkeKdf
- quinn::rustls::crypto::ring::sign::any_ecdsa_type::PrivateKeyDer
- quinn::rustls::crypto::ring::sign::any_eddsa_type::PrivatePkcs8KeyDer
- quinn::rustls::crypto::verify_tls13_signature_with_raw_key::SubjectPublicKeyInfoDer
- quinn::rustls::server::ClientHello::server_cert_types::CertificateType
- quinn::rustls::unbuffered::TransmitTlsData::may_encrypt_early_data::MayEncryptEarlyData
```

Summary of changes:

- `quinn_proto::frame::Type` becomes public. So, in addition to simply re-exporting it:
  - Renamed it to `FrameType`
  - Added doc comment
  - Made its associated constants `pub(crate)` rather than `pub`
- In terms of crate re-exports: Quinn already re-exports `rustls` and `udp`. Following this trend, I also added re-export of `rustls` to proto, and re-export of `bytes` to both.
- I changed crate re-exports from `pub use` to `pub extern crate`. I'm fine changing this back if you like, but I think this is better because it's more clear that it's more clear that it's a crate being re-exported.
- Other than that, simply `pub use`d all the missing items. 

Of course, fixing the missing re-exports in `rustls` is out of scope, and the thing about `MultiLane` is some irrelevant blanket-impl.
