### PR TITLE
chore(ci): Remove workaround for broken `cc` version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -121,11 +121,6 @@ jobs:
 
       - name: Install cargo binstall
         uses: cargo-bins/cargo-binstall@main
-      
-      # We need to downgrade cc to version 1.1.31 for ring Wasm compilation to work.
-      # See the upstream issue https://github.com/rust-lang/cc-rs/issues/1275
-      - name: Use working `cc` version 1.1.31
-        run: cargo update -p cc --precise 1.1.31
 
       - name: build wasm32 tests (quinn-proto)
         run: cargo test -p quinn-proto --target wasm32-unknown-unknown --no-run


### PR DESCRIPTION
We've previously had this workaround in CI for `cc` versions between version `1.1.32` and `1.1.37` which broke the `ring` build for wasm32-unknown-unknown in github actions.

Version `1.2.0` is now released and doesn't break `ring` anymore.

Related PRs:
- https://github.com/rust-lang/cc-rs/pull/1284
- https://github.com/rust-lang/cc-rs/pull/1286