### PR TITLE
Account for probe size limits before coalescing

### DIFF
--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use bytes::Bytes;
 use rand::Rng;
 use tracing::{trace, trace_span};
@@ -8,7 +6,7 @@ use super::{spaces::SentPacket, Connection, SentFrames};
 use crate::{
     frame::{self, Close},
     packet::{Header, InitialHeader, LongType, PacketNumber, PartialEncode, SpaceId, FIXED_BIT},
-    ConnectionId, Instant, TransportError, TransportErrorCode, INITIAL_MTU,
+    ConnectionId, Instant, TransportError, TransportErrorCode,
 };
 
 pub(super) struct PacketBuilder {
@@ -38,7 +36,7 @@ impl PacketBuilder {
         space_id: SpaceId,
         dst_cid: ConnectionId,
         buffer: &mut Vec<u8>,
-        mut buffer_capacity: usize,
+        buffer_capacity: usize,
         datagram_start: usize,
         ack_eliciting: bool,
         conn: &mut Connection,
@@ -79,13 +77,6 @@ impl PacketBuilder {
         }
 
         let space = &mut conn.spaces[space_id];
-
-        if space.loss_probes != 0 {
-            space.loss_probes -= 1;
-            // Clamp the packet size to at most the minimum MTU to ensure that loss probes can get
-            // through and enable recovery even if the path MTU has shrank unexpectedly.
-            buffer_capacity = cmp::min(buffer_capacity, datagram_start + usize::from(INITIAL_MTU));
-        }
         let exact_number = match space_id {
             SpaceId::Data => conn.packet_number_filter.allocate(&mut conn.rng, space),
             _ => space.get_tx_number(),

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -104,7 +104,7 @@ impl PacketSpace {
 
     /// Queue data for a tail loss probe (or anti-amplification deadlock prevention) packet
     ///
-    /// Probes are sent similarly to normal packets when an expect ACK has not arrived. We never
+    /// Probes are sent similarly to normal packets when an expected ACK has not arrived. We never
     /// deem a packet lost until we receive an ACK that should have included it, but if a trailing
     /// run of packets (or their ACKs) are lost, this might not happen in a timely fashion. We send
     /// probe packets to force an ACK, and exempt them from congestion control to prevent a deadlock


### PR DESCRIPTION
Fixes another bug found in #2020.

When a datagram is a loss probe, it must be at most 1200 bytes. This limit must be accounted for before we judge whether there's enough space to coalesce another packet.