### PR TITLE
chore(quinn-udp): tweak log levels

### DIFF
--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -322,7 +322,9 @@ fn send(
                         // Prevent new transmits from being scheduled using GSO. Existing GSO transmits
                         // may already be in the pipeline, so we need to tolerate additional failures.
                         if state.max_gso_segments() > 1 {
-                            crate::log::error!("got transmit error, halting segmentation offload");
+                            crate::log::info!(
+                                "`libc::sendmsg` failed with {e}; halting segmentation offload"
+                            );
                             state
                                 .max_gso_segments
                                 .store(1, std::sync::atomic::Ordering::Relaxed);

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -14,7 +14,7 @@ use windows_sys::Win32::Networking::WinSock;
 
 use crate::{
     cmsg::{self, CMsgHdr},
-    log::{debug, error},
+    log::debug,
     log_sendmsg_error, EcnCodepoint, RecvMeta, Transmit, UdpSockRef, IO_ERROR_LOG_INTERVAL,
 };
 
@@ -61,9 +61,10 @@ impl UdpSocketState {
 
         // We don't support old versions of Windows that do not enable access to `WSARecvMsg()`
         if WSARECVMSG_PTR.is_none() {
-            error!("network stack does not support WSARecvMsg function");
-
-            return Err(io::Error::from(io::ErrorKind::Unsupported));
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "network stack does not support WSARecvMsg function",
+            ));
         }
 
         if is_ipv4 {


### PR DESCRIPTION
This PR is a proposal to remove the two `ERROR` logs that we currently have in `quinn-udp`. Rationale is explained separately in each commit message.