### PR TITLE
docs: Correct MSRV in README

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -163,6 +163,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Note that we must also update the README when changing the MSRV
       - uses: dtolnay/rust-toolchain@1.70.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --lib --all-features -p quinn-udp -p quinn-proto -p quinn

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The project was founded by [Dirkjan Ochtman](https://github.com/djc) and
   [rustls][rustls] and [*ring*][ring]
 - Application-layer datagrams for small, unreliable messages
 - Future-based async API
-- Minimum supported Rust version of 1.66
+- Minimum supported Rust version of 1.70
 
 ## Overview
 


### PR DESCRIPTION
Djc bumped MSRV to 1.70 in #1939 in July. However, the README still claims that the MSRV is 1.66. This PR fixes the README and adds a note to the CI config.