### PR TITLE
Bump MSRV to 1.71

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -164,7 +164,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # Note that we must also update the README when changing the MSRV
-      - uses: dtolnay/rust-toolchain@1.70.0
+      - uses: dtolnay/rust-toolchain@1.71.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --lib --all-features -p quinn-udp -p quinn-proto -p quinn
 
@@ -271,4 +271,3 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-hack
       - run: cargo hack check --feature-powerset --optional-deps --no-dev-deps --ignore-unknown-features --ignore-private --group-features runtime-async-std,async-io,async-std --group-features runtime-smol,async-io,smol --skip "${{env.SKIP_FEATURES}}"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["quinn", "quinn-proto", "quinn-udp", "bench", "perf"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.70.0"
+rust-version = "1.71"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/quinn-rs/quinn"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The project was founded by [Dirkjan Ochtman](https://github.com/djc) and
   [rustls][rustls] and [*ring*][ring]
 - Application-layer datagrams for small, unreliable messages
 - Future-based async API
-- Minimum supported Rust version of 1.70
+- Minimum supported Rust version of 1.71
 
 ## Overview
 


### PR DESCRIPTION
This is the MSRV current rustls has adopted (on the back of current env_logger requiring 1.71).