### PR TITLE
fix(udp): use IPV6_PMTUDISC_PROBE instead of IP_PMTUDISC_PROBE on v6

### DIFF
--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -146,7 +146,7 @@ impl UdpSocketState {
                     &*io,
                     libc::IPPROTO_IPV6,
                     libc::IPV6_MTU_DISCOVER,
-                    libc::IP_PMTUDISC_PROBE,
+                    libc::IPV6_PMTUDISC_PROBE,
                 )?;
             }
         }


### PR DESCRIPTION
Both resolve to `3`, thus not an actual bug.

Caught thanks to @marten-seemann's [DF draft](https://github.com/marten-seemann/draft-seemann-tsvwg-udp-fragmentation).