### PR TITLE
tests(quinn): Ignore stress tests by default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
             echo "===== freebsd-version ====="
             freebsd-version
 
-            cargo build --all-targets && cargo test && cargo test --manifest-path fuzz/Cargo.toml && cargo test -p quinn-udp --benches
+            cargo build --all-targets && cargo test && cargo test -- --ignored stress && cargo test --manifest-path fuzz/Cargo.toml && cargo test -p quinn-udp --benches
 
   test-netbsd:
     name: test on netbsd
@@ -58,7 +58,7 @@ jobs:
             echo "===== uname -a        ====="
             uname -a
 
-            cargo build --all-targets && cargo test && cargo test --manifest-path fuzz/Cargo.toml && cargo test -p quinn-udp --benches
+            cargo build --all-targets && cargo test && cargo test -- --ignored stress && cargo test --manifest-path fuzz/Cargo.toml && cargo test -p quinn-udp --benches
 
   test-solaris:
     name: test on solaris
@@ -80,7 +80,7 @@ jobs:
             uname -a
           run: |
             export PATH=$HOME/.rust_solaris/bin:$PATH
-            cargo build --all-targets && cargo test && cargo test --manifest-path fuzz/Cargo.toml && cargo test -p quinn-udp --benches
+            cargo build --all-targets && cargo test -- --ignored stress && cargo test --manifest-path fuzz/Cargo.toml && cargo test -p quinn-udp --benches
 
   test-illumos:
     name: test on illumos
@@ -98,7 +98,7 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
           run: |
             . "$HOME/.cargo/env"
-            cargo build --all-targets && cargo test && cargo test --manifest-path fuzz/Cargo.toml && cargo test -p quinn-udp --benches
+            cargo build --all-targets && cargo test && cargo test -- --ignored stress && cargo test --manifest-path fuzz/Cargo.toml && cargo test -p quinn-udp --benches
 
   test:
     strategy:
@@ -121,6 +121,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --all-targets
       - run: cargo test
+      - run: cargo test -- --ignored stress
       - run: cargo test --manifest-path fuzz/Cargo.toml
         if: ${{ matrix.rust }} == "stable"
       - run: cargo test -p quinn-udp --benches

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -429,6 +429,7 @@ fn echo_dualstack() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(target_os = "solaris", ignore = "Hangs in poll() on Solaris")]
 fn stress_receive_window() {
     run_echo(EchoArgs {
@@ -442,6 +443,7 @@ fn stress_receive_window() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(target_os = "solaris", ignore = "Hangs in poll() on Solaris")]
 fn stress_stream_receive_window() {
     // Note that there is no point in running this with too many streams,
@@ -457,6 +459,7 @@ fn stress_stream_receive_window() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(target_os = "solaris", ignore = "Hangs in poll() on Solaris")]
 fn stress_both_windows() {
     run_echo(EchoArgs {


### PR DESCRIPTION
Per [Discord messages](https://discord.com/channels/976380008299917365/1063547094863978677/1310833978957234228), ignores long-running stress tests by default.

With this commit, `cargo test` runs in less than 2 seconds on my machine, whereas on main it takes over 60.
