### PR TITLE
Use `Async::new_nonblocking` to avoid redundant socket configuration

### DIFF
--- a/quinn/src/runtime/async_io.rs
+++ b/quinn/src/runtime/async_io.rs
@@ -89,7 +89,7 @@ impl UdpSocket {
     fn new(sock: std::net::UdpSocket) -> io::Result<Self> {
         Ok(Self {
             inner: udp::UdpSocketState::new((&sock).into())?,
-            io: Async::new(sock)?,
+            io: Async::new_nonblocking(sock)?,
         })
     }
 }


### PR DESCRIPTION
This PR replaces Quinn's use of `Async::new` with [`Async::new_nonblocking`](https://docs.rs/async-io/latest/async_io/struct.Async.html#method.new_nonblocking), a constructor introduced in version 2.0 of `async_io`, which assumes the socket has already been put into non-blocking mode. For Quinn this is indeed the case, as `quinn_udp` configures the socket as non-blocking already.

As for the Tokio runtime implementation, that uses [`UdpSocket::from_std`](https://github.com/quinn-rs/quinn/blob/31a0440009afd5a7e29101410aa9d3da2d1f8077/quinn/src/runtime/tokio.rs#L33), which [already makes this assumption](https://docs.rs/tokio/latest/tokio/net/struct.UdpSocket.html#notes).