### PR TITLE
feat(quinn-proto): unhide `quinn_proto::coding`

### DIFF
--- a/quinn-proto/src/coding.rs
+++ b/quinn-proto/src/coding.rs
@@ -1,3 +1,5 @@
+//! Coding related traits.
+
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use bytes::{Buf, BufMut};
@@ -5,14 +7,19 @@ use thiserror::Error;
 
 use crate::VarInt;
 
+/// Error indicating that the provided buffer was too small
 #[derive(Error, Debug, Copy, Clone, Eq, PartialEq)]
 #[error("unexpected end of buffer")]
 pub struct UnexpectedEnd;
 
+/// Coding result type
 pub type Result<T> = ::std::result::Result<T, UnexpectedEnd>;
 
+/// Infallible encoding and decoding of QUIC primitives
 pub trait Codec: Sized {
+    /// Decode a `Self` from the provided buffer, if the buffer is large enough
     fn decode<B: Buf>(buf: &mut B) -> Result<Self>;
+    /// Append the encoding of `self` to the provided buffer
     fn encode<B: BufMut>(&self, buf: &mut B);
 }
 
@@ -92,7 +99,7 @@ impl Codec for Ipv6Addr {
     }
 }
 
-pub trait BufExt {
+pub(crate) trait BufExt {
     fn get<T: Codec>(&mut self) -> Result<T>;
     fn get_var(&mut self) -> Result<u64>;
 }
@@ -107,7 +114,7 @@ impl<T: Buf> BufExt for T {
     }
 }
 
-pub trait BufMutExt {
+pub(crate) trait BufMutExt {
     fn write<T: Codec>(&mut self, x: T);
     fn write_var(&mut self, x: u64);
 }

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -27,7 +27,6 @@ use std::{
 };
 
 mod cid_queue;
-#[doc(hidden)]
 pub mod coding;
 mod constant_time;
 mod range_set;


### PR DESCRIPTION
It turned out currently the `coding` mod is already public, simply hidden from the docs.

It seems to be the minimal change to allow using this functionality for `VarInt` is to document it and not hide it.

Fixes #1277