### PR TITLE
fix(udp): retry send on first EINVAL

### DIFF
--- a/.github/workflows/rust-android-run-tests-on-emulator.sh
+++ b/.github/workflows/rust-android-run-tests-on-emulator.sh
@@ -8,7 +8,7 @@ any_failures=0
 for test in $(find target/$TARGET/debug/deps/ -type f -executable ! -name "*.so" -name "*-*"); do
     adb push "$test" /data/local/tmp/
     adb shell chmod +x /data/local/tmp/$(basename "$test")
-    adb shell /data/local/tmp/$(basename "$test") || any_failures=1
+    adb shell API_LEVEL=$API_LEVEL /data/local/tmp/$(basename "$test") || any_failures=1
 done
 
 exit $any_failures

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -222,17 +222,19 @@ jobs:
 
     strategy:
       matrix:
-        include:
+        target: [x86_64-linux-android, i686-linux-android]
+        emulator-arch: [x86_64, x86]
+        api-level: [26, 25]
+        exclude:
           - target: x86_64-linux-android
-            emulator-arch: x86_64
-            # Note that x86_64 image is only available for API 21+. See
-            # https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#configurations.
-            api-level: 26
-          - target: i686-linux-android
             emulator-arch: x86
-            api-level: 26
+          - target: i686-linux-android
+            emulator-arch: x86_64
 
     steps:
+    - name: Set API level environment variable
+      run: echo "API_LEVEL=${{ matrix.api-level }}" >> $GITHUB_ENV
+
     - name: Checkout code
       uses: actions/checkout@v4
 

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.5.8"
+version = "0.5.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -106,8 +106,8 @@ pub struct RecvMeta {
     pub ecn: Option<EcnCodepoint>,
     /// The destination IP address which was encoded in this datagram
     ///
-    /// Populated on platforms: Windows, Linux, Android, FreeBSD, OpenBSD, NetBSD, macOS,
-    /// and iOS.
+    /// Populated on platforms: Windows, Linux, Android (API level > 25),
+    /// FreeBSD, OpenBSD, NetBSD, macOS, and iOS.
     pub dst_ip: Option<IpAddr>,
 }
 


### PR DESCRIPTION
Android API level < 26 does not support the `libc::IP_TOS` control message. `sendmsg` calls with `libc::IP_TOS` return `libc::EINVAL`.

https://github.com/quinn-rs/quinn/pull/1516 added a fallback, not setting `libc::IP_TOS` on consecutive calls to `sendmsg` after a failure with `libc::EINVAL`. The current datagram would be dropped. Consecutive datagrams passed to `sendmsg` would succeed as they would be sent without `libc::IP_TOS` through the fallback.

Instead of dropping the first datagram on `libc::EINVAL`, this commit adds a retry for it without `libc::IP_TOS`.

This is e.g. relevant for Neqo. When establishing a QUIC connection, dropping the first datagram [delays connection establishment by 100ms](https://github.com/mozilla/neqo/blob/3001a3a56f2274eaafaa956fb394f0817f526ae7/neqo-transport/src/rtt.rs#L28). With the retry introduced in this commit, delay due to unsupported `libc::IP_TOS` should be negligible.

Closes https://github.com/quinn-rs/quinn/pull/1975.

//CC @KershawChang

---

This pull request contains 3 commits:
1. Add Android API level 25 CI step.
2. Add retry on `libc::EINVAL`.
3. Bump `quinn-udp` patch version to `v0.5.9`.