### PR TITLE
refactor(udp): remove unnecessary `return`

### DIFF
--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -341,8 +341,6 @@ fn send(
                     if e.raw_os_error() != Some(libc::EMSGSIZE) {
                         return Err(e);
                     }
-
-                    return Ok(());
                 }
             }
         }


### PR DESCRIPTION
No need to `return Ok(())` early, given the final `return Ok(())` at the end of the function. Makes it consistent with other `send` implementations. Makes it consistent with early returns being errors only.

Follow-up to https://github.com/quinn-rs/quinn/pull/2074#discussion_r1863944160. I have not yet been able to come up with a better refactoring.