### PR TITLE
proto: Connection side enum

### DIFF
--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -4,6 +4,7 @@ use tracing::{trace, trace_span};
 
 use super::{spaces::SentPacket, Connection, SentFrames};
 use crate::{
+    connection::ConnectionSide,
     frame::{self, Close},
     packet::{Header, InitialHeader, LongType, PacketNumber, PartialEncode, SpaceId, FIXED_BIT},
     ConnectionId, Instant, TransportError, TransportErrorCode,
@@ -113,7 +114,10 @@ impl PacketBuilder {
             SpaceId::Initial => Header::Initial(InitialHeader {
                 src_cid: conn.handshake_cid,
                 dst_cid,
-                token: conn.retry_token.clone(),
+                token: match &conn.side {
+                    ConnectionSide::Client { token, .. } => token.clone(),
+                    ConnectionSide::Server { .. } => Bytes::new(),
+                },
                 number,
                 version,
             }),


### PR DESCRIPTION
Some notable differences from how I approached this in #1912:

- Calling it `ConnectionSide` rather than `SideState`
- Call the field `Connection.side` rather than `Connection.side_state`. The causes changes to be necessary to a different, but smaller set of lines of code, since now every existing instance of `self.side.is_client()` or `self.side.is_server()` just works as-is. And it's terser.
- Offloaded more logic to methods on `SideArgs` and an `impl From<SideArgs> for ConnectionSide`, in the interest of taking some complexity load off of `Connection::new`, which is already over 100 lines.