### PR TITLE
Adjust terminology regarding tokens

### DIFF
--- a/quinn-proto/src/config/mod.rs
+++ b/quinn-proto/src/config/mod.rs
@@ -201,7 +201,7 @@ pub struct ServerConfig {
     /// Used to generate one-time AEAD keys to protect handshake tokens
     pub(crate) token_key: Arc<dyn HandshakeTokenKey>,
 
-    /// Duration after a stateless retry token was issued for which it's considered valid
+    /// Duration after a retry token was issued for which it's considered valid
     pub(crate) retry_token_lifetime: Duration,
 
     /// Whether to allow clients to migrate to new addresses
@@ -254,7 +254,7 @@ impl ServerConfig {
         self
     }
 
-    /// Duration after a stateless retry token was issued for which it's considered valid
+    /// Duration after a retry token was issued for which it's considered valid
     ///
     /// Defaults to 15 seconds.
     pub fn retry_token_lifetime(&mut self, value: Duration) -> &mut Self {

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -1307,8 +1307,7 @@ pub struct AcceptError {
     pub response: Option<Transmit>,
 }
 
-/// Error for attempting to retry an [`Incoming`] which already bears an address validation token
-/// from a previous retry
+/// Error for attempting to retry an [`Incoming`] which already bears a token from a previous retry
 #[derive(Debug, Error)]
 #[error("retry() with validated Incoming")]
 pub struct RetryError(Incoming);

--- a/quinn/src/incoming.rs
+++ b/quinn/src/incoming.rs
@@ -104,8 +104,7 @@ struct State {
     endpoint: EndpointRef,
 }
 
-/// Error for attempting to retry an [`Incoming`] which already bears an address validation token
-/// from a previous retry
+/// Error for attempting to retry an [`Incoming`] which already bears a token from a previous retry
 #[derive(Debug, Error)]
 #[error("retry() with validated Incoming")]
 pub struct RetryError(Incoming);


### PR DESCRIPTION
RFC 9000 presents some unfortunate complications to naming things. It introduces a concept of a "token" that may cause a connection to be validated early. In some ways, these tokens must be treated discretely differently based on whether they originated from a NEW_TOKEN frame or a Retry packet. It also introduces an unrelated concept of a "stateless reset token".

If our code and documentation were to constantly use phrases like "token originating from NEW_TOKEN frame," that would be extremely cumbersome. Moreover, it would risk feeling like leaking spec internals to the user.

As such, this commit tries to move things towards the following naming convention:

- A token from a NEW_TOKEN frame is called a "validation token", or "address validation token", although the shorter form should be used most often.
- A token from a Retry packet is called a "retry token".

  We should avoid saying "stateless retry token" because this phrase is not used at all in RFC 9000 and is confusingly similar to "stateless reset token". This commit changes public usages of that phrase.
- In the generic case of either, we call it a "token".
- We still call a stateless reset token a "reset token" or "stateless reset token".

---

Just recently, on the Discord, I noticed an [example](https://discord.com/channels/976380008299917365/1063547094863978677/1308508959040344087) of someone mixing up "stateless reset" and "stateless retry". Notably, I wrote this code _before_ I noticed that happening naturally. They're extremely easy to mix up.
