### PR TITLE
quinn: Remove obsolete must_use for futures

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -31,7 +31,6 @@ use proto::{
 
 /// In-progress connection attempt future
 #[derive(Debug)]
-#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct Connecting {
     conn: Option<ConnectionRef>,
     connected: oneshot::Receiver<bool>,
@@ -212,7 +211,6 @@ impl Future for Connecting {
 ///
 /// For clients, the resulting value indicates if 0-RTT was accepted. For servers, the resulting
 /// value is meaningless.
-#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 pub struct ZeroRttAccepted(oneshot::Receiver<bool>);
 
 impl Future for ZeroRttAccepted {

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -413,7 +413,6 @@ impl<T> From<(Option<T>, Option<proto::ReadError>)> for ReadStatus<T> {
 /// Future produced by [`RecvStream::read_to_end()`].
 ///
 /// [`RecvStream::read_to_end()`]: crate::RecvStream::read_to_end
-#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 struct ReadToEnd<'a> {
     stream: &'a mut RecvStream,
     read: Vec<(Bytes, u64)>,
@@ -597,7 +596,6 @@ impl From<ResetError> for io::Error {
 /// Future produced by [`RecvStream::read()`].
 ///
 /// [`RecvStream::read()`]: crate::RecvStream::read
-#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 struct Read<'a> {
     stream: &'a mut RecvStream,
     buf: ReadBuf<'a>,
@@ -619,7 +617,6 @@ impl Future for Read<'_> {
 /// Future produced by [`RecvStream::read_exact()`].
 ///
 /// [`RecvStream::read_exact()`]: crate::RecvStream::read_exact
-#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 struct ReadExact<'a> {
     stream: &'a mut RecvStream,
     buf: ReadBuf<'a>,
@@ -656,7 +653,6 @@ pub enum ReadExactError {
 /// Future produced by [`RecvStream::read_chunk()`].
 ///
 /// [`RecvStream::read_chunk()`]: crate::RecvStream::read_chunk
-#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 struct ReadChunk<'a> {
     stream: &'a mut RecvStream,
     max_length: usize,
@@ -674,7 +670,6 @@ impl Future for ReadChunk<'_> {
 /// Future produced by [`RecvStream::read_chunks()`].
 ///
 /// [`RecvStream::read_chunks()`]: crate::RecvStream::read_chunks
-#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 struct ReadChunks<'a> {
     stream: &'a mut RecvStream,
     bufs: &'a mut [Bytes],

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -305,7 +305,6 @@ impl Drop for SendStream {
 }
 
 /// Future produced by `SendStream::stopped`
-#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 struct Stopped<'a> {
     stream: &'a mut SendStream,
 }
@@ -321,7 +320,6 @@ impl Future for Stopped<'_> {
 /// Future produced by [`SendStream::write()`].
 ///
 /// [`SendStream::write()`]: crate::SendStream::write
-#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 struct Write<'a> {
     stream: &'a mut SendStream,
     buf: &'a [u8],
@@ -339,7 +337,6 @@ impl Future for Write<'_> {
 /// Future produced by [`SendStream::write_all()`].
 ///
 /// [`SendStream::write_all()`]: crate::SendStream::write_all
-#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 struct WriteAll<'a> {
     stream: &'a mut SendStream,
     buf: &'a [u8],
@@ -363,7 +360,6 @@ impl Future for WriteAll<'_> {
 /// Future produced by [`SendStream::write_chunks()`].
 ///
 /// [`SendStream::write_chunks()`]: crate::SendStream::write_chunks
-#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 struct WriteChunks<'a> {
     stream: &'a mut SendStream,
     bufs: &'a mut [Bytes],
@@ -381,7 +377,6 @@ impl Future for WriteChunks<'_> {
 /// Future produced by [`SendStream::write_chunk()`].
 ///
 /// [`SendStream::write_chunk()`]: crate::SendStream::write_chunk
-#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 struct WriteChunk<'a> {
     stream: &'a mut SendStream,
     buf: [Bytes; 1],
@@ -404,7 +399,6 @@ impl Future for WriteChunk<'_> {
 /// Future produced by [`SendStream::write_all_chunks()`].
 ///
 /// [`SendStream::write_all_chunks()`]: crate::SendStream::write_all_chunks
-#[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
 struct WriteAllChunks<'a> {
     stream: &'a mut SendStream,
     bufs: &'a mut [Bytes],


### PR DESCRIPTION
Various future types had boilerplate `must_use` annotations. Rust now does that automatically for futures. Removes all of them that didn't have some more specific message.

Noted in #1757.