### PR TITLE
Make SystemTime mockable via object

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -31,8 +31,8 @@ use crate::{
     },
     token,
     transport_parameters::{PreferredAddress, TransportParameters},
-    Duration, Instant, ResetToken, RetryToken, Side, SystemTime, Transmit, TransportConfig,
-    TransportError, INITIAL_MTU, MAX_CID_SIZE, MIN_INITIAL_SIZE, RESET_TOKEN_SIZE,
+    Duration, Instant, ResetToken, RetryToken, Side, Transmit, TransportConfig, TransportError,
+    INITIAL_MTU, MAX_CID_SIZE, MIN_INITIAL_SIZE, RESET_TOKEN_SIZE,
 };
 
 /// The main entry point to the library
@@ -506,7 +506,8 @@ impl Endpoint {
                 &header.token,
             ) {
                 Ok(token)
-                    if token.issued + server_config.retry_token_lifetime > SystemTime::now() =>
+                    if token.issued + server_config.retry_token_lifetime
+                        > server_config.time_source.now() =>
                 {
                     (Some(header.dst_cid), token.orig_dst_cid)
                 }
@@ -769,7 +770,7 @@ impl Endpoint {
 
         let token = RetryToken {
             orig_dst_cid: incoming.packet.header.dst_cid,
-            issued: SystemTime::now(),
+            issued: server_config.time_source.now(),
         }
         .encode(
             &*server_config.token_key,

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -51,7 +51,7 @@ pub use rustls;
 mod config;
 pub use config::{
     AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig,
-    ServerConfig, TransportConfig,
+    ServerConfig, StdSystemTime, TimeSource, TransportConfig,
 };
 
 pub mod crypto;

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -65,8 +65,9 @@ pub use proto::{
     congestion, crypto, AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ClosedStream,
     ConfigError, ConnectError, ConnectionClose, ConnectionError, ConnectionId,
     ConnectionIdGenerator, ConnectionStats, Dir, EcnCodepoint, EndpointConfig, FrameStats,
-    FrameType, IdleTimeout, MtuDiscoveryConfig, PathStats, ServerConfig, Side, StreamId, Transmit,
-    TransportConfig, TransportErrorCode, UdpStats, VarInt, VarIntBoundsExceeded, Written,
+    FrameType, IdleTimeout, MtuDiscoveryConfig, PathStats, ServerConfig, Side, StdSystemTime,
+    StreamId, TimeSource, Transmit, TransportConfig, TransportErrorCode, UdpStats, VarInt,
+    VarIntBoundsExceeded, Written,
 };
 #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
 pub use rustls;


### PR DESCRIPTION
- Adds trait SystemTimeClock
- Adds default implementation RealSystemTimeClock
- Adds ServerConfigParameter system_time_clock: Arc<dyn SystemTimeClock>
- Replaces all SystemTime::now calls in proto with SystemTimeClock.now calls (there were 2)

This is a backwards-compatible change.