### PR TITLE
fix(udp): make GRO (i.e. URO) optional on Windows, off by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tracing-subscriber = { version = "0.3.0", default-features = false, features = [
 url = "2"
 wasm-bindgen-test = { version = "0.3.45" }
 web-time = "1"
-windows-sys = { version = ">=0.52, <=0.59", features = ["Win32_Foundation", "Win32_System_IO", "Win32_Networking_WinSock", "Win32_System_SystemInformation", "Win32_System_Threading"] }
+windows-sys = { version = ">=0.52, <=0.59", features = ["Win32_Foundation", "Win32_System_IO", "Win32_Networking_WinSock"] }
 
 [profile.bench]
 debug = true

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.5.8"
+version = "0.5.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -10,13 +10,7 @@ use std::{
 
 use libc::{c_int, c_uint};
 use once_cell::sync::Lazy;
-use windows_sys::Win32::{
-    Networking::WinSock,
-    System::{
-        SystemInformation::IMAGE_FILE_MACHINE_ARM64,
-        Threading::{GetCurrentProcess, IsWow64Process2},
-    },
-};
+use windows_sys::Win32::Networking::WinSock;
 
 use crate::{
     cmsg::{self, CMsgHdr},
@@ -113,33 +107,16 @@ impl UdpSocketState {
             )?;
         }
 
-        match &*IS_WINDOWS_ON_ARM {
-            Ok(true) => {
-                // Bug on Windows on ARM, not receiving `UDP_COALESCED_INFO` `CMSG`
-                // when _Virtual Machine Platform_ feature enabled. See
-                // <https://github.com/quinn-rs/quinn/issues/2041> for details.
-                debug!("detected Windows on ARM host thus not enabling URO")
-            }
-            Ok(false) => {
-                // Opportunistically try to enable URO
-                let result = set_socket_option(
-                    &*socket.0,
-                    WinSock::IPPROTO_UDP,
-                    WinSock::UDP_RECV_MAX_COALESCED_SIZE,
-                    // u32 per
-                    // https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-udp-socket-options.
-                    // Choice of 2^16 - 1 inspired by msquic.
-                    u16::MAX as u32,
-                );
-
-                if let Err(_e) = result {
-                    debug!("failed to enable URO: {_e}");
-                }
-            }
-            Err(_e) => {
-                debug!("failed to detect host system thus not enabling URO: {_e}");
-            }
-        }
+        // Opportunistically try to enable GRO
+        _ = set_socket_option(
+            &*socket.0,
+            WinSock::IPPROTO_UDP,
+            WinSock::UDP_RECV_MAX_COALESCED_SIZE,
+            // u32 per
+            // https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-udp-socket-options.
+            // Choice of 2^16 - 1 inspired by msquic.
+            u16::MAX as u32,
+        );
 
         let now = Instant::now();
         Ok(Self {
@@ -491,31 +468,5 @@ static MAX_GSO_SEGMENTS: Lazy<usize> = Lazy::new(|| {
         // Empirically found on Windows 11 x64
         Ok(()) => 512,
         Err(_) => 1,
-    }
-});
-
-/// Evaluates to [`Ok(true)`] if executed either directly on Windows on ARM, or
-/// on an emulator which itself executes on Windows on ARM.
-///
-/// See
-/// <https://learn.microsoft.com/en-us/windows/arm/apps-on-arm-x86-emulation#detecting-emulation>
-/// for details.
-static IS_WINDOWS_ON_ARM: Lazy<io::Result<bool>> = Lazy::new(|| {
-    let mut process_machine: u16 = 0;
-    let mut native_machine: u16 = 0;
-
-    let result = unsafe {
-        IsWow64Process2(
-            GetCurrentProcess(),
-            &mut process_machine as *mut u16,
-            &mut native_machine as *mut u16,
-        )
-    };
-
-    match result {
-        // See
-        // <https://learn.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-iswow64process2#return-value>.
-        0 => Err(io::Error::last_os_error()),
-        _ => Ok(native_machine == IMAGE_FILE_MACHINE_ARM64),
     }
 });


### PR DESCRIPTION
We have multiple bug reports for GRO (i.e. URO) on Windows with no solution in sight.

- https://github.com/quinn-rs/quinn/issues/2041
- https://bugzilla.mozilla.org/show_bug.cgi?id=1916558

While it previously seemed like this might be bound to _Windows on ARM_ only, that assumption can no longer be made, see e.g. https://github.com/quinn-rs/quinn/issues/2041#issuecomment-2542435062 and [Bugzilla comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1916558#c54). Thus our previous attempt (https://github.com/quinn-rs/quinn/pull/2071) is not enough.

I suggest by default disabling GRO (i.e. URO) on all of Windows, with an advanced option for users to enable it via `UdpSocketState::set_gro(true)`.

Users that control their hardware, i.e. know the hardware supports URO, can enable it.

Users that want to implement a heuristic, as e.g. suggested by @thomaseizinger  in https://github.com/quinn-rs/quinn/issues/2041#issuecomment-2542435062, can enable or disable it programmatically. 

Reverts https://github.com/quinn-rs/quinn/pull/2071.
Tracked in https://github.com/quinn-rs/quinn/issues/2041