### PR TITLE
Factor out `IncomingToken`

### DIFF
--- a/quinn-proto/src/token.rs
+++ b/quinn-proto/src/token.rs
@@ -178,6 +178,13 @@ impl fmt::Display for ResetToken {
     }
 }
 
+/// State in an `Incoming` determined by a token or lack thereof
+#[derive(Debug)]
+pub(crate) struct IncomingToken {
+    pub(crate) retry_src_cid: Option<ConnectionId>,
+    pub(crate) orig_dst_cid: ConnectionId,
+}
+
 #[cfg(all(test, any(feature = "aws-lc-rs", feature = "ring")))]
 mod test {
     #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]


### PR DESCRIPTION
Improved decoupling between modules, makes code flow easier to understand IMO, and sets us up to have an easier time adding more internal variants to `RetryToken`, for NEW_TOKEN stuff.