### PR TITLE
quinn: Make SendStream::poll_stopped private

### DIFF
--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -203,8 +203,7 @@ impl SendStream {
         Stopped { stream: self }.await
     }
 
-    #[doc(hidden)]
-    pub fn poll_stopped(&mut self, cx: &mut Context) -> Poll<Result<Option<VarInt>, StoppedError>> {
+    fn poll_stopped(&mut self, cx: &mut Context) -> Poll<Result<Option<VarInt>, StoppedError>> {
         let mut conn = self.conn.state.lock("SendStream::poll_stopped");
 
         if self.is_0rtt {


### PR DESCRIPTION
Previously, this method was public, but marked as `#[doc(hidden)]`. However, nothing anywhere was using it. This commit makes it private.

---

See #2097