### PR TITLE
Un-hide force_key_update / initiate_key_update

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1233,7 +1233,7 @@ impl Connection {
     /// Update traffic keys spontaneously
     ///
     /// This can be useful for testing key updates, as they otherwise only happen infrequently.
-    pub fn initiate_key_update(&mut self) {
+    pub fn force_key_update(&mut self) {
         self.update_keys(None, false);
     }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1230,7 +1230,9 @@ impl Connection {
         self.spaces[self.highest_space].ping_pending = true;
     }
 
-    #[doc(hidden)]
+    /// Update traffic keys spontaneously
+    ///
+    /// This can be useful for testing key updates, as they otherwise only happen infrequently.
     pub fn initiate_key_update(&mut self) {
         self.update_keys(None, false);
     }

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -47,7 +47,7 @@ impl PacketBuilder {
         let sent_with_keys = conn.spaces[space_id].sent_with_keys;
         if space_id == SpaceId::Data {
             if sent_with_keys >= conn.key_phase_size {
-                conn.initiate_key_update();
+                conn.force_key_update();
             }
         } else {
             let confidentiality_limit = conn.spaces[space_id]

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1012,7 +1012,7 @@ fn key_update_simple() {
     let _ = chunks.finalize();
 
     info!("initiating key update");
-    pair.client_conn_mut(client_ch).initiate_key_update();
+    pair.client_conn_mut(client_ch).force_key_update();
 
     const MSG2: &[u8] = b"hello2";
     pair.client_send(client_ch, s).write(MSG2).unwrap();
@@ -1052,7 +1052,7 @@ fn key_update_reordered() {
     assert!(!pair.client.outbound.is_empty());
     pair.client.delay_outbound();
 
-    pair.client_conn_mut(client_ch).initiate_key_update();
+    pair.client_conn_mut(client_ch).force_key_update();
     info!("updated keys");
 
     const MSG2: &[u8] = b"two";

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -576,8 +576,9 @@ impl Connection {
         self.0.stable_id()
     }
 
-    // Update traffic keys spontaneously for testing purposes.
-    #[doc(hidden)]
+    /// Update traffic keys spontaneously
+    ///
+    /// This primarily exists for testing purposes.
     pub fn force_key_update(&self) {
         self.0
             .state

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -584,7 +584,7 @@ impl Connection {
             .state
             .lock("force_key_update")
             .inner
-            .initiate_key_update()
+            .force_key_update()
     }
 
     /// Derive keying material from this connection's TLS session secrets.


### PR DESCRIPTION
See #2097.

~~Note: `initiate_key_update` (the one in proto) is called from various places internally, which is the primary reason for differences in their names and comment.~~