### PR TITLE
Un-hide get_max_udp_payload_size

### DIFF
--- a/quinn-proto/src/config/mod.rs
+++ b/quinn-proto/src/config/mod.rs
@@ -100,15 +100,14 @@ impl EndpointConfig {
         Ok(self)
     }
 
-    /// Get the current value of `max_udp_payload_size`
-    ///
-    /// While most parameters don't need to be readable, this must be exposed to allow higher-level
-    /// layers, e.g. the `quinn` crate, to determine how large a receive buffer to allocate to
-    /// support an externally-defined `EndpointConfig`.
-    ///
-    /// While `get_` accessors are typically unidiomatic in Rust, we favor concision for setters,
-    /// which will be used far more heavily.
-    #[doc(hidden)]
+    /// Get the current value of [`max_udp_payload_size`](Self::max_udp_payload_size)
+    //
+    // While most parameters don't need to be readable, this must be exposed to allow higher-level
+    // layers, e.g. the `quinn` crate, to determine how large a receive buffer to allocate to
+    // support an externally-defined `EndpointConfig`.
+    //
+    // While `get_` accessors are typically unidiomatic in Rust, we favor concision for setters,
+    // which will be used far more heavily.
     pub fn get_max_udp_payload_size(&self) -> u64 {
         self.max_udp_payload_size.into()
     }


### PR DESCRIPTION
- Removes `#[doc(hidden)]`
- Adds hyperlink
- Demotes most of the doc comment to non-doc comment, as it seems more like an internal note than something the user needs to see.

---

See #2097