### PR TITLE
Implement Default for ClosedStream

### DIFF
--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -508,17 +508,10 @@ impl ShouldTransmit {
 }
 
 /// Error indicating that a stream has not been opened or has already been finished or reset
-#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Error, Clone, PartialEq, Eq)]
 #[error("closed stream")]
 pub struct ClosedStream {
     _private: (),
-}
-
-impl ClosedStream {
-    #[doc(hidden)] // For use in quinn only
-    pub fn new() -> Self {
-        Self { _private: () }
-    }
 }
 
 impl From<ClosedStream> for io::Error {

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -144,7 +144,7 @@ impl SendStream {
                 conn.wake();
                 Ok(())
             }
-            Err(FinishError::ClosedStream) => Err(ClosedStream::new()),
+            Err(FinishError::ClosedStream) => Err(ClosedStream::default()),
             // Harmless. If the application needs to know about stopped streams at this point, it
             // should call `stopped`.
             Err(FinishError::Stopped(_)) => Ok(()),


### PR DESCRIPTION
This allows us to remove the `#[doc(hidden)] pub fn new() -> Self`.

---

See #2097