### PR TITLE
proto: Remove superfluous `#[doc(hidden)]` fuzzing

### DIFF
--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -96,7 +96,6 @@ pub(crate) use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 pub(crate) use web_time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-#[doc(hidden)]
 #[cfg(fuzzing)]
 pub mod fuzzing {
     pub use crate::connection::{Retransmits, State as ConnectionState, StreamsState};


### PR DESCRIPTION
The module is already `#[cfg(fuzzing)]`, which should make it not appear in docs.

---

See #2097 

I manually confirmed that the module doesn't appear when running `cargo doc` locally. However, I'm aware that docs.rs does some stuff about annotating which conditions different items are feature-gated behind, platform-gated behind, etc, which running `cargo doc` doesn't. I don't know how that works, whether it's a feature of cargo doc or something docs.rs has hacked on top, or how to recreate it locally. I'm hoping that it being `#[cfg(fuzzing)]`--notably, not a feature--will make it just not appear. But if we notice that it's popped up on the next release then we might have to revert.