### PR TITLE
Unhide ecn variants

### DIFF
--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -144,11 +144,11 @@ impl fmt::Display for ConnectionId {
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum EcnCodepoint {
-    #[doc(hidden)]
+    /// The ECT(0) codepoint, indicating that an endpoint is ECN-capable
     Ect0 = 0b10,
-    #[doc(hidden)]
+    /// The ECT(1) codepoint, indicating that an endpoint is ECN-capable
     Ect1 = 0b01,
-    #[doc(hidden)]
+    /// The CE codepoint, signalling that congestion was experienced
     Ce = 0b11,
 }
 

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -155,7 +155,7 @@ pub enum EcnCodepoint {
 impl EcnCodepoint {
     /// Create new object from the given bits
     pub fn from_bits(x: u8) -> Option<Self> {
-        use self::EcnCodepoint::*;
+        use EcnCodepoint::*;
         Some(match x & 0b11 {
             0b10 => Ect0,
             0b01 => Ect1,

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -198,11 +198,11 @@ where
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum EcnCodepoint {
-    #[doc(hidden)]
+    /// The ECT(0) codepoint, indicating that an endpoint is ECN-capable
     Ect0 = 0b10,
-    #[doc(hidden)]
+    /// The ECT(1) codepoint, indicating that an endpoint is ECN-capable
     Ect1 = 0b01,
-    #[doc(hidden)]
+    /// The CE codepoint, signalling that congestion was experienced
     Ce = 0b11,
 }
 


### PR DESCRIPTION
See #2097

~~I took the liberty of committing b11f2bf5e71daeac93827541183be1e0a1fdab9c. Unfortunately, it is semver breaking for everything. Users must convert `x.is_ce()` to `x == EcnCodepoint::Ce`.~~