### PR TITLE
proto: Pass `SocketAddr` by value

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -887,7 +887,7 @@ impl Connection {
             // Send an off-path PATH_RESPONSE. Prioritized over on-path data to ensure that path
             // validation can occur while the link is saturated.
             if space_id == SpaceId::Data && num_datagrams == 1 {
-                if let Some((token, remote)) = self.path_responses.pop_off_path(&self.path.remote) {
+                if let Some((token, remote)) = self.path_responses.pop_off_path(self.path.remote) {
                     // `unwrap` guaranteed to succeed because `builder_storage` was populated just
                     // above.
                     let mut builder = builder_storage.take().unwrap();
@@ -3127,7 +3127,7 @@ impl Connection {
 
         // PATH_RESPONSE
         if buf.len() + 9 < max_size && space_id == SpaceId::Data {
-            if let Some(token) = self.path_responses.pop_on_path(&self.path.remote) {
+            if let Some(token) = self.path_responses.pop_on_path(self.path.remote) {
                 sent.non_retransmits = true;
                 sent.requires_padding = true;
                 trace!("PATH_RESPONSE {:08x}", token);

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -261,9 +261,9 @@ impl PathResponses {
         }
     }
 
-    pub(crate) fn pop_off_path(&mut self, remote: &SocketAddr) -> Option<(u64, SocketAddr)> {
+    pub(crate) fn pop_off_path(&mut self, remote: SocketAddr) -> Option<(u64, SocketAddr)> {
         let response = *self.pending.last()?;
-        if response.remote == *remote {
+        if response.remote == remote {
             // We don't bother searching further because we expect that the on-path response will
             // get drained in the immediate future by a call to `pop_on_path`
             return None;
@@ -272,9 +272,9 @@ impl PathResponses {
         Some((response.token, response.remote))
     }
 
-    pub(crate) fn pop_on_path(&mut self, remote: &SocketAddr) -> Option<u64> {
+    pub(crate) fn pop_on_path(&mut self, remote: SocketAddr) -> Option<u64> {
         let response = *self.pending.last()?;
-        if response.remote != *remote {
+        if response.remote != remote {
             // We don't bother searching further because we expect that the off-path response will
             // get drained in the immediate future by a call to `pop_off_path`
             return None;

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -758,7 +758,7 @@ impl Endpoint {
         }
         .encode(
             &*server_config.token_key,
-            &incoming.addresses.remote,
+            incoming.addresses.remote,
             &loc_cid,
         );
 


### PR DESCRIPTION
Changes all `&SocketAddr` to `SocketAddr`. Per [previous discussion](https://github.com/quinn-rs/quinn/pull/2094#discussion_r1887198528). Note: This repo contains no occurrences of `&IpAddr`.