### PR TITLE
Remove `use self::` occurrences

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1054,7 +1054,7 @@ impl Connection {
     /// (including application `Event`s, `EndpointEvent`s and outgoing datagrams) that should be
     /// extracted through the relevant methods.
     pub fn handle_event(&mut self, event: ConnectionEvent) {
-        use self::ConnectionEventInner::*;
+        use ConnectionEventInner::*;
         match event.0 {
             Datagram(DatagramConnectionEvent {
                 now,
@@ -3744,7 +3744,7 @@ impl From<Close> for ConnectionError {
 // For compatibility with API consumers
 impl From<ConnectionError> for io::Error {
     fn from(x: ConnectionError) -> Self {
-        use self::ConnectionError::*;
+        use ConnectionError::*;
         let kind = match x {
             TimedOut => io::ErrorKind::TimedOut,
             Reset => io::ErrorKind::ConnectionReset,

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -168,7 +168,7 @@ pub(crate) enum Frame {
 
 impl Frame {
     pub(crate) fn ty(&self) -> FrameType {
-        use self::Frame::*;
+        use Frame::*;
         match *self {
             Padding => FrameType::PADDING,
             ResetStream(_) => FrameType::RESET_STREAM,
@@ -776,7 +776,7 @@ enum IterErr {
 
 impl IterErr {
     fn reason(&self) -> &'static str {
-        use self::IterErr::*;
+        use IterErr::*;
         match *self {
             UnexpectedEnd => "unexpected end",
             InvalidFrameId => "invalid frame ID",

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -206,7 +206,7 @@ impl Dir {
 
 impl fmt::Display for Dir {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use self::Dir::*;
+        use Dir::*;
         f.pad(match *self {
             Bi => "bidirectional",
             Uni => "unidirectional",

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -74,7 +74,7 @@ impl PartialDecode {
     }
 
     pub(crate) fn space(&self) -> Option<SpaceId> {
-        use self::ProtectedHeader::*;
+        use ProtectedHeader::*;
         match self.plain_header {
             Initial { .. } => Some(SpaceId::Initial),
             Long {
@@ -112,7 +112,7 @@ impl PartialDecode {
         self,
         header_crypto: Option<&dyn crypto::HeaderKey>,
     ) -> Result<Packet, PacketDecodeError> {
-        use self::ProtectedHeader::*;
+        use ProtectedHeader::*;
         let Self {
             plain_header,
             mut buf,
@@ -281,7 +281,7 @@ pub(crate) enum Header {
 
 impl Header {
     pub(crate) fn encode(&self, w: &mut Vec<u8>) -> PartialEncode {
-        use self::Header::*;
+        use Header::*;
         let start = w.len();
         match *self {
             Initial(InitialHeader {
@@ -383,7 +383,7 @@ impl Header {
     }
 
     pub(crate) fn number(&self) -> Option<PacketNumber> {
-        use self::Header::*;
+        use Header::*;
         Some(match *self {
             Initial(InitialHeader { number, .. }) => number,
             Long { number, .. } => number,
@@ -395,7 +395,7 @@ impl Header {
     }
 
     pub(crate) fn space(&self) -> SpaceId {
-        use self::Header::*;
+        use Header::*;
         match *self {
             Short { .. } => SpaceId::Data,
             Long {
@@ -436,7 +436,7 @@ impl Header {
     }
 
     pub(crate) fn dst_cid(&self) -> &ConnectionId {
-        use self::Header::*;
+        use Header::*;
         match *self {
             Initial(InitialHeader { ref dst_cid, .. }) => dst_cid,
             Long { ref dst_cid, .. } => dst_cid,
@@ -555,7 +555,7 @@ impl ProtectedHeader {
 
     /// The destination Connection ID of the packet
     pub fn dst_cid(&self) -> &ConnectionId {
-        use self::ProtectedHeader::*;
+        use ProtectedHeader::*;
         match self {
             Initial(header) => &header.dst_cid,
             Long { dst_cid, .. } => dst_cid,
@@ -566,7 +566,7 @@ impl ProtectedHeader {
     }
 
     fn payload_len(&self) -> Option<u64> {
-        use self::ProtectedHeader::*;
+        use ProtectedHeader::*;
         match self {
             Initial(ProtectedInitialHeader { len, .. }) | Long { len, .. } => Some(*len),
             _ => None,
@@ -702,7 +702,7 @@ impl PacketNumber {
     }
 
     pub(crate) fn len(self) -> usize {
-        use self::PacketNumber::*;
+        use PacketNumber::*;
         match self {
             U8(_) => 1,
             U16(_) => 2,
@@ -712,7 +712,7 @@ impl PacketNumber {
     }
 
     pub(crate) fn encode<W: BufMut>(self, w: &mut W) {
-        use self::PacketNumber::*;
+        use PacketNumber::*;
         match self {
             U8(x) => w.write(x),
             U16(x) => w.write(x),
@@ -722,7 +722,7 @@ impl PacketNumber {
     }
 
     pub(crate) fn decode<R: Buf>(len: usize, r: &mut R) -> Result<Self, PacketDecodeError> {
-        use self::PacketNumber::*;
+        use PacketNumber::*;
         let pn = match len {
             1 => U8(r.get()?),
             2 => U16(r.get()?),
@@ -738,7 +738,7 @@ impl PacketNumber {
     }
 
     fn tag(self) -> u8 {
-        use self::PacketNumber::*;
+        use PacketNumber::*;
         match self {
             U8(_) => 0b00,
             U16(_) => 0b01,
@@ -749,7 +749,7 @@ impl PacketNumber {
 
     pub(crate) fn expand(self, expected: u64) -> u64 {
         // From Appendix A
-        use self::PacketNumber::*;
+        use PacketNumber::*;
         let truncated = match self {
             U8(x) => u64::from(x),
             U16(x) => u64::from(x),
@@ -815,7 +815,7 @@ pub(crate) enum LongHeaderType {
 
 impl LongHeaderType {
     fn from_byte(b: u8) -> Result<Self, PacketDecodeError> {
-        use self::{LongHeaderType::*, LongType::*};
+        use {LongHeaderType::*, LongType::*};
         debug_assert!(b & LONG_HEADER_FORM != 0, "not a long packet");
         Ok(match (b & 0x30) >> 4 {
             0x0 => Initial,
@@ -829,7 +829,7 @@ impl LongHeaderType {
 
 impl From<LongHeaderType> for u8 {
     fn from(ty: LongHeaderType) -> Self {
-        use self::{LongHeaderType::*, LongType::*};
+        use {LongHeaderType::*, LongType::*};
         match ty {
             Initial => LONG_HEADER_FORM | FIXED_BIT,
             Standard(ZeroRtt) => LONG_HEADER_FORM | FIXED_BIT | (0x1 << 4),

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -209,7 +209,7 @@ pub enum EcnCodepoint {
 impl EcnCodepoint {
     /// Create new object from the given bits
     pub fn from_bits(x: u8) -> Option<Self> {
-        use self::EcnCodepoint::*;
+        use EcnCodepoint::*;
         Some(match x & 0b11 {
             0b10 => Ect0,
             0b01 => Ect1,

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -556,7 +556,7 @@ impl From<ResetError> for ReadError {
 
 impl From<ReadError> for io::Error {
     fn from(x: ReadError) -> Self {
-        use self::ReadError::*;
+        use ReadError::*;
         let kind = match x {
             Reset { .. } | ZeroRttRejected => io::ErrorKind::ConnectionReset,
             ConnectionLost(_) | ClosedStream => io::ErrorKind::NotConnected,

--- a/quinn/src/runtime.rs
+++ b/quinn/src/runtime.rs
@@ -187,10 +187,12 @@ pub fn default_runtime() -> Option<Arc<dyn Runtime>> {
 
 #[cfg(feature = "runtime-tokio")]
 mod tokio;
+// Due to MSRV, we must specify `self::` where there's crate/module ambiguity
 #[cfg(feature = "runtime-tokio")]
 pub use self::tokio::TokioRuntime;
 
 #[cfg(feature = "async-io")]
 mod async_io;
+// Due to MSRV, we must specify `self::` where there's crate/module ambiguity
 #[cfg(feature = "async-io")]
 pub use self::async_io::*;

--- a/quinn/src/runtime/async_io.rs
+++ b/quinn/src/runtime/async_io.rs
@@ -12,6 +12,7 @@ use async_io::{Async, Timer};
 use super::{AsyncTimer, AsyncUdpSocket, Runtime, UdpPollHelper};
 
 #[cfg(feature = "smol")]
+// Due to MSRV, we must specify `self::` where there's crate/module ambiguity
 pub use self::smol::SmolRuntime;
 
 #[cfg(feature = "smol")]
@@ -41,6 +42,7 @@ mod smol {
 }
 
 #[cfg(feature = "async-std")]
+// Due to MSRV, we must specify `self::` where there's crate/module ambiguity
 pub use self::async_std::AsyncStdRuntime;
 
 #[cfg(feature = "async-std")]

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -461,7 +461,7 @@ impl From<StoppedError> for WriteError {
 
 impl From<WriteError> for io::Error {
     fn from(x: WriteError) -> Self {
-        use self::WriteError::*;
+        use WriteError::*;
         let kind = match x {
             Stopped(_) | ZeroRttRejected => io::ErrorKind::ConnectionReset,
             ConnectionLost(_) | ClosedStream => io::ErrorKind::NotConnected,


### PR DESCRIPTION
I noticed this was occurring here and there in the repo. I don't recall if there was a motivation for it in some old Rust version, but I don't think there is now.