### PR TITLE
proto: Pass `ConnectionId` by value internally

### DIFF
--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -51,7 +51,7 @@ impl TlsSession {
 
 impl crypto::Session for TlsSession {
     fn initial_keys(&self, dst_cid: &ConnectionId, side: Side) -> Keys {
-        initial_keys(self.version, dst_cid, side, &self.suite)
+        initial_keys(self.version, *dst_cid, side, &self.suite)
     }
 
     fn handshake_data(&self) -> Option<Box<dyn Any>> {
@@ -504,7 +504,7 @@ impl crypto::ServerConfig for QuicServerConfig {
         dst_cid: &ConnectionId,
     ) -> Result<Keys, UnsupportedVersion> {
         let version = interpret_version(version)?;
-        Ok(initial_keys(version, dst_cid, Side::Server, &self.initial))
+        Ok(initial_keys(version, *dst_cid, Side::Server, &self.initial))
     }
 
     fn retry_tag(&self, version: u32, orig_dst_cid: &ConnectionId, packet: &[u8]) -> [u8; 16] {
@@ -564,11 +564,11 @@ fn to_vec(params: &TransportParameters) -> Vec<u8> {
 
 pub(crate) fn initial_keys(
     version: Version,
-    dst_cid: &ConnectionId,
+    dst_cid: ConnectionId,
     side: Side,
     suite: &Suite,
 ) -> Keys {
-    let keys = suite.keys(dst_cid, side.into(), version);
+    let keys = suite.keys(&dst_cid, side.into(), version);
     Keys {
         header: KeyPair {
             local: Box::new(keys.local.header),

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -435,14 +435,14 @@ impl Header {
         )
     }
 
-    pub(crate) fn dst_cid(&self) -> &ConnectionId {
+    pub(crate) fn dst_cid(&self) -> ConnectionId {
         use Header::*;
         match *self {
-            Initial(InitialHeader { ref dst_cid, .. }) => dst_cid,
-            Long { ref dst_cid, .. } => dst_cid,
-            Retry { ref dst_cid, .. } => dst_cid,
-            Short { ref dst_cid, .. } => dst_cid,
-            VersionNegotiate { ref dst_cid, .. } => dst_cid,
+            Initial(InitialHeader { dst_cid, .. }) => dst_cid,
+            Long { dst_cid, .. } => dst_cid,
+            Retry { dst_cid, .. } => dst_cid,
+            Short { dst_cid, .. } => dst_cid,
+            VersionNegotiate { dst_cid, .. } => dst_cid,
         }
     }
 
@@ -949,7 +949,7 @@ mod tests {
         let provider = default_provider();
 
         let suite = initial_suite_from_provider(&std::sync::Arc::new(provider)).unwrap();
-        let client = initial_keys(Version::V1, &dcid, Side::Client, &suite);
+        let client = initial_keys(Version::V1, dcid, Side::Client, &suite);
         let mut buf = Vec::new();
         let header = Header::Initial(InitialHeader {
             number: PacketNumber::U8(0),
@@ -979,7 +979,7 @@ mod tests {
             )[..]
         );
 
-        let server = initial_keys(Version::V1, &dcid, Side::Server, &suite);
+        let server = initial_keys(Version::V1, dcid, Side::Server, &suite);
         let supported_versions = crate::DEFAULT_SUPPORTED_VERSIONS.to_vec();
         let decode = PartialDecode::new(
             buf.as_slice().into(),


### PR DESCRIPTION
Same idea as #2107 but for `ConnectionId`. `ConnectionId` is, and probably always will be, `Copy`. `ConnectionId` is not remotely large enough to trigger stack overflows or severe performance hazards by being copied. So, we should just simplify the code and let the compiler figure out if it wants to optimize it elsewise.

~~Plus, this shaves off a few lines by convincing the rustfmt to collapse some multi-line method signatures into one line.~~

Edit: Changes this PR to only do so internally, and not change the API.