### PR TITLE
proto: Refactor `Endpoint.handle`

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -26,8 +26,8 @@ use crate::{
     },
     range_set::ArrayRangeSet,
     shared::{
-        ConnectionEvent, ConnectionEventInner, ConnectionId, DatagramConnectionEvent, EcnCodepoint,
-        EndpointEvent, EndpointEventInner,
+        ConnectionEvent, ConnectionEventInner, ConnectionId, DatagramConnectionEvent, DatagramInfo,
+        EcnCodepoint, EndpointEvent, EndpointEventInner,
     },
     token::ResetToken,
     transport_parameters::TransportParameters,
@@ -1057,11 +1057,14 @@ impl Connection {
         use ConnectionEventInner::*;
         match event.0 {
             Datagram(DatagramConnectionEvent {
-                now,
-                remote,
-                ecn,
                 first_decode,
-                remaining,
+                info:
+                    DatagramInfo {
+                        now,
+                        remote,
+                        ecn,
+                        remaining,
+                    },
             }) => {
                 // If this packet could initiate a migration and we're a client or a server that
                 // forbids migration, drop the datagram. This could be relaxed to heuristically
@@ -3425,7 +3428,7 @@ impl Connection {
         let (first_decode, remaining) = match &event.0 {
             ConnectionEventInner::Datagram(DatagramConnectionEvent {
                 first_decode,
-                remaining,
+                info: DatagramInfo { remaining, .. },
                 ..
             }) => (first_decode, remaining),
             _ => return None,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -157,10 +157,7 @@ impl Endpoint {
             Err(e) => return self.handle_decode_err(e, remote, local_ip, buf),
         };
 
-        //
         // Handle packet on existing connection, if any
-        //
-
         let addresses = FourTuple { remote, local_ip };
         if let Some(route_to) = self.index.get(&addresses, &first_decode) {
             let event = DatagramConnectionEvent {
@@ -173,12 +170,7 @@ impl Endpoint {
             return self.route_datagram(route_to, datagram_len, event);
         }
 
-        //
         // Potentially create a new connection
-        //
-
-        let dst_cid = first_decode.dst_cid();
-
         if first_decode.initial_header().is_some() {
             return self.handle_first_packet(
                 first_decode,
@@ -191,6 +183,7 @@ impl Endpoint {
             );
         }
 
+        let dst_cid = first_decode.dst_cid();
         if first_decode.has_long_header() {
             debug!(
                 "ignoring non-initial packet for unknown connection {}",
@@ -199,11 +192,8 @@ impl Endpoint {
             return None;
         }
 
-        //
         // If we got this far, we're a server receiving a seemingly valid packet for an unknown
         // connection. Send a stateless reset if possible.
-        //
-
         if !first_decode.is_initial()
             && self
                 .local_cid_generator

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -154,44 +154,7 @@ impl Endpoint {
             self.config.grease_quic_bit,
         ) {
             Ok(x) => x,
-            Err(PacketDecodeError::UnsupportedVersion {
-                src_cid,
-                dst_cid,
-                version,
-            }) => {
-                if self.server_config.is_none() {
-                    debug!("dropping packet with unsupported version");
-                    return None;
-                }
-                trace!("sending version negotiation");
-                // Negotiate versions
-                Header::VersionNegotiate {
-                    random: self.rng.gen::<u8>() | 0x40,
-                    src_cid: dst_cid,
-                    dst_cid: src_cid,
-                }
-                .encode(buf);
-                // Grease with a reserved version
-                if version != 0x0a1a_2a3a {
-                    buf.write::<u32>(0x0a1a_2a3a);
-                } else {
-                    buf.write::<u32>(0x0a1a_2a4a);
-                }
-                for &version in &self.config.supported_versions {
-                    buf.write(version);
-                }
-                return Some(DatagramEvent::Response(Transmit {
-                    destination: remote,
-                    ecn: None,
-                    size: buf.len(),
-                    segment_size: None,
-                    src_ip: local_ip,
-                }));
-            }
-            Err(e) => {
-                trace!("malformed header: {}", e);
-                return None;
-            }
+            Err(e) => return self.handle_decode_err(e, remote, local_ip, buf),
         };
 
         //
@@ -319,6 +282,56 @@ impl Endpoint {
 
         trace!("dropping unrecognized short packet without ID");
         None
+    }
+
+    /// Handle an incoming UDP datagram which can not be decoded
+    fn handle_decode_err(
+        &mut self,
+        error: PacketDecodeError,
+        remote: SocketAddr,
+        local_ip: Option<IpAddr>,
+        buf: &mut Vec<u8>,
+    ) -> Option<DatagramEvent> {
+        match error {
+            PacketDecodeError::UnsupportedVersion {
+                src_cid,
+                dst_cid,
+                version,
+            } => {
+                if self.server_config.is_none() {
+                    debug!("dropping packet with unsupported version");
+                    return None;
+                }
+                trace!("sending version negotiation");
+                // Negotiate versions
+                Header::VersionNegotiate {
+                    random: self.rng.gen::<u8>() | 0x40,
+                    src_cid: dst_cid,
+                    dst_cid: src_cid,
+                }
+                .encode(buf);
+                // Grease with a reserved version
+                if version != 0x0a1a_2a3a {
+                    buf.write::<u32>(0x0a1a_2a3a);
+                } else {
+                    buf.write::<u32>(0x0a1a_2a4a);
+                }
+                for &version in &self.config.supported_versions {
+                    buf.write(version);
+                }
+                Some(DatagramEvent::Response(Transmit {
+                    destination: remote,
+                    ecn: None,
+                    size: buf.len(),
+                    segment_size: None,
+                    src_ip: local_ip,
+                }))
+            }
+            _ => {
+                trace!("malformed header: {}", error);
+                None
+            }
+        }
     }
 
     fn stateless_reset(

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -189,7 +189,9 @@ impl Endpoint {
                 buf,
                 now,
             );
-        } else if first_decode.has_long_header() {
+        }
+
+        if first_decode.has_long_header() {
             debug!(
                 "ignoring non-initial packet for unknown connection {}",
                 dst_cid

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -22,8 +22,8 @@ use crate::{
     crypto::{self, Keys, UnsupportedVersion},
     frame,
     packet::{
-        FixedLengthConnectionIdParser, Header, InitialHeader, InitialPacket, Packet,
-        PacketDecodeError, PacketNumber, PartialDecode, ProtectedInitialHeader,
+        FixedLengthConnectionIdParser, Header, InitialHeader, InitialPacket, PacketDecodeError,
+        PacketNumber, PartialDecode, ProtectedInitialHeader,
     },
     shared::{
         ConnectionEvent, ConnectionEventInner, ConnectionId, DatagramConnectionEvent, EcnCodepoint,
@@ -178,52 +178,17 @@ impl Endpoint {
         //
 
         let dst_cid = first_decode.dst_cid();
-        let Some(server_config) = &self.server_config else {
-            debug!("packet for unrecognized connection {}", dst_cid);
-            return self
-                .stateless_reset(now, datagram_len, addresses, dst_cid, buf)
-                .map(DatagramEvent::Response);
-        };
 
-        if let Some(header) = first_decode.initial_header() {
-            if datagram_len < MIN_INITIAL_SIZE as usize {
-                debug!("ignoring short initial for connection {}", dst_cid);
-                return None;
-            }
-
-            let crypto = match server_config.crypto.initial_keys(header.version, dst_cid) {
-                Ok(keys) => keys,
-                Err(UnsupportedVersion) => {
-                    // This probably indicates that the user set supported_versions incorrectly in
-                    // `EndpointConfig`.
-                    debug!(
-                        "ignoring initial packet version {:#x} unsupported by cryptographic layer",
-                        header.version
-                    );
-                    return None;
-                }
-            };
-
-            if let Err(reason) = self.early_validate_first_packet(header) {
-                return Some(DatagramEvent::Response(self.initial_close(
-                    header.version,
-                    addresses,
-                    &crypto,
-                    &header.src_cid,
-                    reason,
-                    buf,
-                )));
-            }
-
-            return match first_decode.finish(Some(&*crypto.header.remote)) {
-                Ok(packet) => {
-                    self.handle_first_packet(addresses, ecn, packet, remaining, crypto, buf, now)
-                }
-                Err(e) => {
-                    trace!("unable to decode initial packet: {}", e);
-                    None
-                }
-            };
+        if first_decode.initial_header().is_some() {
+            return self.handle_first_packet(
+                first_decode,
+                datagram_len,
+                addresses,
+                ecn,
+                remaining,
+                buf,
+                now,
+            );
         } else if first_decode.has_long_header() {
             debug!(
                 "ignoring non-initial packet for unknown connection {}",
@@ -490,14 +455,61 @@ impl Endpoint {
 
     fn handle_first_packet(
         &mut self,
+        first_decode: PartialDecode,
+        datagram_len: usize,
         addresses: FourTuple,
         ecn: Option<EcnCodepoint>,
-        packet: Packet,
         rest: Option<BytesMut>,
-        crypto: Keys,
         buf: &mut Vec<u8>,
         now: Instant,
     ) -> Option<DatagramEvent> {
+        let dst_cid = first_decode.dst_cid();
+        let header = first_decode.initial_header().unwrap();
+
+        let Some(server_config) = &self.server_config else {
+            debug!("packet for unrecognized connection {}", dst_cid);
+            return self
+                .stateless_reset(now, datagram_len, addresses, dst_cid, buf)
+                .map(DatagramEvent::Response);
+        };
+
+        if datagram_len < MIN_INITIAL_SIZE as usize {
+            debug!("ignoring short initial for connection {}", dst_cid);
+            return None;
+        }
+
+        let crypto = match server_config.crypto.initial_keys(header.version, dst_cid) {
+            Ok(keys) => keys,
+            Err(UnsupportedVersion) => {
+                // This probably indicates that the user set supported_versions incorrectly in
+                // `EndpointConfig`.
+                debug!(
+                    "ignoring initial packet version {:#x} unsupported by cryptographic layer",
+                    header.version
+                );
+                return None;
+            }
+        };
+
+        if let Err(reason) = self.early_validate_first_packet(header) {
+            return Some(DatagramEvent::Response(self.initial_close(
+                header.version,
+                addresses,
+                &crypto,
+                &header.src_cid,
+                reason,
+                buf,
+            )));
+        }
+
+        let packet = match first_decode.finish(Some(&*crypto.header.remote)) {
+            Ok(packet) => packet,
+            Err(e) => {
+                trace!("unable to decode initial packet: {}", e);
+                return None;
+            }
+        };
+
         if !packet.reserved_bits_valid() {
             debug!("dropping connection attempt with invalid reserved bits");
             return None;

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -26,8 +26,8 @@ use crate::{
         PacketNumber, PartialDecode, ProtectedInitialHeader,
     },
     shared::{
-        ConnectionEvent, ConnectionEventInner, ConnectionId, DatagramConnectionEvent, EcnCodepoint,
-        EndpointEvent, EndpointEventInner, IssuedCid,
+        ConnectionEvent, ConnectionEventInner, ConnectionId, DatagramConnectionEvent, DatagramInfo,
+        EcnCodepoint, EndpointEvent, EndpointEventInner, IssuedCid,
     },
     token::{IncomingToken, InvalidRetryTokenError},
     transport_parameters::{PreferredAddress, TransportParameters},
@@ -161,11 +161,13 @@ impl Endpoint {
         let addresses = FourTuple { remote, local_ip };
         if let Some(route_to) = self.index.get(&addresses, &first_decode) {
             let event = DatagramConnectionEvent {
-                now,
-                remote,
-                ecn,
                 first_decode,
-                remaining,
+                info: DatagramInfo {
+                    now,
+                    remote,
+                    ecn,
+                    remaining,
+                },
             };
             return self.route_datagram(route_to, datagram_len, event);
         }

--- a/quinn-proto/src/shared.rs
+++ b/quinn-proto/src/shared.rs
@@ -19,10 +19,16 @@ pub(crate) enum ConnectionEventInner {
 /// Variant of [`ConnectionEventInner`].
 #[derive(Debug)]
 pub(crate) struct DatagramConnectionEvent {
+    pub(crate) first_decode: PartialDecode,
+    pub(crate) info: DatagramInfo,
+}
+
+/// Information about a received datagram beyond the partially decoded first packet
+#[derive(Debug)]
+pub(crate) struct DatagramInfo {
     pub(crate) now: Instant,
     pub(crate) remote: SocketAddr,
     pub(crate) ecn: Option<EcnCodepoint>,
-    pub(crate) first_decode: PartialDecode,
     pub(crate) remaining: Option<BytesMut>,
 }
 


### PR DESCRIPTION
Just a draft for now.

---

Main motivation:

I think `Endpoint.handle` is too long. It's 173 lines and it contains section divider comments like this:

```rs
//
// Potentially create a new connection
//
```

The general architecture of this function dates back to a [very long time ago](https://github.com/gretchenfrage/quinn/commit/b919cc7100a1807413d5ee562231694df5a54831#diff-b7dd6c6dc06c9c5da00a0c048df395e5fed282392d70a222b1d0e34706d9baf3R47-R111) and it used to be a lot smaller. I find it difficult to read and think it should be split up more.

Also: take opportunities to reduce LOC where found. However, some overhead is to be expected due to additional function signatures.