### PR TITLE
proto: Replace calls to Duration::new

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1816,7 +1816,7 @@ impl Connection {
     /// Probe Timeout
     fn pto(&self, space: SpaceId) -> Duration {
         let max_ack_delay = match space {
-            SpaceId::Initial | SpaceId::Handshake => Duration::new(0, 0),
+            SpaceId::Initial | SpaceId::Handshake => Duration::ZERO,
             SpaceId::Data => self.ack_frequency.max_ack_delay_for_pto(),
         };
         self.path.rtt.pto_base() + max_ack_delay
@@ -3844,7 +3844,7 @@ fn instant_saturating_sub(x: Instant, y: Instant) -> Duration {
     if x > y {
         x - y
     } else {
-        Duration::new(0, 0)
+        Duration::ZERO
     }
 }
 

--- a/quinn-proto/src/connection/pacing.rs
+++ b/quinn-proto/src/connection/pacing.rs
@@ -104,7 +104,7 @@ impl Pacer {
 
         let unscaled_delay = smoothed_rtt
             .checked_mul((bytes_to_send.max(self.capacity) - self.tokens) as _)
-            .unwrap_or_else(|| Duration::new(u64::MAX, 999_999_999))
+            .unwrap_or(Duration::MAX)
             / window;
 
         // divisions come before multiplications to prevent overflow

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -81,7 +81,7 @@ impl Pair {
             epoch: now,
             time: now,
             mtu: DEFAULT_MTU,
-            latency: Duration::new(0, 0),
+            latency: Duration::ZERO,
             spins: 0,
             last_spin: false,
             congestion_experienced: false,
@@ -315,7 +315,7 @@ impl TestEndpoint {
         let socket = if env::var_os("SSLKEYLOGFILE").is_some() {
             let socket = UdpSocket::bind(addr).expect("failed to bind UDP socket");
             socket
-                .set_read_timeout(Some(Duration::new(0, 10_000_000)))
+                .set_read_timeout(Some(Duration::from_millis(10)))
                 .unwrap();
             Some(socket)
         } else {

--- a/quinn-proto/src/token.rs
+++ b/quinn-proto/src/token.rs
@@ -173,7 +173,7 @@ fn encode_unix_secs(buf: &mut Vec<u8>, time: SystemTime) {
 }
 
 fn decode_unix_secs<B: Buf>(buf: &mut B) -> Option<SystemTime> {
-    Some(UNIX_EPOCH + Duration::new(buf.get::<u64>().ok()?, 0))
+    Some(UNIX_EPOCH + Duration::from_secs(buf.get::<u64>().ok()?))
 }
 
 /// Stateless reset token
@@ -253,7 +253,7 @@ mod test {
         let token = RetryToken {
             address,
             orig_dst_cid: RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid(),
-            issued: UNIX_EPOCH + Duration::new(42, 0), // Fractional seconds would be lost
+            issued: UNIX_EPOCH + Duration::from_secs(42), // Fractional seconds would be lost
         };
         let encoded = token.encode(&prk, retry_src_cid);
 


### PR DESCRIPTION
Replaces them with more modern and appropriate constructors or constants.