### PR TITLE
fix(udp/windows): set socket option IPV6_RECVECN

### DIFF
--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -102,7 +102,7 @@ impl UdpSocketState {
             set_socket_option(
                 &*socket.0,
                 WinSock::IPPROTO_IPV6,
-                WinSock::IPV6_ECN,
+                WinSock::IPV6_RECVECN,
                 OPTION_ON,
             )?;
         }


### PR DESCRIPTION
On Windows, to enable ECN reporting, one sets the `IPV6_RECVECN` socket option. The Windows IP stack will then report ECN markings via the `IPV6_ECN` message type.

Previously `quinn-udp` would use `IPV6_ECN` for both. With this commit `IPV6_RECVECN` is used to set the socket option and `IPV6_ECN` is used to read the option.

Given that both constants evaluate to the same value (i.e. `50`) the previous behavior does not result in an actual bug.

See also:

- https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
- https://www.ietf.org/archive/id/draft-duke-tsvwg-udp-ecn-01.html
- https://docs.rs/windows-sys/latest/windows_sys/Win32/Networking/WinSock/constant.IPV6_RECVECN.html
- https://docs.rs/windows-sys/latest/windows_sys/Win32/Networking/WinSock/constant.IPV6_ECN.html