### PR TITLE
fix(udp/windows): set socket option IP_RECVECN

### DIFF
--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -81,7 +81,12 @@ impl UdpSocketState {
                 WinSock::IP_PKTINFO,
                 OPTION_ON,
             )?;
-            set_socket_option(&*socket.0, WinSock::IPPROTO_IP, WinSock::IP_ECN, OPTION_ON)?;
+            set_socket_option(
+                &*socket.0,
+                WinSock::IPPROTO_IP,
+                WinSock::IP_RECVECN,
+                OPTION_ON,
+            )?;
         }
 
         if is_ipv6 {


### PR DESCRIPTION
Equivalent to https://github.com/quinn-rs/quinn/pull/2125 for IPv4.

On Windows, to enable ECN reporting on IPv4, one sets the `IP_RECVECN` socket option. The Windows IP stack will then report ECN markings via the `IP_ECN` message type.

Previously `quinn-udp` would use `IP_ECN` for both. With this commit `IP_RECVECN` is used to set the socket option and `IP_ECN` is used to read the option.

Given that both constants evaluate to the same value (i.e. `50`) the previous behavior does not result in an actual bug.

See also:

- https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
- https://www.ietf.org/archive/id/draft-duke-tsvwg-udp-ecn-01.html
- https://docs.rs/windows-sys/latest/windows_sys/Win32/Networking/WinSock/constant.IP_RECVECN.html
- https://docs.rs/windows-sys/latest/windows_sys/Win32/Networking/WinSock/constant.IP_ECN.html