### PR TITLE
Expose stream write limit

### DIFF
--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -233,6 +233,11 @@ impl<'a> SendStream<'a> {
         self.write_source(&mut BytesArray::from_chunks(data))
     }
 
+    /// Returns the maximum amount of data this is allowed to be written on the connection.
+    pub fn write_limit(&self) -> u64 {
+        self.state.write_limit()
+    }
+
     fn write_source<B: BytesSource>(&mut self, source: &mut B) -> Result<Written, WriteError> {
         if self.conn_state.is_closed() {
             trace!(%self.id, "write blocked; connection draining");

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -243,6 +243,12 @@ impl SendStream {
     ) -> Poll<Result<usize, WriteError>> {
         self.get_mut().execute_poll(cx, |stream| stream.write(buf))
     }
+
+    /// Returns the maximum amount of data this is allowed to be written on the connection.
+    pub fn write_limit(&self) -> u64 {
+        let mut conn = self.conn.state.lock("SendStream::write_limit");
+        conn.inner.send_stream(self.stream).write_limit()
+    }
 }
 
 #[cfg(feature = "futures-io")]


### PR DESCRIPTION
Seems like it could be useful for applications to know. My use case in particular is implementing https://w3c.github.io/webtransport/#dom-webtransportwriter-atomicwrite