### PR TITLE
ci: run quinn-udp tests with fast-apple-datapath

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,6 +126,8 @@ jobs:
       - run: cargo test --manifest-path fuzz/Cargo.toml
         if: ${{ matrix.rust }} == "stable"
       - run: cargo test -p quinn-udp --benches
+      - run: cargo test -p quinn-udp --benches --features fast-apple-datapath
+        if: ${{ matrix.os }} == "macos-latest"
 
   test-aws-lc-rs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I suggest we test the feature introduced in https://github.com/quinn-rs/quinn/pull/1993 on CI.

---

Related, we are currently integrating it into Neqo (https://github.com/mozilla/neqo/pull/2302). On our localhost Download benchmark it shows ~10% throughput improvement.