### PR TITLE
Simplify weirdly broken test code

### DIFF
--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1636,13 +1636,10 @@ fn cid_retirement() {
     assert!(!pair.client_conn_mut(client_ch).is_closed());
     assert!(!pair.server_conn_mut(server_ch).is_closed());
 
-    #[allow(unreachable_patterns)] // https://github.com/rust-lang/rust/issues/135289
-    {
-        assert_matches!(
-            pair.client_conn_mut(client_ch).active_rem_cid_seq(),
-            _next_retire_prior_to
-        );
-    }
+    assert_eq!(
+        pair.client_conn_mut(client_ch).active_rem_cid_seq(),
+        next_retire_prior_to,
+    );
 }
 
 #[test]


### PR DESCRIPTION
#871 seems to have added a test with this code:

```rust
    let next_retire_prior_to = active_cid_num + 1;
    pair.client_conn_mut(client_ch).ping();
    // Server retires all valid remote CIDs
    pair.server_conn_mut(server_ch)
        .rotate_local_cid(next_retire_prior_to);
    pair.drive();
    assert!(!pair.client_conn_mut(client_ch).is_closed());
    assert!(!pair.server_conn_mut(server_ch).is_closed());
    assert_matches!(
        pair.client_conn_mut(client_ch).active_rem_cid_seq(),
        _next_retire_prior_to
    );
```

Note on the last line that `_next_retire_prior_to` is a new identifier, which does not actually reference the earlier binding `next_retire_prior_to`. Because this is is `assert_matches!()`, I think the intended semantics here are a little unclear, and this was probably be intended as `assert_eq!(.., next_retire_prior_to)`.