### PR TITLE
Add `BloomTokenLog`

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -27,7 +27,7 @@ jobs:
         #       | paste -sd ',' -
         run: |
           cargo llvm-cov \
-            --features="arbitrary,async-io,async-std,aws-lc-rs,direct-log,fast-apple-datapath,futures-io,json-output,lock_tracking,log,platform-verifier,ring,runtime-async-std,runtime-smol,runtime-tokio,rustls,rustls-aws-lc-rs,rustls-log,rustls-ring,serde,serde_json,smol,tracing" \
+            --features="arbitrary,async-io,async-std,aws-lc-rs,bloom,direct-log,fast-apple-datapath,futures-io,json-output,lock_tracking,log,platform-verifier,ring,runtime-async-std,runtime-smol,runtime-tokio,rustls,rustls-aws-lc-rs,rustls-log,rustls-ring,serde,serde_json,smol,tracing" \
             --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "bytemuck"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +779,18 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.0",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27cea6e7f512d43b098939ff4d5a5d6fe3db07971e1d05176fe26c642d33f5b8"
+dependencies = [
+ "getrandom 0.3.2",
+ "rand",
+ "siphasher",
+ "wide",
 ]
 
 [[package]]
@@ -1593,6 +1611,7 @@ dependencies = [
  "assert_matches",
  "aws-lc-rs",
  "bytes",
+ "fastbloom",
  "getrandom 0.3.2",
  "hex-literal",
  "lazy_static",
@@ -1893,6 +1912,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2016,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -2469,6 +2503,16 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bytes = "1"
 clap = { version = "4", features = ["derive"] }
 crc = "3"
 directories-next = "2"
+fastbloom = "0.9"
 futures-io = "0.3.19"
 getrandom = { version = "0.3", default-features = false }
 hdrhistogram = { version = "7.2", default-features = false }

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -13,9 +13,11 @@ workspace = ".."
 [features]
 # NOTE: Please keep this in sync with the feature list in `.github/workflows/codecov.yml`, see
 # comment in that file for more information.
-default = ["rustls-ring", "log"]
+default = ["rustls-ring", "log", "bloom"]
 aws-lc-rs = ["dep:aws-lc-rs", "aws-lc-rs?/aws-lc-sys", "aws-lc-rs?/prebuilt-nasm"]
 aws-lc-rs-fips = ["aws-lc-rs", "aws-lc-rs?/fips"]
+# Enables BloomTokenLog, and uses it by default
+bloom = ["dep:fastbloom"]
 # For backwards compatibility, `rustls` forwards to `rustls-ring`
 rustls = ["rustls-ring"]
 # Enable rustls with the `aws-lc-rs` crypto provider
@@ -36,6 +38,7 @@ rustls-log = ["rustls?/logging"]
 arbitrary = { workspace = true, optional = true }
 aws-lc-rs = { workspace = true, optional = true }
 bytes = { workspace = true }
+fastbloom = { workspace = true, optional = true }
 lru-slab = { workspace = true }
 rustc-hash = { workspace = true }
 rand = { workspace = true }
@@ -57,8 +60,8 @@ web-time = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-rand_pcg = "0.9"
 hex-literal = { workspace = true  }
+rand_pcg = "0.9"
 rcgen = { workspace = true }
 tracing-subscriber = { workspace = true }
 lazy_static = "1"

--- a/quinn-proto/src/bloom_token_log.rs
+++ b/quinn-proto/src/bloom_token_log.rs
@@ -1,0 +1,368 @@
+use std::{
+    collections::HashSet,
+    f64::consts::LN_2,
+    hash::{BuildHasher, Hasher},
+    mem::{size_of, take},
+    sync::Mutex,
+};
+
+use fastbloom::BloomFilter;
+use rustc_hash::FxBuildHasher;
+use tracing::{trace, warn};
+
+use crate::{Duration, SystemTime, TokenLog, TokenReuseError, UNIX_EPOCH};
+
+/// Bloom filter-based [`TokenLog`]
+///
+/// Parameterizable over an approximate maximum number of bytes to allocate. Starts out by storing
+/// used tokens in a hash set. Once the hash set becomes too large, converts it to a bloom filter.
+/// This achieves a memory profile of linear growth with an upper bound.
+///
+/// Divides time into periods based on `lifetime` and stores two filters at any given moment, for
+/// each of the two periods currently non-expired tokens could expire in. As such, turns over
+/// filters as time goes on to avoid bloom filter false positive rate increasing infinitely over
+/// time.
+pub struct BloomTokenLog(Mutex<State>);
+
+impl BloomTokenLog {
+    /// Construct with an approximate maximum memory usage and expected number of validation token
+    /// usages per expiration period
+    ///
+    /// Calculates the optimal bloom filter k number automatically.
+    pub fn new_expected_items(max_bytes: usize, expected_hits: u64) -> Self {
+        Self::new(max_bytes, optimal_k_num(max_bytes, expected_hits))
+    }
+
+    /// Construct with an approximate maximum memory usage and a [bloom filter k number][bloom]
+    ///
+    /// [bloom]: https://en.wikipedia.org/wiki/Bloom_filter
+    ///
+    /// If choosing a custom k number, note that `BloomTokenLog` always maintains two filters
+    /// between them and divides the allocation budget of `max_bytes` evenly between them. As such,
+    /// each bloom filter will contain `max_bytes * 4` bits.
+    pub fn new(max_bytes: usize, k_num: u32) -> Self {
+        Self(Mutex::new(State {
+            config: FilterConfig {
+                filter_max_bytes: max_bytes / 2,
+                k_num,
+            },
+            period_1_start: UNIX_EPOCH,
+            filter_1: Filter::default(),
+            filter_2: Filter::default(),
+        }))
+    }
+}
+
+impl TokenLog for BloomTokenLog {
+    fn check_and_insert(
+        &self,
+        nonce: u128,
+        issued: SystemTime,
+        lifetime: Duration,
+    ) -> Result<(), TokenReuseError> {
+        trace!(%nonce, "check_and_insert");
+
+        if lifetime.is_zero() {
+            // avoid divide-by-zero if lifetime is zero
+            return Err(TokenReuseError);
+        }
+
+        let mut guard = self.0.lock().unwrap();
+        let state = &mut *guard;
+
+        // calculate how many periods past period 1 the token expires
+        let expires_at = issued + lifetime;
+        let Ok(periods_forward) = expires_at
+            .duration_since(state.period_1_start)
+            .map(|duration| duration.as_nanos() / lifetime.as_nanos())
+        else {
+            // shouldn't happen unless time travels backwards or lifetime changes or the current
+            // system time is before the Unix epoch
+            warn!("BloomTokenLog presented with token too far in past");
+            return Err(TokenReuseError);
+        };
+
+        // get relevant filter
+        let filter = match periods_forward {
+            0 => &mut state.filter_1,
+            1 => &mut state.filter_2,
+            2 => {
+                // turn over filter 1
+                state.filter_1 = take(&mut state.filter_2);
+                state.period_1_start += lifetime;
+                &mut state.filter_2
+            }
+            _ => {
+                // turn over both filters
+                state.filter_1 = Filter::default();
+                state.filter_2 = Filter::default();
+                state.period_1_start = expires_at;
+                &mut state.filter_1
+            }
+        };
+
+        // insert into the filter
+        //
+        // the token's nonce needs to guarantee uniqueness because of the role it plays in the
+        // encryption of the tokens, so it is 128 bits. but since the token log can tolerate false
+        // positives, we trim it down to 64 bits, which would still only have a small collision
+        // rate even at significant amounts of usage, while allowing us to store twice as many in
+        // the hash set variant.
+        //
+        // token nonce values are uniformly randomly generated server-side and cryptographically
+        // integrity-checked, so we don't need to employ secure hashing to trim it down to 64 bits,
+        // we can simply truncate.
+        //
+        // per the Rust reference, we can truncate by simply casting:
+        // https://doc.rust-lang.org/stable/reference/expressions/operator-expr.html#numeric-cast
+        filter.check_and_insert(nonce as u64, &state.config)
+    }
+}
+
+/// Default to 20 MiB max memory consumption and expected one million hits
+///
+/// With the default validation token lifetime of 2 weeks, this corresponds to one token usage per
+/// 1.21 seconds.
+impl Default for BloomTokenLog {
+    fn default() -> Self {
+        Self::new_expected_items(DEFAULT_MAX_BYTES, DEFAULT_EXPECTED_HITS)
+    }
+}
+
+/// Lockable state of [`BloomTokenLog`]
+struct State {
+    config: FilterConfig,
+    // filter_1 covers tokens that expire in the period starting at period_1_start and extending
+    // lifetime after. filter_2 covers tokens for the next lifetime after that.
+    period_1_start: SystemTime,
+    filter_1: Filter,
+    filter_2: Filter,
+}
+
+/// Unchanging parameters governing [`Filter`] behavior
+struct FilterConfig {
+    filter_max_bytes: usize,
+    k_num: u32,
+}
+
+/// Period filter within [`State`]
+enum Filter {
+    Set(HashSet<u64, IdentityBuildHasher>),
+    Bloom(BloomFilter<512, FxBuildHasher>),
+}
+
+impl Filter {
+    fn check_and_insert(
+        &mut self,
+        fingerprint: u64,
+        config: &FilterConfig,
+    ) -> Result<(), TokenReuseError> {
+        match self {
+            Self::Set(hset) => {
+                if !hset.insert(fingerprint) {
+                    return Err(TokenReuseError);
+                }
+
+                if hset.capacity() * size_of::<u64>() <= config.filter_max_bytes {
+                    return Ok(());
+                }
+
+                // convert to bloom
+                // avoid panicking if user passed in filter_max_bytes of 0. we document that this
+                // limit is approximate, so just fudge it up to 1.
+                let mut bloom = BloomFilter::with_num_bits((config.filter_max_bytes * 8).max(1))
+                    .hasher(FxBuildHasher)
+                    .hashes(config.k_num);
+                for item in &*hset {
+                    bloom.insert(item);
+                }
+                *self = Self::Bloom(bloom);
+            }
+            Self::Bloom(bloom) => {
+                if bloom.insert(&fingerprint) {
+                    return Err(TokenReuseError);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Default for Filter {
+    fn default() -> Self {
+        Self::Set(HashSet::default())
+    }
+}
+
+/// `BuildHasher` of `IdentityHasher`
+#[derive(Default)]
+struct IdentityBuildHasher;
+
+impl BuildHasher for IdentityBuildHasher {
+    type Hasher = IdentityHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        IdentityHasher::default()
+    }
+}
+
+/// Hasher that is the identity operation--it assumes that exactly 8 bytes will be hashed, and the
+/// resultant hash is those bytes as a `u64`
+#[derive(Default)]
+struct IdentityHasher {
+    data: [u8; 8],
+    #[cfg(debug_assertions)]
+    wrote_8_byte_slice: bool,
+}
+
+impl Hasher for IdentityHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        #[cfg(debug_assertions)]
+        {
+            assert!(!self.wrote_8_byte_slice);
+            assert_eq!(bytes.len(), 8);
+            self.wrote_8_byte_slice = true;
+        }
+        self.data.copy_from_slice(bytes);
+    }
+
+    fn finish(&self) -> u64 {
+        #[cfg(debug_assertions)]
+        assert!(self.wrote_8_byte_slice);
+        u64::from_ne_bytes(self.data)
+    }
+}
+
+fn optimal_k_num(num_bytes: usize, expected_hits: u64) -> u32 {
+    // be more forgiving rather than panickey here. excessively high num_bits may occur if the user
+    // wishes it to be unbounded, so just saturate. expected_hits of 0 would cause divide-by-zero,
+    // so just fudge it up to 1 in that case.
+    let num_bits = (num_bytes as u64).saturating_mul(8);
+    let expected_hits = expected_hits.max(1);
+    // reference for this formula: https://programming.guide/bloom-filter-calculator.html
+    // optimal k = (m ln 2) / n
+    // wherein m is the number of bits, and n is the number of elements in the set.
+    //
+    // we also impose a minimum return value of 1, to avoid making the bloom filter entirely
+    // useless in the case that the user provided an absurdly high ratio of hits / bytes.
+    (((num_bits as f64 / expected_hits as f64) * LN_2).round() as u32).max(1)
+}
+
+// remember to change the doc comment for `impl Default for BloomTokenLog` if these ever change
+const DEFAULT_MAX_BYTES: usize = 10 << 20;
+const DEFAULT_EXPECTED_HITS: u64 = 1_000_000;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rand::prelude::*;
+    use rand_pcg::Pcg32;
+
+    fn new_rng() -> impl Rng {
+        Pcg32::from_seed(0xdeadbeefdeadbeefdeadbeefdeadbeef_u128.to_le_bytes())
+    }
+
+    #[test]
+    fn identity_hash_test() {
+        let mut rng = new_rng();
+        let builder = IdentityBuildHasher;
+        for _ in 0..100 {
+            let n = rng.random::<u64>();
+            let hash = builder.hash_one(n);
+            assert_eq!(hash, n);
+        }
+    }
+
+    #[test]
+    fn optimal_k_num_test() {
+        assert_eq!(optimal_k_num(10 << 20, 1_000_000), 58);
+        assert_eq!(optimal_k_num(10 << 20, 1_000_000_000_000_000), 1);
+        // assert that these don't panic:
+        optimal_k_num(10 << 20, 0);
+        optimal_k_num(usize::MAX, 1_000_000);
+    }
+
+    #[test]
+    fn bloom_token_log_conversion() {
+        let mut rng = new_rng();
+        let mut log = BloomTokenLog::new_expected_items(800, 200);
+
+        let issued = SystemTime::now();
+        let lifetime = Duration::from_secs(1_000_000);
+
+        for i in 0..200 {
+            let token = rng.random::<u128>();
+            let result = log.check_and_insert(token, issued, lifetime);
+            {
+                let filter = &log.0.lock().unwrap().filter_1;
+                if let Filter::Set(ref hset) = *filter {
+                    assert!(hset.capacity() * size_of::<u64>() <= 800);
+                    assert_eq!(hset.len(), i + 1);
+                    assert!(result.is_ok());
+                } else {
+                    assert!(i > 10, "definitely bloomed too early");
+                }
+            }
+            assert!(log.check_and_insert(token, issued, lifetime).is_err());
+        }
+
+        assert!(
+            matches!(log.0.get_mut().unwrap().filter_1, Filter::Bloom { .. }),
+            "didn't bloom"
+        );
+    }
+
+    #[test]
+    fn turn_over() {
+        let mut rng = new_rng();
+        let log = BloomTokenLog::new_expected_items(800, 200);
+        let lifetime = Duration::from_secs(1_000);
+        let mut old = Vec::default();
+        let mut accepted = 0;
+
+        for i in 0..200 {
+            let token = rng.random::<u128>();
+            let now = UNIX_EPOCH + lifetime * 10 + lifetime * i / 10;
+            let issued = now - lifetime.mul_f32(rng.random_range(0.0..3.0));
+            let result = log.check_and_insert(token, issued, lifetime);
+            if result.is_ok() {
+                accepted += 1;
+            }
+            old.push((token, issued));
+            let old_idx = rng.random_range(0..old.len());
+            let (old_token, old_issued) = old[old_idx];
+            assert!(
+                log.check_and_insert(old_token, old_issued, lifetime)
+                    .is_err()
+            );
+        }
+        assert!(accepted > 0);
+    }
+
+    fn test_doesnt_panic(log: BloomTokenLog) {
+        let mut rng = new_rng();
+
+        let issued = SystemTime::now();
+        let lifetime = Duration::from_secs(1_000_000);
+
+        for _ in 0..200 {
+            let _ = log.check_and_insert(rng.random::<u128>(), issued, lifetime);
+        }
+    }
+
+    #[test]
+    fn max_bytes_zero() {
+        // "max bytes" is documented to be approximate. but make sure it doesn't panic.
+        test_doesnt_panic(BloomTokenLog::new_expected_items(0, 200));
+    }
+
+    #[test]
+    fn expected_hits_zero() {
+        test_doesnt_panic(BloomTokenLog::new_expected_items(100, 0));
+    }
+
+    #[test]
+    fn k_num_zero() {
+        test_doesnt_panic(BloomTokenLog::new(100, 0));
+    }
+}

--- a/quinn-proto/src/config/mod.rs
+++ b/quinn-proto/src/config/mod.rs
@@ -11,11 +11,15 @@ use rustls::client::WebPkiServerVerifier;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use thiserror::Error;
 
+#[cfg(feature = "bloom")]
+use crate::BloomTokenLog;
+#[cfg(not(feature = "bloom"))]
+use crate::NoneTokenLog;
 #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
 use crate::crypto::rustls::{QuicServerConfig, configured_provider};
 use crate::{
-    DEFAULT_SUPPORTED_VERSIONS, Duration, MAX_CID_SIZE, NoneTokenLog, RandomConnectionIdGenerator,
-    SystemTime, TokenLog, TokenMemoryCache, TokenStore, VarInt, VarIntBoundsExceeded,
+    DEFAULT_SUPPORTED_VERSIONS, Duration, MAX_CID_SIZE, RandomConnectionIdGenerator, SystemTime,
+    TokenLog, TokenMemoryCache, TokenStore, VarInt, VarIntBoundsExceeded,
     cid_generator::{ConnectionIdGenerator, HashedConnectionIdGenerator},
     crypto::{self, HandshakeTokenKey, HmacKey},
     shared::ConnectionId,
@@ -485,10 +489,15 @@ impl ValidationTokenConfig {
         self
     }
 
+    #[allow(rustdoc::redundant_explicit_links)] // which links are redundant depends on features
     /// Set a custom [`TokenLog`]
     ///
-    /// Defaults to [`NoneTokenLog`], which makes the server ignore all address validation tokens
-    /// (that is, tokens originating from NEW_TOKEN frames--retry tokens are not affected).
+    /// If the `bloom` feature is enabled (which it is by default), defaults to a default
+    /// [`BloomTokenLog`][crate::BloomTokenLog], which is suitable for most internet applications.
+    ///
+    /// If the `bloom` feature is disabled, defaults to [`NoneTokenLog`][crate::NoneTokenLog],
+    /// which makes the server ignore all address validation tokens (that is, tokens originating
+    /// from NEW_TOKEN frames--retry tokens are not affected).
     pub fn log(&mut self, log: Arc<dyn TokenLog>) -> &mut Self {
         self.log = log;
         self
@@ -507,9 +516,13 @@ impl ValidationTokenConfig {
 
 impl Default for ValidationTokenConfig {
     fn default() -> Self {
+        #[cfg(feature = "bloom")]
+        let log = Arc::new(BloomTokenLog::default());
+        #[cfg(not(feature = "bloom"))]
+        let log = Arc::new(NoneTokenLog);
         Self {
             lifetime: Duration::from_secs(2 * 7 * 24 * 60 * 60),
-            log: Arc::new(NoneTokenLog),
+            log,
             sent: 0,
         }
     }

--- a/quinn-proto/src/config/mod.rs
+++ b/quinn-proto/src/config/mod.rs
@@ -507,7 +507,8 @@ impl ValidationTokenConfig {
     ///
     /// This refers only to tokens sent in NEW_TOKEN frames, in contrast to retry tokens.
     ///
-    /// Defaults to 0.
+    /// If the `bloom` feature is enabled (which it is by default), defaults to 2. Otherwise,
+    /// defaults to 0.
     pub fn sent(&mut self, value: u32) -> &mut Self {
         self.sent = value;
         self
@@ -523,7 +524,7 @@ impl Default for ValidationTokenConfig {
         Self {
             lifetime: Duration::from_secs(2 * 7 * 24 * 60 * 60),
             log,
-            sent: 0,
+            sent: if cfg!(feature = "bloom") { 2 } else { 0 },
         }
     }
 }

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -37,6 +37,11 @@ mod varint;
 
 pub use varint::{VarInt, VarIntBoundsExceeded};
 
+#[cfg(feature = "bloom")]
+mod bloom_token_log;
+#[cfg(feature = "bloom")]
+pub use bloom_token_log::BloomTokenLog;
+
 mod connection;
 pub use crate::connection::{
     BytesSource, Chunk, Chunks, ClosedStream, Connection, ConnectionError, ConnectionStats,

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -561,10 +561,12 @@ impl Write for TestWriter {
 
 pub(super) fn server_config() -> ServerConfig {
     let mut config = ServerConfig::with_crypto(Arc::new(server_crypto()));
-    config
-        .validation_token
-        .sent(2)
-        .log(Arc::new(SimpleTokenLog::default()));
+    if !cfg!(feature = "bloom") {
+        config
+            .validation_token
+            .sent(2)
+            .log(Arc::new(SimpleTokenLog::default()));
+    }
     config
 }
 

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -15,10 +15,12 @@ rust-version.workspace = true
 [features]
 # NOTE: Please keep this in sync with the feature list in `.github/workflows/codecov.yml`, see
 # comment in that file for more information.
-default = ["log", "platform-verifier", "runtime-tokio", "rustls-ring"]
+default = ["log", "platform-verifier", "runtime-tokio", "rustls-ring", "bloom"]
 # Enables `Endpoint::client` and `Endpoint::server` conveniences
 aws-lc-rs = ["proto/aws-lc-rs"]
 aws-lc-rs-fips = ["proto/aws-lc-rs-fips"]
+# Enables BloomTokenLog, and uses it by default
+bloom = ["proto/bloom"]
 # Records how long locks are held, and warns if they are held >= 1ms
 lock_tracking = []
 # Provides `ClientConfig::with_platform_verifier()` convenience method

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -57,6 +57,8 @@ pub(crate) use std::time::{Duration, Instant};
 #[cfg(wasm_browser)]
 pub(crate) use web_time::{Duration, Instant};
 
+#[cfg(feature = "bloom")]
+pub use proto::BloomTokenLog;
 pub use proto::{
     AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ClosedStream, ConfigError,
     ConnectError, ConnectionClose, ConnectionError, ConnectionId, ConnectionIdGenerator,


### PR DESCRIPTION
- Adds default optional dependency on [`fastbloom`](https://lib.rs/crates/fastbloom)
- Adds `BloomTokenLog`, a new `TokenLog` implementation:
  - At first, it just stores elements in a hash set. In this phase, it experiences linear memory growth and neither false positives nor false negatives.
  - When the hash set would consume more memory than a configurable limit, it converts it to a bloom filter. This essentially makes it so that, rather than more elements causing it to consume more memory, more elements cause its false positive rate to keep going up. This way, its memory usage stays constant, and it treats old and newly added elements "fairly" rather than say, discarded new elements or something more questionable.
    - The `fastbloom` crate is a popular bloom filter implementation with SIMD acceleration.
  - The reason why it doesn't just use a bloom filter from the beginning is because then it would consume its maximum memory usage from the time it's first initialized. Overall, this two-phase mechanism means that its memory profile its linear with a ceiling, which avoids making the user pay for what they're not using, and has a false negative rate of zero in both phases, which is perhaps a safer default for users than one that doesn't.
  - The overall token log actually maintains two filters at any given point in time, each of which can independently contain elements as described above. It divides time into periods equal to the token lifetime, and stores a filter for each of the two phases in which currently non-expired tokens could expire in. This means the filters get reset over time, which prevents the hash set from consuming memory forever / the bloom filter from getting infinitely saturating and its false positive rate rising to 100%.
  - Note on false negatives: Although the bloom token log _itself_ doesn't experience false negatives, a server operationalizing it could experience false negatives if it is using the same token keys across multiple token log instances. This could occur over time (token keys persisted, but token log not persisted, and server restarts) and/or over space (multiple servers behind a load balancer sharing the same token key but each with their own token log). These cases probably wouldn't be security vulnerabilities--RFC 9000 does permit false negatives to occur so long as it's mitigated in some sense, and an attacker which gets to use the servers for amplification attacks only to the extent that there are multiple load-balanced servers / it can get the servers to reboot is probably still acceptably mitigated. But due to this complication I avoid mentioning the lack of false negatives in the documentation to avoid giving the user's a misleading impression.
- BloomTokenLog is made the default token log. Also, the default tokens sent is raised from 0 to 2.