### PR TITLE
Allow the NCSA license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,7 @@ allow = [
     "ISC",
     "MIT",
     "MPL-2.0",
+    "NCSA",
     "OpenSSL",
     "Unicode-3.0",
 ]


### PR DESCRIPTION
This is newly required for libfuzzer-sys 0.4.9. It is a permissive license similar to the MIT or 3-claused BSD licenses.