### PR TITLE
fix(udp/fast-apple): ignore empty cmsghdr

### DIFF
--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.5.9"
+version = "0.5.10"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
On MacOS < 14, with `fast-apple-datapath` feature, calls to `libc::CMSG_NXTHDR` might continuously return empty (i.e. all zero) `libc::cmsghdr` instead of a null pointer. This results in a busy loop in `decode_recv`:

``` rust
let cmsg_iter = unsafe { cmsg::Iter::new(hdr) };
for cmsg in cmsg_iter {
	match (cmsg.cmsg_level, cmsg.cmsg_type) {
```
https://github.com/quinn-rs/quinn/blob/b4378bb39dab4b58a1e6a3fea4fff9f87033dab6/quinn-udp/src/unix.rs#L685C1-L687C50

This commit fixes the above, returning a `null_mut()` pointer on an empty `libc::cmsgdhr`, thus terminating the `cmsg_iter`.

See also https://github.com/mozilla/neqo/pull/2427 for details.