### PR TITLE
fix: Do not produce tail-loss probes larger than segment size

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -699,7 +699,7 @@ impl Connection {
                         // Clamp the datagram to at most the minimum MTU to ensure that loss probes
                         // can get through and enable recovery even if the path MTU has shrank
                         // unexpectedly.
-                        usize::from(INITIAL_MTU)
+                        std::cmp::min(segment_size, usize::from(INITIAL_MTU))
                     }
                 };
                 buf_capacity += next_datagram_size_limit;


### PR DESCRIPTION
When needing to send tail-loss probes and building a GSO batch the tail-loss probe should not exceed the GSO segment size.  At the same time a GSO batch needs to be broken when the segment size exceeds the maximum size for a tail-loss probe.

Somehow we have a reliable reproducer of this in https://github.com/n0-computer/callme/tree/no-graceful-close, but that is quite a bit away from Quinn main.  Applying this fix solves it, but I am not really sure how to test this in the test suite.  There isn't any example in the file of tests constructing their state to test particular poll_transmit behaviours.  Any hints on how I might be able to add tests to this?