### PR TITLE
refactor: Introduce a TransmitBuf for poll_transmit

### DIFF
--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -4,7 +4,7 @@ use bytes::{BufMut, Bytes};
 use thiserror::Error;
 use tracing::{debug, trace};
 
-use super::{BufLen, Connection};
+use super::Connection;
 use crate::{
     TransportError,
     frame::{Datagram, FrameStruct},
@@ -163,13 +163,13 @@ impl DatagramState {
     ///
     /// Returns whether a frame was written. At most `max_size` bytes will be written, including
     /// framing.
-    pub(super) fn write(&mut self, buf: &mut (impl BufMut + BufLen), max_size: usize) -> bool {
+    pub(super) fn write(&mut self, buf: &mut impl BufMut) -> bool {
         let datagram = match self.outgoing.pop_front() {
             Some(x) => x,
             None => return false,
         };
 
-        if buf.len() + datagram.size(true) > max_size {
+        if datagram.size(true) > buf.remaining_mut() {
             // Future work: we could be more clever about cramming small datagrams into
             // mostly-full packets when a larger one is queued first
             self.outgoing.push_front(datagram);

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -1,10 +1,10 @@
 use std::collections::VecDeque;
 
-use bytes::Bytes;
+use bytes::{BufMut, Bytes};
 use thiserror::Error;
 use tracing::{debug, trace};
 
-use super::Connection;
+use super::{BufLen, Connection};
 use crate::{
     TransportError,
     frame::{Datagram, FrameStruct},
@@ -163,7 +163,7 @@ impl DatagramState {
     ///
     /// Returns whether a frame was written. At most `max_size` bytes will be written, including
     /// framing.
-    pub(super) fn write(&mut self, buf: &mut Vec<u8>, max_size: usize) -> bool {
+    pub(super) fn write(&mut self, buf: &mut (impl BufMut + BufLen), max_size: usize) -> bool {
         let datagram = match self.outgoing.pop_front() {
             Some(x) => x,
             None => return false,

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -647,8 +647,7 @@ impl Connection {
                                 - builder.partial_encode.start
                                 + builder.tag_len;
                         if packet_len_unpadded + MAX_PADDING < transmit.segment_size()
-                            || transmit.datagram_start_offset() + transmit.segment_size()
-                                > transmit.datagram_max_offset()
+                            || transmit.datagram_mut().capacity() < transmit.segment_size()
                         {
                             trace!(
                                 "GSO truncated by demand for {} padding bytes or loss probe",
@@ -712,7 +711,7 @@ impl Connection {
                 }
             }
 
-            debug_assert!(transmit.datagram_max_offset() - transmit.len() >= MIN_PACKET_SPACE);
+            debug_assert!(transmit.datagram_mut().remaining_mut() >= MIN_PACKET_SPACE);
 
             //
             // From here on, we've determined that a packet will definitely be sent.
@@ -867,8 +866,7 @@ impl Connection {
                 !(sent.is_ack_only(&self.streams)
                     && !can_send.acks
                     && can_send.other
-                    && (transmit.datagram_max_offset() - builder.datagram_start)
-                        == self.path.current_mtu() as usize
+                    && transmit.datagram_mut().capacity() == self.path.current_mtu() as usize
                     && self.datagrams.outgoing.is_empty()),
                 "SendableFrames was {can_send:?}, but only ACKs have been written"
             );
@@ -911,7 +909,7 @@ impl Connection {
             debug_assert_eq!(transmit.num_datagrams(), 0);
             transmit.start_new_datagram_with_size(probe_size as usize);
 
-            debug_assert_eq!(transmit.datagram_start_offset(), 0);
+            debug_assert!(transmit.datagram().is_empty());
             let mut builder = PacketBuilder::new(
                 now,
                 space_id,
@@ -1003,7 +1001,7 @@ impl Connection {
         // sent once, immediately after migration, when the CID is known to be valid. Even
         // if a post-migration packet caused the CID to be retired, it's fair to pretend
         // this is sent first.
-        debug_assert_eq!(buf.datagram_start_offset(), 0);
+        debug_assert!(buf.datagram().is_empty());
         let mut builder = PacketBuilder::new(now, SpaceId::Data, *prev_cid, buf, false, self)?;
         trace!("validating previous path with PATH_CHALLENGE {:08x}", token);
         buf.datagram_mut().write(frame::FrameType::PATH_CHALLENGE);

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -89,7 +89,7 @@ mod timer;
 use timer::{Timer, TimerTable};
 
 mod transmit_builder;
-pub(crate) use transmit_builder::BufSlice;
+pub(crate) use transmit_builder::DatagramBuffer;
 use transmit_builder::TransmitBuilder;
 
 /// Protocol state and logic for a single QUIC connection

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -964,20 +964,12 @@ impl Connection {
             .udp_tx
             .on_sent(transmit.num_datagrams() as u64, transmit.len());
 
-        Some(Transmit {
-            destination: self.path.remote,
-            size: transmit.len(),
-            ecn: if self.path.sending_ecn {
-                Some(EcnCodepoint::Ect0)
-            } else {
-                None
-            },
-            segment_size: match transmit.num_datagrams() {
-                1 => None,
-                _ => Some(transmit.segment_size()),
-            },
-            src_ip: self.local_ip,
-        })
+        let ecn = if self.path.sending_ecn {
+            Some(EcnCodepoint::Ect0)
+        } else {
+            None
+        };
+        Some(transmit.build(self.path.remote, ecn, self.local_ip))
     }
 
     /// Send PATH_CHALLENGE for a previous path if necessary

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -629,7 +629,7 @@ impl Connection {
                         builder.pad_to(MIN_INITIAL_SIZE);
                     }
 
-                    if transmit.num_datagrams() > 1 {
+                    if !transmit.is_first_datagram() {
                         // If too many padding bytes would be required to continue the GSO batch
                         // after this packet, end the GSO batch here. Ensures that fixed-size frames
                         // with heterogeneous sizes (e.g. application datagrams) won't inadvertently
@@ -670,7 +670,7 @@ impl Connection {
                         &mut transmit.datagram_mut(),
                     );
 
-                    if transmit.num_datagrams() == 1 {
+                    if transmit.is_first_datagram() {
                         transmit.clip_datagram_size();
                         if space_id == SpaceId::Data {
                             // Now that we know the size of the first datagram, check
@@ -827,7 +827,7 @@ impl Connection {
 
             // Send an off-path PATH_RESPONSE. Prioritized over on-path data to ensure that path
             // validation can occur while the link is saturated.
-            if space_id == SpaceId::Data && transmit.num_datagrams() == 1 {
+            if space_id == SpaceId::Data && transmit.is_first_datagram() {
                 let mut datagram = transmit.datagram_mut();
                 if let Some((token, remote)) = self.path_responses.pop_off_path(self.path.remote) {
                     // `unwrap` guaranteed to succeed because `builder_storage` was populated just

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -659,7 +659,7 @@ impl Connection {
                         builder.pad_to(transmit.segment_size() as u16);
                     }
 
-                    builder.finish_and_track(now, self, sent_frames.take(), transmit.buf);
+                    builder.finish_and_track(now, self, sent_frames.take(), &mut transmit);
 
                     if transmit.num_datagrams() == 1 {
                         transmit.clip_datagram_size();
@@ -704,7 +704,7 @@ impl Connection {
                 // datagram.
                 // Finish current packet without adding extra padding
                 if let Some(builder) = builder_storage.take() {
-                    builder.finish_and_track(now, self, sent_frames.take(), transmit.buf);
+                    builder.finish_and_track(now, self, sent_frames.take(), &mut transmit);
                 }
             }
 
@@ -828,7 +828,7 @@ impl Connection {
                             non_retransmits: true,
                             ..SentFrames::default()
                         }),
-                        transmit.buf,
+                        &mut transmit,
                     );
                     self.stats.udp_tx.on_sent(1, transmit.len());
                     return Some(Transmit {
@@ -884,7 +884,7 @@ impl Connection {
                 builder.pad_to(MIN_INITIAL_SIZE);
             }
             let last_packet_number = builder.exact_number;
-            builder.finish_and_track(now, self, sent_frames, transmit.buf);
+            builder.finish_and_track(now, self, sent_frames, &mut transmit);
             self.path
                 .congestion
                 .on_sent(now, transmit.len() as u64, last_packet_number);
@@ -928,7 +928,7 @@ impl Connection {
                 non_retransmits: true,
                 ..Default::default()
             };
-            builder.finish_and_track(now, self, Some(sent_frames), transmit.buf);
+            builder.finish_and_track(now, self, Some(sent_frames), &mut transmit);
 
             self.stats.path.sent_plpmtud_probes += 1;
 
@@ -1006,7 +1006,7 @@ impl Connection {
         // sending a datagram of this size
         builder.pad_to(MIN_INITIAL_SIZE);
 
-        builder.finish(self, buf.buf);
+        builder.finish(self, buf);
         self.stats.udp_tx.on_sent(1, buf.len());
 
         Some(Transmit {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -661,70 +661,42 @@ impl Connection {
 
                     builder.finish_and_track(now, self, sent_frames.take(), transmit.buf);
 
-                    if transmit.num_datagrams == 1 {
-                        // Set the segment size for this GSO batch to the size of the first UDP
-                        // datagram in the batch. Larger data that cannot be fragmented
-                        // (e.g. application datagrams) will be included in a future batch. When
-                        // sending large enough volumes of data for GSO to be useful, we expect
-                        // packet sizes to usually be consistent, e.g. populated by max-size STREAM
-                        // frames or uniformly sized datagrams.
-                        transmit.segment_size = transmit.len();
-                        // Clip the unused capacity out of the buffer so future packets don't
-                        // overrun
-                        transmit.buf_capacity = transmit.len();
+                    if transmit.num_datagrams == 1 && space_id == SpaceId::Data {
+                        // Now that we know the size of the first datagram, check whether
+                        // the data we planned to send will fit in the next segment.  If
+                        // not, bails out and leave it for the next GSO batch.  We can't
+                        // easily compute the right segment size before the original call to
+                        // `space_can_send`, because at that time we haven't determined
+                        // whether we're going to coalesce with the first datagram or
+                        // potentially pad it to `MIN_INITIAL_SIZE`.
 
-                        // Check whether the data we planned to send will fit in the reduced segment
-                        // size. If not, bail out and leave it for the next GSO batch so we don't
-                        // end up trying to send an empty packet. We can't easily compute the right
-                        // segment size before the original call to `space_can_send`, because at
-                        // that time we haven't determined whether we're going to coalesce with the
-                        // first datagram or potentially pad it to `MIN_INITIAL_SIZE`.
-                        if space_id == SpaceId::Data {
-                            let frame_space_1rtt = transmit
-                                .segment_size
-                                .saturating_sub(self.predict_1rtt_overhead(Some(pn)));
-                            if self.space_can_send(space_id, frame_space_1rtt).is_empty() {
-                                break;
-                            }
+                        transmit.clip_datagram_size();
+
+                        let frame_space_1rtt = transmit
+                            .segment_size
+                            .saturating_sub(self.predict_1rtt_overhead(Some(pn)));
+                        if self.space_can_send(space_id, frame_space_1rtt).is_empty() {
+                            break;
                         }
                     }
                 }
 
-                // Allocate space for another datagram
-                let next_datagram_size_limit = match self.spaces[space_id].loss_probes {
-                    0 => transmit.segment_size,
+                // Start the next datagram
+                match self.spaces[space_id].loss_probes {
+                    0 => transmit.start_new_datagram(),
                     _ => {
                         self.spaces[space_id].loss_probes -= 1;
                         // Clamp the datagram to at most the minimum MTU to ensure that loss probes
                         // can get through and enable recovery even if the path MTU has shrank
                         // unexpectedly.
-                        std::cmp::min(transmit.segment_size, usize::from(INITIAL_MTU))
+                        transmit.start_new_datagram_with_size(std::cmp::min(
+                            usize::from(INITIAL_MTU),
+                            transmit.segment_size,
+                        ));
                     }
                 };
-                transmit.buf_capacity += next_datagram_size_limit;
-                if transmit.buf.capacity() < transmit.buf_capacity {
-                    // We reserve the maximum space for sending `max_datagrams` upfront
-                    // to avoid any reallocations if more datagrams have to be appended later on.
-                    // Benchmarks have shown shown a 5-10% throughput improvement
-                    // compared to continuously resizing the datagram buffer.
-                    // While this will lead to over-allocation for small transmits
-                    // (e.g. purely containing ACKs), modern memory allocators
-                    // (e.g. mimalloc and jemalloc) will pool certain allocation sizes
-                    // and therefore this is still rather efficient.
-                    transmit
-                        .buf
-                        .reserve(transmit.max_datagrams * transmit.segment_size);
-                }
-                transmit.num_datagrams += 1;
                 coalesce = true;
                 pad_datagram = false;
-                transmit.datagram_start = transmit.len();
-
-                debug_assert_eq!(
-                    transmit.datagram_start % transmit.segment_size,
-                    0,
-                    "datagrams in a GSO batch must be aligned to the segment size"
-                );
             } else {
                 // We can append/coalesce the next packet into the current
                 // datagram.
@@ -926,8 +898,8 @@ impl Connection {
                 .mtud
                 .poll_transmit(now, self.packet_number_filter.peek(&self.spaces[space_id]))?;
 
-            transmit.buf_capacity = probe_size as usize;
-            transmit.buf.reserve(transmit.buf_capacity);
+            debug_assert_eq!(transmit.num_datagrams, 0);
+            transmit.start_new_datagram_with_size(probe_size as usize);
 
             debug_assert_eq!(transmit.datagram_start, 0);
             let mut builder = PacketBuilder::new(
@@ -957,7 +929,6 @@ impl Connection {
             builder.finish_and_track(now, self, Some(sent_frames), transmit.buf);
 
             self.stats.path.sent_plpmtud_probes += 1;
-            transmit.num_datagrams = 1;
 
             trace!(?probe_size, "writing MTUD probe");
         }
@@ -1013,9 +984,7 @@ impl Connection {
             SpaceId::Data,
             "PATH_CHALLENGE queued without 1-RTT keys"
         );
-        buf.buf.reserve(MIN_INITIAL_SIZE as usize);
-
-        buf.buf_capacity = buf.buf.capacity();
+        buf.start_new_datagram_with_size(MIN_INITIAL_SIZE as usize);
 
         // Use the previous CID to avoid linking the new path with the previous path. We
         // don't bother accounting for possible retirement of that prev_cid because this is

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use bytes::{Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use frame::StreamMetaVec;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use thiserror::Error;
@@ -757,7 +757,7 @@ impl Connection {
                         self.receiving_ecn,
                         &mut SentFrames::default(),
                         &mut self.spaces[space_id],
-                        transmit.buf,
+                        &mut transmit,
                         &mut self.stats,
                     );
                 }
@@ -844,7 +844,7 @@ impl Connection {
             let sent = self.populate_packet(
                 now,
                 space_id,
-                transmit.buf,
+                &mut transmit,
                 builder.max_size,
                 builder.exact_number,
             );
@@ -3032,7 +3032,7 @@ impl Connection {
         &mut self,
         now: Instant,
         space_id: SpaceId,
-        buf: &mut Vec<u8>,
+        buf: &mut (impl BufMut + BufLen),
         max_size: usize,
         pn: u64,
     ) -> SentFrames {
@@ -3298,7 +3298,7 @@ impl Connection {
         receiving_ecn: bool,
         sent: &mut SentFrames,
         space: &mut PacketSpace,
-        buf: &mut Vec<u8>,
+        buf: &mut impl BufMut,
         stats: &mut ConnectionStats,
     ) {
         debug_assert!(!space.pending_acks.ranges().is_empty());
@@ -3965,6 +3965,23 @@ fn negotiate_max_idle_timeout(x: Option<VarInt>, y: Option<VarInt>) -> Option<Du
         (Some(VarInt(0)) | None, Some(y)) => Some(Duration::from_millis(y.0)),
         (Some(x), Some(VarInt(0)) | None) => Some(Duration::from_millis(x.0)),
         (Some(x), Some(y)) => Some(Duration::from_millis(cmp::min(x, y).0)),
+    }
+}
+
+/// A buffer that can tell how much has been written to it already
+///
+/// This is commonly used for when a buffer is passed and the user may not write past a
+/// given size. It allows the user of such a buffer to know the current cursor position in
+/// the buffer. The maximum write size is usually passed in the same unit as
+/// [`BufLen::len`]: bytes since the buffer start.
+pub(crate) trait BufLen {
+    /// Returns the number of bytes written into the buffer so far
+    fn len(&self) -> usize;
+}
+
+impl BufLen for Vec<u8> {
+    fn len(&self) -> usize {
+        self.len()
     }
 }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -576,9 +576,10 @@ impl Connection {
                 // for starting another datagram. If there is any anti-amplification
                 // budget left, we always allow a full MTU to be sent
                 // (see https://github.com/quinn-rs/quinn/issues/1082)
-                if self.path.anti_amplification_blocked(
-                    (transmit.segment_size() * transmit.num_datagrams()) as u64 + 1,
-                ) {
+                if self
+                    .path
+                    .anti_amplification_blocked(transmit.capacity() as u64 + 1)
+                {
                     trace!("blocked by anti-amplification");
                     break;
                 }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -565,7 +565,7 @@ impl Connection {
                 // We need to send 1 more datagram and extend the buffer for that.
 
                 // Is 1 more datagram allowed?
-                if transmit.num_datagrams() >= transmit.max_datagrams() {
+                if transmit.has_datagram_capacity() {
                     // No more datagrams allowed
                     break;
                 }

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -5,7 +5,7 @@ use tracing::{trace, trace_span};
 use super::{Connection, SentFrames, TransmitBuilder, spaces::SentPacket};
 use crate::{
     ConnectionId, Instant, TransportError, TransportErrorCode,
-    connection::{BufSlice, ConnectionSide},
+    connection::ConnectionSide,
     frame::{self, Close},
     packet::{FIXED_BIT, Header, InitialHeader, LongType, PacketNumber, PartialEncode, SpaceId},
 };

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 
 pub(super) struct PacketBuilder {
-    pub(super) datagram_start: usize,
     pub(super) space: SpaceId,
     pub(super) partial_encode: PartialEncode,
     pub(super) ack_eliciting: bool,
@@ -154,7 +153,6 @@ impl PacketBuilder {
         debug_assert!(max_size >= min_size);
 
         Some(Self {
-            datagram_start: buffer.datagram_start_offset(),
             space: space_id,
             partial_encode,
             exact_number,

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -149,11 +149,11 @@ impl PacketBuilder {
             buffer.len() + (sample_size + 4).saturating_sub(number.len() + tag_len),
             partial_encode.start + dst_cid.len() + 6,
         );
-        let max_size = buffer.buf_capacity - tag_len;
+        let max_size = buffer.datagram_max_offset() - tag_len;
         debug_assert!(max_size >= min_size);
 
         Some(Self {
-            datagram_start: buffer.datagram_start,
+            datagram_start: buffer.datagram_start_offset(),
             space: space_id,
             partial_encode,
             exact_number,

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -2,7 +2,7 @@ use bytes::{BufMut, Bytes};
 use rand::Rng;
 use tracing::{trace, trace_span};
 
-use super::{Connection, SentFrames, TransmitBuilder, spaces::SentPacket};
+use super::{Connection, DatagramBuffer, SentFrames, spaces::SentPacket};
 use crate::{
     ConnectionId, Instant, TransportError, TransportErrorCode,
     connection::ConnectionSide,
@@ -36,7 +36,7 @@ impl PacketBuilder {
         now: Instant,
         space_id: SpaceId,
         dst_cid: ConnectionId,
-        buffer: &mut TransmitBuilder<'_>,
+        datagram: &mut DatagramBuffer<'_>,
         ack_eliciting: bool,
         conn: &mut Connection,
     ) -> Option<Self> {
@@ -120,9 +120,9 @@ impl PacketBuilder {
                 version,
             }),
         };
-        let partial_encode = header.encode(&mut buffer.datagram_mut());
+        let partial_encode = header.encode(datagram);
         if conn.peer_params.grease_quic_bit && conn.rng.random() {
-            buffer.datagram_mut()[partial_encode.start] ^= FIXED_BIT;
+            datagram[partial_encode.start] ^= FIXED_BIT;
         }
 
         let (sample_size, tag_len) = if let Some(ref crypto) = space.crypto {
@@ -146,10 +146,10 @@ impl PacketBuilder {
         // pn_len + payload_len + tag_len >= sample_size + 4
         // payload_len >= sample_size + 4 - pn_len - tag_len
         let min_size = Ord::max(
-            buffer.datagram().len() + (sample_size + 4).saturating_sub(number.len() + tag_len),
+            datagram.len() + (sample_size + 4).saturating_sub(number.len() + tag_len),
             partial_encode.start + dst_cid.len() + 6,
         );
-        let max_size = buffer.datagram_mut().capacity() - tag_len;
+        let max_size = datagram.capacity() - tag_len;
         debug_assert!(max_size >= min_size);
 
         Some(Self {
@@ -179,12 +179,12 @@ impl PacketBuilder {
         now: Instant,
         conn: &mut Connection,
         sent: Option<SentFrames>,
-        buffer: &mut TransmitBuilder<'_>,
+        datagram: &mut DatagramBuffer<'_>,
     ) {
         let ack_eliciting = self.ack_eliciting;
         let exact_number = self.exact_number;
         let space_id = self.space;
-        let (size, padded) = self.finish(conn, buffer);
+        let (size, padded) = self.finish(conn, datagram);
         let sent = match sent {
             Some(sent) => sent,
             None => return,
@@ -225,13 +225,13 @@ impl PacketBuilder {
     pub(super) fn finish(
         self,
         conn: &mut Connection,
-        buffer: &mut TransmitBuilder<'_>,
+        datagram: &mut DatagramBuffer<'_>,
     ) -> (usize, bool) {
-        let pad = self.min_size > buffer.datagram().len();
+        let pad = self.min_size > datagram.len();
         if pad {
-            let padding_bytes = self.min_size - buffer.datagram().len();
+            let padding_bytes = self.min_size - datagram.len();
             trace!("PADDING * {padding_bytes}");
-            buffer.datagram_mut().put_bytes(0, padding_bytes);
+            datagram.put_bytes(0, padding_bytes);
         }
 
         let space = &conn.spaces[self.space];
@@ -250,16 +250,15 @@ impl PacketBuilder {
             "Mismatching crypto tag len"
         );
 
-        buffer.datagram_mut().put_bytes(0, packet_crypto.tag_len());
+        datagram.put_bytes(0, packet_crypto.tag_len());
         let encode_start = self.partial_encode.start;
-        let mut datagram_buf = buffer.datagram_mut();
-        let packet_buf = &mut datagram_buf[encode_start..];
+        let packet_buf = &mut datagram[encode_start..];
         self.partial_encode.finish(
             packet_buf,
             header_crypto,
             Some((self.exact_number, packet_crypto)),
         );
 
-        (buffer.datagram().len() - encode_start, pad)
+        (datagram.len() - encode_start, pad)
     }
 }

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -15,7 +15,7 @@ use super::{
 use crate::{
     Dir, MAX_STREAM_COUNT, Side, StreamId, TransportError, VarInt,
     coding::BufMutExt,
-    connection::stats::FrameStats,
+    connection::{BufLen, stats::FrameStats},
     frame::{self, FrameStruct, StreamMetaVec},
     transport_parameters::TransportParameters,
 };
@@ -411,7 +411,7 @@ impl StreamsState {
 
     pub(in crate::connection) fn write_control_frames(
         &mut self,
-        buf: &mut Vec<u8>,
+        buf: &mut (impl BufMut + BufLen),
         pending: &mut Retransmits,
         retransmits: &mut ThinRetransmits,
         stats: &mut FrameStats,
@@ -541,7 +541,7 @@ impl StreamsState {
 
     pub(crate) fn write_stream_frames(
         &mut self,
-        buf: &mut Vec<u8>,
+        buf: &mut (impl BufMut + BufLen),
         max_buf_size: usize,
         fair: bool,
     ) -> StreamMetaVec {

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -15,7 +15,7 @@ use super::{
 use crate::{
     Dir, MAX_STREAM_COUNT, Side, StreamId, TransportError, VarInt,
     coding::BufMutExt,
-    connection::{BufLen, stats::FrameStats},
+    connection::stats::FrameStats,
     frame::{self, FrameStruct, StreamMetaVec},
     transport_parameters::TransportParameters,
 };
@@ -411,14 +411,13 @@ impl StreamsState {
 
     pub(in crate::connection) fn write_control_frames(
         &mut self,
-        buf: &mut (impl BufMut + BufLen),
+        buf: &mut impl BufMut,
         pending: &mut Retransmits,
         retransmits: &mut ThinRetransmits,
         stats: &mut FrameStats,
-        max_size: usize,
     ) {
         // RESET_STREAM
-        while buf.len() + frame::ResetStream::SIZE_BOUND < max_size {
+        while frame::ResetStream::SIZE_BOUND < buf.remaining_mut() {
             let (id, error_code) = match pending.reset_stream.pop() {
                 Some(x) => x,
                 None => break,
@@ -442,7 +441,7 @@ impl StreamsState {
         }
 
         // STOP_SENDING
-        while buf.len() + frame::StopSending::SIZE_BOUND < max_size {
+        while frame::StopSending::SIZE_BOUND < buf.remaining_mut() {
             let frame = match pending.stop_sending.pop() {
                 Some(x) => x,
                 None => break,
@@ -461,7 +460,7 @@ impl StreamsState {
         }
 
         // MAX_DATA
-        if pending.max_data && buf.len() + 9 < max_size {
+        if pending.max_data && 9 < buf.remaining_mut() {
             pending.max_data = false;
 
             // `local_max_data` can grow bigger than `VarInt`.
@@ -484,7 +483,7 @@ impl StreamsState {
         }
 
         // MAX_STREAM_DATA
-        while buf.len() + 17 < max_size {
+        while 17 < buf.remaining_mut() {
             let id = match pending.max_stream_data.iter().next() {
                 Some(x) => *x,
                 None => break,
@@ -516,7 +515,7 @@ impl StreamsState {
 
         // MAX_STREAMS
         for dir in Dir::iter() {
-            if !pending.max_stream_id[dir as usize] || buf.len() + 9 >= max_size {
+            if !pending.max_stream_id[dir as usize] || 9 >= buf.remaining_mut() {
                 continue;
             }
 
@@ -541,19 +540,11 @@ impl StreamsState {
 
     pub(crate) fn write_stream_frames(
         &mut self,
-        buf: &mut (impl BufMut + BufLen),
-        max_buf_size: usize,
+        buf: &mut impl BufMut,
         fair: bool,
     ) -> StreamMetaVec {
         let mut stream_frames = StreamMetaVec::new();
-        while buf.len() + frame::Stream::SIZE_BOUND < max_buf_size {
-            if max_buf_size
-                .checked_sub(buf.len() + frame::Stream::SIZE_BOUND)
-                .is_none()
-            {
-                break;
-            }
-
+        while frame::Stream::SIZE_BOUND < buf.remaining_mut() {
             // Pop the stream of the highest priority that currently has pending data
             // If the stream still has some pending data left after writing, it will be reinserted, otherwise not
             let Some(stream) = self.pending.pop() else {
@@ -577,7 +568,7 @@ impl StreamsState {
 
             // Now that we know the `StreamId`, we can better account for how many bytes
             // are required to encode it.
-            let max_buf_size = max_buf_size - buf.len() - 1 - VarInt::size(id.into());
+            let max_buf_size = buf.remaining_mut() - 1 - VarInt::size(id.into());
             let (offsets, encode_length) = stream.pending.poll_transmit(max_buf_size);
             let fin = offsets.end == stream.pending.offset()
                 && matches!(stream.state, SendState::DataSent { .. });
@@ -1379,8 +1370,8 @@ mod tests {
         high.set_priority(1).unwrap();
         high.write(b"high").unwrap();
 
-        let mut buf = Vec::with_capacity(40);
-        let meta = server.write_stream_frames(&mut buf, 40, true);
+        let buf = Vec::with_capacity(40);
+        let meta = server.write_stream_frames(&mut buf.limit(40), true);
         assert_eq!(meta[0].id, id_high);
         assert_eq!(meta[1].id, id_mid);
         assert_eq!(meta[2].id, id_low);
@@ -1438,8 +1429,10 @@ mod tests {
         };
         high.set_priority(-1).unwrap();
 
-        let mut buf = Vec::with_capacity(1000);
-        let meta = server.write_stream_frames(&mut buf, 40, true);
+        let buf = Vec::with_capacity(1000);
+        let mut buf = buf.limit(40);
+        let meta = server.write_stream_frames(&mut buf, true);
+        let buf = buf.into_inner();
         assert_eq!(meta.len(), 1);
         assert_eq!(meta[0].id, id_high);
 
@@ -1447,7 +1440,7 @@ mod tests {
         assert_eq!(server.pending.len(), 2);
 
         // Send the remaining data. The initial mid priority one should go first now
-        let meta = server.write_stream_frames(&mut buf, 1000, true);
+        let meta = server.write_stream_frames(&mut buf.limit(1000), true);
         assert_eq!(meta.len(), 2);
         assert_eq!(meta[0].id, id_mid);
         assert_eq!(meta[1].id, id_high);
@@ -1507,8 +1500,9 @@ mod tests {
 
             // loop until all the streams are written
             loop {
-                let buf_len = buf.len();
-                let meta = server.write_stream_frames(&mut buf, buf_len + 40, fair);
+                let mut lbuf = buf.limit(40);
+                let meta = server.write_stream_frames(&mut lbuf, fair);
+                buf = lbuf.into_inner();
                 if meta.is_empty() {
                     break;
                 }
@@ -1575,11 +1569,12 @@ mod tests {
         stream_b.write(&[b'b'; 100]).unwrap();
 
         let mut metas = vec![];
-        let mut buf = Vec::with_capacity(1024);
+        let buf = Vec::with_capacity(1024);
 
         // Write the first chunk of stream_a
-        let buf_len = buf.len();
-        let meta = server.write_stream_frames(&mut buf, buf_len + 40, false);
+        let mut buf = buf.limit(40);
+        let meta = server.write_stream_frames(&mut buf, false);
+        let mut buf = buf.into_inner();
         assert!(!meta.is_empty());
         metas.extend(meta);
 
@@ -1595,8 +1590,9 @@ mod tests {
 
         // loop until all the streams are written
         loop {
-            let buf_len = buf.len();
-            let meta = server.write_stream_frames(&mut buf, buf_len + 40, false);
+            let mut lbuf = buf.limit(40);
+            let meta = server.write_stream_frames(&mut lbuf, false);
+            buf = lbuf.into_inner();
             if meta.is_empty() {
                 break;
             }

--- a/quinn-proto/src/connection/transmit_builder.rs
+++ b/quinn-proto/src/connection/transmit_builder.rs
@@ -30,14 +30,14 @@ pub(super) struct TransmitBuilder<'a> {
     ///
     /// Note that when coalescing packets this might be before the start of the current
     /// packet.
-    pub(super) datagram_start: usize,
+    datagram_start: usize,
     /// The maximum offset allowed to be used for the current datagram in the buffer
     ///
     /// The first and last datagram in a batch are allowed to be smaller then the maximum
     /// size. All datagrams in between need to be exactly this size.
-    pub(super) buf_capacity: usize,
+    buf_capacity: usize,
     /// The maximum number of datagrams allowed to write into [`TransmitBuf::buf`]
-    pub(super) max_datagrams: usize,
+    max_datagrams: usize,
     /// The number of datagrams already (partially) written into the buffer
     ///
     /// Incremented by a call to [`TransmitBuf::start_new_datagram`].
@@ -50,7 +50,7 @@ pub(super) struct TransmitBuilder<'a> {
     /// For the first datagram this is set to the maximum size a datagram is allowed to be:
     /// the current path MTU. After the first datagram is finished this is reduced to the
     /// size of the first datagram and can no longer change.
-    pub(super) segment_size: usize,
+    segment_size: usize,
 }
 
 impl<'a> TransmitBuilder<'a> {
@@ -138,6 +138,42 @@ impl<'a> TransmitBuilder<'a> {
         debug_assert_eq!(self.num_datagrams, 1);
         self.segment_size = self.buf.len();
         self.buf_capacity = self.buf.len();
+    }
+
+    /// Returns the GSO segment size
+    ///
+    /// This is also the maximum size datagrams are allowed to be. The first and last
+    /// datagram in a batch are allowed to be smaller however. After the first datagram the
+    /// segment size is clipped to the size of the first datagram.
+    pub(super) fn segment_size(&self) -> usize {
+        self.segment_size
+    }
+
+    /// Returns the number of datagrams written into the buffer
+    ///
+    /// The last datagram is not necessarily finished yet.
+    pub(super) fn num_datagrams(&self) -> usize {
+        self.num_datagrams
+    }
+
+    /// Returns the maximum number of datagrams allowed to be written into the buffer
+    pub(super) fn max_datagrams(&self) -> usize {
+        self.max_datagrams
+    }
+
+    /// Returns the start offset of the current datagram in the buffer
+    ///
+    /// In other words, this offset contains the first byte of the current datagram.
+    pub(super) fn datagram_start_offset(&self) -> usize {
+        self.datagram_start
+    }
+
+    /// Returns the maximum offset in the buffer allowed for the current datagram
+    ///
+    /// The first and last datagram in a batch are allowed to be smaller then the maximum
+    /// size. All datagrams in between need to be exactly this size.
+    pub(super) fn datagram_max_offset(&self) -> usize {
+        self.buf_capacity
     }
 
     /// Returns `true` if the buffer did not have anything written into it

--- a/quinn-proto/src/connection/transmit_builder.rs
+++ b/quinn-proto/src/connection/transmit_builder.rs
@@ -2,8 +2,6 @@ use std::ops::{Deref, DerefMut};
 
 use bytes::BufMut;
 
-use super::BufLen;
-
 /// The buffer in which to write datagrams for [`Connection::poll_transmit`]
 ///
 /// The `poll_transmit` function writes zero or more datagrams to a buffer. Multiple
@@ -252,12 +250,5 @@ impl DatagramBuffer<'_> {
     /// Returns the maximum size of the buffer
     pub(crate) fn capacity(&self) -> usize {
         self.max_offset - self.start_offset
-    }
-}
-
-// Temporary compatibility with the BufLen trait.  To be removed in follow-up commits.
-impl BufLen for DatagramBuffer<'_> {
-    fn len(&self) -> usize {
-        self.deref().len()
     }
 }

--- a/quinn-proto/src/connection/transmit_builder.rs
+++ b/quinn-proto/src/connection/transmit_builder.rs
@@ -160,6 +160,11 @@ impl<'a> TransmitBuilder<'a> {
         &self.buf[self.datagram_start..]
     }
 
+    /// Whether there is space for another datagram in this transmit
+    pub(super) fn has_datagram_capacity(&self) -> bool {
+        self.num_datagrams >= self.max_datagrams
+    }
+
     /// Returns the GSO segment size
     ///
     /// This is also the maximum size datagrams are allowed to be. The first and last
@@ -174,11 +179,6 @@ impl<'a> TransmitBuilder<'a> {
     /// The last datagram is not necessarily finished yet.
     pub(super) fn num_datagrams(&self) -> usize {
         self.num_datagrams
-    }
-
-    /// Returns the maximum number of datagrams allowed to be written into the buffer
-    pub(super) fn max_datagrams(&self) -> usize {
-        self.max_datagrams
     }
 
     /// Returns `true` if there are no datagrams in this transmit

--- a/quinn-proto/src/connection/transmit_builder.rs
+++ b/quinn-proto/src/connection/transmit_builder.rs
@@ -176,6 +176,11 @@ impl<'a> TransmitBuilder<'a> {
         self.segment_size * self.num_datagrams
     }
 
+    /// Whether the current datagram is the first in the transmit buffer
+    pub(super) fn is_first_datagram(&self) -> bool {
+        self.num_datagrams == 1
+    }
+
     /// Returns the GSO segment size
     ///
     /// This is also the maximum size datagrams are allowed to be. The first and last

--- a/quinn-proto/src/connection/transmit_builder.rs
+++ b/quinn-proto/src/connection/transmit_builder.rs
@@ -165,6 +165,17 @@ impl<'a> TransmitBuilder<'a> {
         self.num_datagrams >= self.max_datagrams
     }
 
+    /// The sum of the capacity of all started datagrams in the transmit
+    ///
+    /// This might be more than [`len`] when the current datagram is not yet fully
+    /// written. In other words: this is the length of the transmit when the current
+    /// datagram would fill the entire segment size.
+    ///
+    /// [`len`]: TransmitBuf::len
+    pub(super) fn capacity(&self) -> usize {
+        self.segment_size * self.num_datagrams
+    }
+
     /// Returns the GSO segment size
     ///
     /// This is also the maximum size datagrams are allowed to be. The first and last

--- a/quinn-proto/src/connection/transmit_builder.rs
+++ b/quinn-proto/src/connection/transmit_builder.rs
@@ -185,27 +185,12 @@ impl<'a> TransmitBuilder<'a> {
         self.max_datagrams
     }
 
-    /// Returns the start offset of the current datagram in the buffer
-    ///
-    /// In other words, this offset contains the first byte of the current datagram.
-    pub(super) fn datagram_start_offset(&self) -> usize {
-        self.datagram_start
-    }
-
-    /// Returns the maximum offset in the buffer allowed for the current datagram
-    ///
-    /// The first and last datagram in a batch are allowed to be smaller then the maximum
-    /// size. All datagrams in between need to be exactly this size.
-    pub(super) fn datagram_max_offset(&self) -> usize {
-        self.buf_capacity
-    }
-
-    /// Returns `true` if the buffer did not have anything written into it
+    /// Returns `true` if there are no datagrams in this transmit
     pub(super) fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    /// The number of bytes written into the buffer so far
+    /// Returns the sum of the bytes for all datagrams in the builder
     pub(super) fn len(&self) -> usize {
         self.buf.len()
     }

--- a/quinn-proto/src/connection/transmit_builder.rs
+++ b/quinn-proto/src/connection/transmit_builder.rs
@@ -65,6 +65,81 @@ impl<'a> TransmitBuilder<'a> {
         }
     }
 
+    /// Starts a datagram with a custom datagram size
+    ///
+    /// This is a specialized version of [`TransmitBuf::start_new_datagram`] which sets the
+    /// datagram size. Useful for e.g. PATH_CHALLENGE, tail-loss probes or MTU probes.
+    ///
+    /// After the first datagram you can never increase the segment size. If you decrease
+    /// the size of a datagram in a batch, it must be the last datagram of the batch.
+    pub(super) fn start_new_datagram_with_size(&mut self, datagram_size: usize) {
+        // Only reserve space for this datagram, usually it is the last one in the batch.
+        let max_capacity_hint = datagram_size;
+        self.new_datagram_inner(datagram_size, max_capacity_hint)
+    }
+
+    /// Starts a new datagram in the transmit buffer
+    ///
+    /// If this starts the second datagram the segment size will be set to the size of the
+    /// first datagram.
+    ///
+    /// If the underlying buffer does not have enough capacity yet this will allocate enough
+    /// capacity for all the datagrams allowed in a single batch. Use
+    /// [`TransmitBuf::start_new_datagram_with_size`] if you know you will need less.
+    pub(super) fn start_new_datagram(&mut self) {
+        // We reserve the maximum space for sending `max_datagrams` upfront to avoid any
+        // reallocations if more datagrams have to be appended later on.  Benchmarks have
+        // shown a 5-10% throughput improvement compared to continuously resizing the
+        // datagram buffer. While this will lead to over-allocation for small transmits
+        // (e.g. purely containing ACKs), modern memory allocators (e.g. mimalloc and
+        // jemalloc) will pool certain allocation sizes and therefore this is still rather
+        // efficient.
+        let max_capacity_hint = self.max_datagrams * self.segment_size;
+        self.new_datagram_inner(self.segment_size, max_capacity_hint)
+    }
+
+    fn new_datagram_inner(&mut self, datagram_size: usize, max_capacity_hint: usize) {
+        debug_assert!(self.num_datagrams < self.max_datagrams);
+        if self.num_datagrams == 1 {
+            // Set the segment size to the size of the first datagram.
+            self.segment_size = self.buf.len();
+        }
+        if self.num_datagrams >= 1 {
+            debug_assert!(datagram_size <= self.segment_size);
+            if datagram_size < self.segment_size {
+                // If this is a GSO batch and this datagram is smaller than the segment
+                // size, this must be the last datagram in the batch.
+                self.max_datagrams = self.num_datagrams + 1;
+            }
+        }
+        self.datagram_start = self.buf.len();
+        debug_assert_eq!(
+            self.datagram_start % self.segment_size,
+            0,
+            "datagrams in a GSO batch must be aligned to the segment size"
+        );
+        self.buf_capacity = self.datagram_start + datagram_size;
+        if self.buf_capacity > self.buf.capacity() {
+            self.buf
+                .reserve_exact(max_capacity_hint.saturating_sub(self.buf.capacity()));
+        }
+        self.num_datagrams += 1;
+    }
+
+    /// Clips the datagram size to the current size
+    ///
+    /// Only valid for the first datagram, when the datagram might be smaller than the
+    /// segment size. Needed before estimating the available space in the next datagram
+    /// based on [`TransmitBuf::segment_size`].
+    ///
+    /// Use [`TransmitBuf::start_new_datagram_with_size`] if you need to reduce the size of
+    /// the last datagram in a batch.
+    pub(super) fn clip_datagram_size(&mut self) {
+        debug_assert_eq!(self.num_datagrams, 1);
+        self.segment_size = self.buf.len();
+        self.buf_capacity = self.buf.len();
+    }
+
     /// Returns `true` if the buffer did not have anything written into it
     pub(super) fn is_empty(&self) -> bool {
         self.len() == 0

--- a/quinn-proto/src/connection/transmit_builder.rs
+++ b/quinn-proto/src/connection/transmit_builder.rs
@@ -1,7 +1,5 @@
 use bytes::BufMut;
 
-use super::BufLen;
-
 /// The buffer in which to write datagrams for [`Connection::poll_transmit`]
 ///
 /// The `poll_transmit` function writes zero or more datagrams to a buffer. Multiple
@@ -147,6 +145,11 @@ impl<'a> TransmitBuilder<'a> {
         self.buf.as_mut_slice()
     }
 
+    /// Returns a buffer into which the current datagram can be written
+    pub(super) fn datagram_mut(&mut self) -> bytes::buf::Limit<&mut Vec<u8>> {
+        self.buf.limit(self.buf_capacity)
+    }
+
     /// Returns the GSO segment size
     ///
     /// This is also the maximum size datagrams are allowed to be. The first and last
@@ -191,25 +194,5 @@ impl<'a> TransmitBuilder<'a> {
     /// The number of bytes written into the buffer so far
     pub(super) fn len(&self) -> usize {
         self.buf.len()
-    }
-}
-
-unsafe impl BufMut for TransmitBuilder<'_> {
-    fn remaining_mut(&self) -> usize {
-        self.buf.remaining_mut()
-    }
-
-    unsafe fn advance_mut(&mut self, cnt: usize) {
-        self.buf.advance_mut(cnt);
-    }
-
-    fn chunk_mut(&mut self) -> &mut bytes::buf::UninitSlice {
-        self.buf.chunk_mut()
-    }
-}
-
-impl BufLen for TransmitBuilder<'_> {
-    fn len(&self) -> usize {
-        self.len()
     }
 }

--- a/quinn-proto/src/connection/transmit_builder.rs
+++ b/quinn-proto/src/connection/transmit_builder.rs
@@ -1,5 +1,7 @@
 use bytes::BufMut;
 
+use super::BufLen;
+
 /// The buffer in which to write datagrams for [`Connection::poll_transmit`]
 ///
 /// The `poll_transmit` function writes zero or more datagrams to a buffer. Multiple
@@ -198,5 +200,11 @@ unsafe impl BufMut for TransmitBuilder<'_> {
 
     fn chunk_mut(&mut self) -> &mut bytes::buf::UninitSlice {
         self.buf.chunk_mut()
+    }
+}
+
+impl BufLen for TransmitBuilder<'_> {
+    fn len(&self) -> usize {
+        self.len()
     }
 }

--- a/quinn-proto/src/connection/transmit_builder.rs
+++ b/quinn-proto/src/connection/transmit_builder.rs
@@ -1,0 +1,91 @@
+use bytes::BufMut;
+
+/// The buffer in which to write datagrams for [`Connection::poll_transmit`]
+///
+/// The `poll_transmit` function writes zero or more datagrams to a buffer. Multiple
+/// datagrams are possible in case GSO (Generic Segmentation Offload) is supported.
+///
+/// This buffer tracks datagrams being written to it. There is always a "current" datagram,
+/// which is started by calling [`TransmitBuf::start_new_datagram`]. Writing to the buffer
+/// is done through the [`BufMut`] interface.
+///
+/// Usually a datagram contains one QUIC packet, though QUIC-TRANSPORT 12.2 Coalescing
+/// Packets allows for placing multiple packets into a single datagram provided all but the
+/// last packet uses long headers. This is normally used during connection setup where often
+/// the initial, handshake and sometimes even a 1-RTT packet can be coalesced into a single
+/// datagram.
+///
+/// Inside a single packet multiple QUIC frames are written.
+///
+/// The buffer managed here is passed straight to the OS' `sendmsg` call (or variant) once
+/// `poll_transmit` returns.  So needs to contain the datagrams as they are sent on the
+/// wire.
+///
+/// [`Connection::poll_transmit`]: super::Connection::poll_transmit
+#[derive(Debug)]
+pub(super) struct TransmitBuilder<'a> {
+    /// The buffer itself, packets are written to this buffer
+    pub(super) buf: &'a mut Vec<u8>,
+    /// Offset into the buffer at which the current datagram starts
+    ///
+    /// Note that when coalescing packets this might be before the start of the current
+    /// packet.
+    pub(super) datagram_start: usize,
+    /// The maximum offset allowed to be used for the current datagram in the buffer
+    ///
+    /// The first and last datagram in a batch are allowed to be smaller then the maximum
+    /// size. All datagrams in between need to be exactly this size.
+    pub(super) buf_capacity: usize,
+    /// The maximum number of datagrams allowed to write into [`TransmitBuf::buf`]
+    pub(super) max_datagrams: usize,
+    /// The number of datagrams already (partially) written into the buffer
+    ///
+    /// Incremented by a call to [`TransmitBuf::start_new_datagram`].
+    pub(super) num_datagrams: usize,
+    /// The segment size of this GSO batch
+    ///
+    /// The segment size is the size of each datagram in the GSO batch, only the last
+    /// datagram in the batch may be smaller.
+    ///
+    /// For the first datagram this is set to the maximum size a datagram is allowed to be:
+    /// the current path MTU. After the first datagram is finished this is reduced to the
+    /// size of the first datagram and can no longer change.
+    pub(super) segment_size: usize,
+}
+
+impl<'a> TransmitBuilder<'a> {
+    pub(super) fn new(buf: &'a mut Vec<u8>, max_datagrams: usize, mtu: usize) -> Self {
+        Self {
+            buf,
+            datagram_start: 0,
+            buf_capacity: 0,
+            max_datagrams,
+            num_datagrams: 0,
+            segment_size: mtu,
+        }
+    }
+
+    /// Returns `true` if the buffer did not have anything written into it
+    pub(super) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The number of bytes written into the buffer so far
+    pub(super) fn len(&self) -> usize {
+        self.buf.len()
+    }
+}
+
+unsafe impl BufMut for TransmitBuilder<'_> {
+    fn remaining_mut(&self) -> usize {
+        self.buf.remaining_mut()
+    }
+
+    unsafe fn advance_mut(&mut self, cnt: usize) {
+        self.buf.advance_mut(cnt);
+    }
+
+    fn chunk_mut(&mut self) -> &mut bytes::buf::UninitSlice {
+        self.buf.chunk_mut()
+    }
+}

--- a/quinn-proto/src/connection/transmit_builder.rs
+++ b/quinn-proto/src/connection/transmit_builder.rs
@@ -27,7 +27,7 @@ use super::BufLen;
 #[derive(Debug)]
 pub(super) struct TransmitBuilder<'a> {
     /// The buffer itself, packets are written to this buffer
-    pub(super) buf: &'a mut Vec<u8>,
+    buf: &'a mut Vec<u8>,
     /// Offset into the buffer at which the current datagram starts
     ///
     /// Note that when coalescing packets this might be before the start of the current
@@ -140,6 +140,11 @@ impl<'a> TransmitBuilder<'a> {
         debug_assert_eq!(self.num_datagrams, 1);
         self.segment_size = self.buf.len();
         self.buf_capacity = self.buf.len();
+    }
+
+    /// Returns the already written bytes in the buffer
+    pub(super) fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.buf.as_mut_slice()
     }
 
     /// Returns the GSO segment size

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -899,13 +899,13 @@ impl FrameStruct for Datagram {
 }
 
 impl Datagram {
-    pub(crate) fn encode(&self, length: bool, out: &mut Vec<u8>) {
+    pub(crate) fn encode(&self, length: bool, out: &mut impl BufMut) {
         out.write(FrameType(*DATAGRAM_TYS.start() | u64::from(length))); // 1 byte
         if length {
             // Safe to unwrap because we check length sanity before queueing datagrams
             out.write(VarInt::from_u64(self.data.len() as u64).unwrap()); // <= 8 bytes
         }
-        out.extend_from_slice(&self.data);
+        out.put_slice(&self.data);
     }
 
     pub(crate) fn size(&self, length: bool) -> usize {

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 use crate::{
     ConnectionId,
     coding::{self, BufExt, BufMutExt},
-    connection::BufLen,
+    connection::BufSlice,
     crypto,
 };
 
@@ -282,7 +282,11 @@ pub(crate) enum Header {
 }
 
 impl Header {
-    pub(crate) fn encode(&self, w: &mut (impl BufMut + BufLen)) -> PartialEncode {
+    /// Encodes the QUIC packet header into the buffer
+    ///
+    /// The current position of the buffer is stored in the [`PartialEncode`] as the start
+    /// of the packet in the buffer.
+    pub(crate) fn encode(&self, w: &mut impl BufSlice) -> PartialEncode {
         use Header::*;
         let start = w.len();
         match *self {

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 use crate::{
     ConnectionId,
     coding::{self, BufExt, BufMutExt},
+    connection::BufLen,
     crypto,
 };
 
@@ -281,7 +282,7 @@ pub(crate) enum Header {
 }
 
 impl Header {
-    pub(crate) fn encode(&self, w: &mut Vec<u8>) -> PartialEncode {
+    pub(crate) fn encode(&self, w: &mut (impl BufMut + BufLen)) -> PartialEncode {
         use Header::*;
         let start = w.len();
         match *self {


### PR DESCRIPTION
Hi, I've been looking around in `poll_receive` recently and started wondering if it could be simplified.  This is my first attempt at a step in this direction, it pulls together the state about datagrams and their boundaries in the write buffer.  I think this helps understand the interactions between a bunch of state changes that were previously spread across many lines.  See the commit message for a detailed description.

If the general direction is considered useful I think I'd like to continue this further.  The next thing I'd probably look at is the buffer management for a packet.  I expect a lot of places don't need to know much about the full transmit buffer they're writing into but rather need to know the (start, len, end) space they can write their frames.  Probably reducing the need to do everything with offsets from the transmit buffer.

Anyway, my aim is the make things clearer and easier to manage.  Let's first see if this is step in that direction and then see what the future steps turn out to be.  I think any change like this should be able to stand on its own rather than rely on a future change, because the future is always uncertain and might never happen :)