### PR TITLE
Prefer sending extra ping again

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -470,11 +470,7 @@ impl Connection {
         for space in SpaceId::iter() {
             let request_immediate_ack =
                 space == SpaceId::Data && self.peer_supports_ack_frequency();
-            self.spaces[space].maybe_queue_probe(
-                request_immediate_ack,
-                &self.streams,
-                &self.datagrams,
-            );
+            self.spaces[space].maybe_queue_probe(request_immediate_ack, &self.streams);
         }
 
         // Check whether we need to send a close message

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -9,7 +9,7 @@ use rand::Rng;
 use rustc_hash::FxHashSet;
 use tracing::trace;
 
-use super::{assembler::Assembler, datagrams::DatagramState};
+use super::assembler::Assembler;
 use crate::{
     Dir, Duration, Instant, SocketAddr, StreamId, TransportError, VarInt, connection::StreamsState,
     crypto::Keys, frame, packet::SpaceId, range_set::ArrayRangeSet, shared::IssuedCid,
@@ -118,7 +118,6 @@ impl PacketSpace {
         &mut self,
         request_immediate_ack: bool,
         streams: &StreamsState,
-        datagrams: &DatagramState,
     ) {
         if self.loss_probes == 0 {
             return;
@@ -130,7 +129,7 @@ impl PacketSpace {
             self.immediate_ack_pending = true;
         }
 
-        if !self.pending.is_empty(streams) || !datagrams.outgoing.is_empty() {
+        if !self.pending.is_empty(streams) {
             // There's real data to send here, no need to make something up
             return;
         }


### PR DESCRIPTION
This reverts the change that tries to avoid sending a PING frame if there are user datagrams to send.  The problem is that the user dataram might not fit in the probe that will be sent.

It is possible to do this better, but the quick thing is to accept the extra ping frame, the space wasted because of this is rather minimal. And if a user was sending user datagrams at just the right MTU size it is unlikely they would fit in the next packet anyway since typically the probe packet will end up with a smaller size-limit compared to the MTU.

Reverts part of #2169.