### PR TITLE
Avoid inference hazard for integer comparisons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,9 +665,9 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
 ]

--- a/quinn-proto/src/connection/pacing.rs
+++ b/quinn-proto/src/connection/pacing.rs
@@ -73,7 +73,7 @@ impl Pacer {
         }
 
         // we disable pacing for extremely large windows
-        if window > u32::MAX.into() {
+        if window > u64::from(u32::MAX) {
             return None;
         }
 

--- a/quinn-proto/src/connection/send_buffer.rs
+++ b/quinn-proto/src/connection/send_buffer.rs
@@ -339,7 +339,7 @@ mod tests {
         buf.ack(4..7);
         assert_eq!(aggregate_unacked(&buf), &MSG[9..]);
         buf.ack(0..MSG_LEN);
-        assert_eq!(aggregate_unacked(&buf), &[]);
+        assert_eq!(aggregate_unacked(&buf), &[] as &[u8]);
     }
 
     #[test]

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -176,7 +176,7 @@ impl Recv {
             if offset != final_offset.into_inner() {
                 return Err(TransportError::FINAL_SIZE_ERROR("inconsistent value"));
             }
-        } else if self.end > final_offset.into() {
+        } else if self.end > u64::from(final_offset) {
             return Err(TransportError::FINAL_SIZE_ERROR(
                 "lower than high water mark",
             ));


### PR DESCRIPTION
Fixes #2186.

The deranged maintainer appears to be [unlikely](https://github.com/jhpratt/deranged/issues/18#issuecomment-2749704917) to revert the new `PartialEq` impls that are causing this. I'm guessing this is not causing downstream issues because only dev-dependencies are pulling in the deranged crate, so there should be no urgent need for a release.