### PR TITLE
Make PacketBuilder own the write buffer

### DIFF
--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -1,10 +1,10 @@
 use std::collections::VecDeque;
 
-use bytes::Bytes;
+use bytes::{BufMut, Bytes};
 use thiserror::Error;
 use tracing::{debug, trace};
 
-use super::Connection;
+use super::{BufLen, Connection};
 use crate::{
     TransportError,
     frame::{Datagram, FrameStruct},
@@ -163,7 +163,7 @@ impl DatagramState {
     ///
     /// Returns whether a frame was written. At most `max_size` bytes will be written, including
     /// framing.
-    pub(super) fn write(&mut self, buf: &mut Vec<u8>, max_size: usize) -> bool {
+    pub(super) fn write(&mut self, buf: &mut (impl BufMut + BufLen), max_size: usize) -> bool {
         let datagram = match self.outgoing.pop_front() {
             Some(x) => x,
             None => return false,

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -4,7 +4,7 @@ use bytes::{BufMut, Bytes};
 use thiserror::Error;
 use tracing::{debug, trace};
 
-use super::{BufLen, Connection};
+use super::Connection;
 use crate::{
     TransportError,
     frame::{Datagram, FrameStruct},
@@ -163,13 +163,13 @@ impl DatagramState {
     ///
     /// Returns whether a frame was written. At most `max_size` bytes will be written, including
     /// framing.
-    pub(super) fn write(&mut self, buf: &mut (impl BufMut + BufLen), max_size: usize) -> bool {
+    pub(super) fn write(&mut self, buf: &mut impl BufMut) -> bool {
         let datagram = match self.outgoing.pop_front() {
             Some(x) => x,
             None => return false,
         };
 
-        if buf.len() + datagram.size(true) > max_size {
+        if buf.remaining_mut() < datagram.size(true) {
             // Future work: we could be more clever about cramming small datagrams into
             // mostly-full packets when a larger one is queued first
             self.outgoing.push_front(datagram);

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3970,23 +3970,6 @@ fn negotiate_max_idle_timeout(x: Option<VarInt>, y: Option<VarInt>) -> Option<Du
     }
 }
 
-/// A buffer that can tell how much has been written to it already
-///
-/// This is commonly used for when a buffer is passed and the user may not write past a
-/// given size. It allows the user of such a buffer to know the current cursor position in
-/// the buffer. The maximum write size is usually passed in the same unit as
-/// [`BufLen::len`]: bytes since the buffer start.
-pub(crate) trait BufLen {
-    /// Returns the number of bytes written into the buffer so far
-    fn len(&self) -> usize;
-}
-
-impl BufLen for Vec<u8> {
-    fn len(&self) -> usize {
-        self.len()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -803,9 +803,7 @@ impl Connection {
                         // are the only packets for which we might grow `buf_capacity`
                         // by less than `segment_size`.
                         const MAX_PADDING: usize = 16;
-                        let packet_len_unpadded = cmp::max(builder.min_size, builder.buf.len())
-                            - builder.buf.datagram_start_offset()
-                            + builder.tag_len;
+                        let packet_len_unpadded = builder.predict_packet_size();
                         if packet_len_unpadded + MAX_PADDING < builder.buf.segment_size()
                             || builder.buf.datagram_start_offset() + builder.buf.segment_size()
                                 > builder.buf.datagram_max_offset()

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -659,7 +659,7 @@ impl Connection {
                         builder.pad_to(buf.segment_size() as u16);
                     }
 
-                    builder.finish_and_track(now, self, sent_frames.take(), buf.buf);
+                    builder.finish_and_track(now, self, sent_frames.take(), &mut buf);
 
                     if buf.num_datagrams() == 1 {
                         buf.clip_datagram_size();
@@ -704,7 +704,7 @@ impl Connection {
                 // datagram.
                 // Finish current packet without adding extra padding
                 if let Some(builder) = builder_storage.take() {
-                    builder.finish_and_track(now, self, sent_frames.take(), buf.buf);
+                    builder.finish_and_track(now, self, sent_frames.take(), &mut buf);
                 }
             }
 
@@ -828,7 +828,7 @@ impl Connection {
                             non_retransmits: true,
                             ..SentFrames::default()
                         }),
-                        buf.buf,
+                        &mut buf,
                     );
                     self.stats.udp_tx.on_sent(1, buf.len());
                     return Some(Transmit {
@@ -884,7 +884,7 @@ impl Connection {
                 builder.pad_to(MIN_INITIAL_SIZE);
             }
             let last_packet_number = builder.exact_number;
-            builder.finish_and_track(now, self, sent_frames, buf.buf);
+            builder.finish_and_track(now, self, sent_frames, &mut buf);
             self.path
                 .congestion
                 .on_sent(now, buf.len() as u64, last_packet_number);
@@ -922,7 +922,7 @@ impl Connection {
                 non_retransmits: true,
                 ..Default::default()
             };
-            builder.finish_and_track(now, self, Some(sent_frames), buf.buf);
+            builder.finish_and_track(now, self, Some(sent_frames), &mut buf);
 
             self.stats.path.sent_plpmtud_probes += 1;
 
@@ -996,7 +996,7 @@ impl Connection {
         // sending a datagram of this size
         builder.pad_to(MIN_INITIAL_SIZE);
 
-        builder.finish(self, buf.buf);
+        builder.finish(self, buf);
         self.stats.udp_tx.on_sent(1, buf.len());
 
         Some(Transmit {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -643,7 +643,7 @@ impl Connection {
                         self.receiving_ecn,
                         &mut sent_frames,
                         &mut self.spaces[space_id],
-                        &mut builder,
+                        &mut builder.frame_space_mut(),
                         &mut self.stats,
                     );
                 }
@@ -660,14 +660,14 @@ impl Connection {
                     match self.state {
                         State::Closed(state::Closed { ref reason }) => {
                             if space_id == SpaceId::Data || reason.is_transport_layer() {
-                                reason.encode(&mut builder, max_frame_size)
+                                reason.encode(&mut builder.frame_space_mut(), max_frame_size)
                             } else {
                                 frame::ConnectionClose {
                                     error_code: TransportErrorCode::APPLICATION_ERROR,
                                     frame_type: None,
                                     reason: Bytes::new(),
                                 }
-                                .encode(&mut builder, max_frame_size)
+                                .encode(&mut builder.frame_space_mut(), max_frame_size)
                             }
                         }
                         State::Draining => frame::ConnectionClose {
@@ -675,7 +675,7 @@ impl Connection {
                             frame_type: None,
                             reason: Bytes::new(),
                         }
-                        .encode(&mut builder, max_frame_size),
+                        .encode(&mut builder.frame_space_mut(), max_frame_size),
                         _ => unreachable!(
                             "tried to make a close packet when the connection wasn't closed"
                         ),
@@ -704,8 +704,10 @@ impl Connection {
             if space_id == SpaceId::Data && builder.buf.num_datagrams() == 1 {
                 if let Some((token, remote)) = self.path_responses.pop_off_path(self.path.remote) {
                     trace!("PATH_RESPONSE {:08x} (off-path)", token);
-                    builder.write(frame::FrameType::PATH_RESPONSE);
-                    builder.write(token);
+                    builder
+                        .frame_space_mut()
+                        .write(frame::FrameType::PATH_RESPONSE);
+                    builder.frame_space_mut().write(token);
                     self.stats.frame_tx.path_response += 1;
                     builder.pad_to(MIN_INITIAL_SIZE);
                     builder.finish_and_track(
@@ -772,22 +774,10 @@ impl Connection {
             // might be needed because of the packet type, or to fill the GSO segment size.
             next_space_id = self.next_send_space(space_id, builder.buf, close);
             if let Some(next_space_id) = next_space_id {
-                // Can we append another packet into the current datagram?
-                let buf_end = builder.len().max(builder.min_size) + builder.tag_len;
-                let tag_len = if let Some(ref crypto) = self.spaces[next_space_id].crypto {
-                    crypto.packet.local.tag_len()
-                } else if next_space_id == SpaceId::Data {
-                    self.zero_rtt_crypto.as_ref().expect(
-                        "sending packets in the application data space requires known 0-RTT or 1-RTT keys",
-                    ).packet.tag_len()
-                } else {
-                    unreachable!("tried to send {:?} packet without keys", next_space_id);
-                };
-
                 // Are we allowed to coalesce AND is there enough space for another *packet*
                 // in this datagram?
                 if coalesce
-                    && builder.buf.datagram_max_offset() - buf_end > MIN_PACKET_SPACE + tag_len
+                    && builder.buf.segment_size() - builder.predict_packet_size() > MIN_PACKET_SPACE
                 {
                     // We can append/coalesce the next packet into the current
                     // datagram. Finish the current packet without adding extra padding.
@@ -895,12 +885,14 @@ impl Connection {
                 PacketBuilder::new(now, space_id, self.rem_cids.active(), &mut buf, true, self)?;
 
             // We implement MTU probes as ping packets padded up to the probe size
-            builder.write(frame::FrameType::PING);
+            builder.frame_space_mut().write(frame::FrameType::PING);
             self.stats.frame_tx.ping += 1;
 
             // If supported by the peer, we want no delays to the probe's ACK
             if self.peer_supports_ack_frequency() {
-                builder.write(frame::FrameType::IMMEDIATE_ACK);
+                builder
+                    .frame_space_mut()
+                    .write(frame::FrameType::IMMEDIATE_ACK);
                 self.stats.frame_tx.immediate_ack += 1;
             }
 
@@ -1007,8 +999,10 @@ impl Connection {
         debug_assert_eq!(buf.datagram_start_offset(), 0);
         let mut builder = PacketBuilder::new(now, SpaceId::Data, *prev_cid, buf, false, self)?;
         trace!("validating previous path with PATH_CHALLENGE {:08x}", token);
-        builder.write(frame::FrameType::PATH_CHALLENGE);
-        builder.write(token);
+        builder
+            .frame_space_mut()
+            .write(frame::FrameType::PATH_CHALLENGE);
+        builder.frame_space_mut().write(token);
         self.stats.frame_tx.path_challenge += 1;
 
         // An endpoint MUST expand datagrams that contain a PATH_CHALLENGE frame

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -684,7 +684,7 @@ impl Connection {
                 if pad_datagram {
                     builder.pad_to(MIN_INITIAL_SIZE);
                 }
-                builder.finish_and_track(now, self, Some(sent_frames), &mut buf);
+                builder.finish_and_track(now, self, sent_frames, &mut buf);
                 if space_id == self.highest_space {
                     // Don't send another close packet
                     self.close = false;
@@ -711,10 +711,10 @@ impl Connection {
                     builder.finish_and_track(
                         now,
                         self,
-                        Some(SentFrames {
+                        SentFrames {
                             non_retransmits: true,
                             ..SentFrames::default()
-                        }),
+                        },
                         &mut buf,
                     );
                     self.stats.udp_tx.on_sent(1, buf.len());
@@ -792,7 +792,7 @@ impl Connection {
                 if coalesce && buf.datagram_max_offset() - buf_end > MIN_PACKET_SPACE + tag_len {
                     // We can append/coalesce the next packet into the current
                     // datagram. Finish the current packet without adding extra padding.
-                    builder.finish_and_track(now, self, Some(sent_frames), &mut buf);
+                    builder.finish_and_track(now, self, sent_frames, &mut buf);
                 } else {
                     // We need a new datagram for the next packet.  Finish the current
                     // packet with padding.
@@ -826,7 +826,7 @@ impl Connection {
                                 "GSO truncated by demand for {} padding bytes or loss probe",
                                 buf.segment_size() - packet_len_unpadded
                             );
-                            builder.finish_and_track(now, self, Some(sent_frames), &mut buf);
+                            builder.finish_and_track(now, self, sent_frames, &mut buf);
                             break;
                         }
 
@@ -835,7 +835,7 @@ impl Connection {
                         builder.pad_to(buf.segment_size() as u16);
                     }
 
-                    builder.finish_and_track(now, self, Some(sent_frames), &mut buf);
+                    builder.finish_and_track(now, self, sent_frames, &mut buf);
 
                     if buf.num_datagrams() == 1 {
                         buf.clip_datagram_size();
@@ -865,7 +865,7 @@ impl Connection {
                 if pad_datagram {
                     builder.pad_to(MIN_INITIAL_SIZE);
                 }
-                builder.finish_and_track(now, self, Some(sent_frames), &mut buf);
+                builder.finish_and_track(now, self, sent_frames, &mut buf);
                 break;
             }
         }
@@ -910,7 +910,7 @@ impl Connection {
                 non_retransmits: true,
                 ..Default::default()
             };
-            builder.finish_and_track(now, self, Some(sent_frames), &mut buf);
+            builder.finish_and_track(now, self, sent_frames, &mut buf);
 
             self.stats.path.sent_plpmtud_probes += 1;
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -21,6 +21,7 @@ use crate::{
     cid_queue::CidQueue,
     coding::BufMutExt,
     config::{ServerConfig, TransportConfig},
+    congestion::Controller,
     crypto::{self, KeyPair, Keys, PacketKey},
     frame::{self, Close, Datagram, FrameStruct, NewToken},
     packet::{
@@ -85,8 +86,10 @@ pub use streams::{
 };
 
 mod timer;
-use crate::congestion::Controller;
 use timer::{Timer, TimerTable};
+
+mod transmit_buf;
+use transmit_buf::TransmitBuf;
 
 /// Protocol state and logic for a single QUIC connection
 ///
@@ -455,14 +458,9 @@ impl Connection {
             false => 1,
             true => max_datagrams,
         };
+        let mut buf = TransmitBuf::new(buf, max_datagrams, self.path.current_mtu().into());
 
-        let mut num_datagrams = 0;
-        // Position in `buf` of the first byte of the current UDP datagram. When coalescing QUIC
-        // packets, this can be earlier than the start of the current QUIC packet.
-        let mut datagram_start = 0;
-        let mut segment_size = usize::from(self.path.current_mtu());
-
-        if let Some(challenge) = self.send_path_challenge(now, buf) {
+        if let Some(challenge) = self.send_path_challenge(now, &mut buf) {
             return Some(challenge);
         }
 
@@ -500,11 +498,6 @@ impl Connection {
                 && self.peer_supports_ack_frequency();
         }
 
-        // Reserving capacity can provide more capacity than we asked for. However, we are not
-        // allowed to write more than `segment_size`. Therefore the maximum capacity is tracked
-        // separately.
-        let mut buf_capacity = 0;
-
         let mut coalesce = true;
         let mut builder_storage: Option<PacketBuilder> = None;
         let mut sent_frames = None;
@@ -525,8 +518,9 @@ impl Connection {
             // don't account for coalesced packets potentially occupying space because frames can
             // always spill into the next datagram.
             let pn = self.packet_number_filter.peek(&self.spaces[SpaceId::Data]);
-            let frame_space_1rtt =
-                segment_size.saturating_sub(self.predict_1rtt_overhead(Some(pn)));
+            let frame_space_1rtt = buf
+                .segment_size
+                .saturating_sub(self.predict_1rtt_overhead(Some(pn)));
 
             // Is there data or a close message to send in this space?
             let can_send = self.space_can_send(space_id, frame_space_1rtt);
@@ -560,11 +554,15 @@ impl Connection {
             } else {
                 unreachable!("tried to send {:?} packet without keys", space_id)
             };
-            if !coalesce || buf_capacity - buf_end < MIN_PACKET_SPACE + tag_len {
+
+            // We are NOT coalescing (the default is we are, so this was turned off in an
+            // earlier iteration) OR there is not enough space for another *packet* in this
+            // datagram (buf_capacity - buf_end == unused space in datagram).
+            if !coalesce || buf.buf_capacity - buf_end < MIN_PACKET_SPACE + tag_len {
                 // We need to send 1 more datagram and extend the buffer for that.
 
                 // Is 1 more datagram allowed?
-                if num_datagrams >= max_datagrams {
+                if buf.num_datagrams >= buf.max_datagrams {
                     // No more datagrams allowed
                     break;
                 }
@@ -577,7 +575,7 @@ impl Connection {
                 // (see https://github.com/quinn-rs/quinn/issues/1082)
                 if self
                     .path
-                    .anti_amplification_blocked(segment_size as u64 * (num_datagrams as u64) + 1)
+                    .anti_amplification_blocked((buf.segment_size * buf.num_datagrams) as u64 + 1)
                 {
                     trace!("blocked by anti-amplification");
                     break;
@@ -588,13 +586,13 @@ impl Connection {
                 if ack_eliciting && self.spaces[space_id].loss_probes == 0 {
                     // Assume the current packet will get padded to fill the segment
                     let untracked_bytes = if let Some(builder) = &builder_storage {
-                        buf_capacity - builder.partial_encode.start
+                        buf.buf_capacity - builder.partial_encode.start
                     } else {
                         0
                     } as u64;
-                    debug_assert!(untracked_bytes <= segment_size as u64);
+                    debug_assert!(untracked_bytes <= buf.segment_size as u64);
 
-                    let bytes_to_send = segment_size as u64 + untracked_bytes;
+                    let bytes_to_send = buf.segment_size as u64 + untracked_bytes;
                     if self.path.in_flight.bytes + bytes_to_send >= self.path.congestion.window() {
                         space_idx += 1;
                         congestion_blocked = true;
@@ -628,7 +626,7 @@ impl Connection {
                         builder.pad_to(MIN_INITIAL_SIZE);
                     }
 
-                    if num_datagrams > 1 {
+                    if buf.num_datagrams > 1 {
                         // If too many padding bytes would be required to continue the GSO batch
                         // after this packet, end the GSO batch here. Ensures that fixed-size frames
                         // with heterogeneous sizes (e.g. application datagrams) won't inadvertently
@@ -643,14 +641,14 @@ impl Connection {
                         // `buf_capacity` by less than `segment_size`.
                         const MAX_PADDING: usize = 16;
                         let packet_len_unpadded = cmp::max(builder.min_size, buf.len())
-                            - datagram_start
+                            - buf.datagram_start
                             + builder.tag_len;
-                        if packet_len_unpadded + MAX_PADDING < segment_size
-                            || datagram_start + segment_size > buf_capacity
+                        if packet_len_unpadded + MAX_PADDING < buf.segment_size
+                            || buf.datagram_start + buf.segment_size > buf.buf_capacity
                         {
                             trace!(
                                 "GSO truncated by demand for {} padding bytes or loss probe",
-                                segment_size - packet_len_unpadded
+                                buf.segment_size - packet_len_unpadded
                             );
                             builder_storage = Some(builder);
                             break;
@@ -658,22 +656,22 @@ impl Connection {
 
                         // Pad the current datagram to GSO segment size so it can be included in the
                         // GSO batch.
-                        builder.pad_to(segment_size as u16);
+                        builder.pad_to(buf.segment_size as u16);
                     }
 
-                    builder.finish_and_track(now, self, sent_frames.take(), buf);
+                    builder.finish_and_track(now, self, sent_frames.take(), buf.buf);
 
-                    if num_datagrams == 1 {
+                    if buf.num_datagrams == 1 {
                         // Set the segment size for this GSO batch to the size of the first UDP
                         // datagram in the batch. Larger data that cannot be fragmented
                         // (e.g. application datagrams) will be included in a future batch. When
                         // sending large enough volumes of data for GSO to be useful, we expect
                         // packet sizes to usually be consistent, e.g. populated by max-size STREAM
                         // frames or uniformly sized datagrams.
-                        segment_size = buf.len();
+                        buf.segment_size = buf.len();
                         // Clip the unused capacity out of the buffer so future packets don't
                         // overrun
-                        buf_capacity = buf.len();
+                        buf.buf_capacity = buf.len();
 
                         // Check whether the data we planned to send will fit in the reduced segment
                         // size. If not, bail out and leave it for the next GSO batch so we don't
@@ -682,8 +680,9 @@ impl Connection {
                         // that time we haven't determined whether we're going to coalesce with the
                         // first datagram or potentially pad it to `MIN_INITIAL_SIZE`.
                         if space_id == SpaceId::Data {
-                            let frame_space_1rtt =
-                                segment_size.saturating_sub(self.predict_1rtt_overhead(Some(pn)));
+                            let frame_space_1rtt = buf
+                                .segment_size
+                                .saturating_sub(self.predict_1rtt_overhead(Some(pn)));
                             if self.space_can_send(space_id, frame_space_1rtt).is_empty() {
                                 break;
                             }
@@ -693,17 +692,17 @@ impl Connection {
 
                 // Allocate space for another datagram
                 let next_datagram_size_limit = match self.spaces[space_id].loss_probes {
-                    0 => segment_size,
+                    0 => buf.segment_size,
                     _ => {
                         self.spaces[space_id].loss_probes -= 1;
                         // Clamp the datagram to at most the minimum MTU to ensure that loss probes
                         // can get through and enable recovery even if the path MTU has shrank
                         // unexpectedly.
-                        std::cmp::min(segment_size, usize::from(INITIAL_MTU))
+                        std::cmp::min(buf.segment_size, usize::from(INITIAL_MTU))
                     }
                 };
-                buf_capacity += next_datagram_size_limit;
-                if buf.capacity() < buf_capacity {
+                buf.buf_capacity += next_datagram_size_limit;
+                if buf.buf.capacity() < buf.buf_capacity {
                     // We reserve the maximum space for sending `max_datagrams` upfront
                     // to avoid any reallocations if more datagrams have to be appended later on.
                     // Benchmarks have shown shown a 5-10% throughput improvement
@@ -712,15 +711,15 @@ impl Connection {
                     // (e.g. purely containing ACKs), modern memory allocators
                     // (e.g. mimalloc and jemalloc) will pool certain allocation sizes
                     // and therefore this is still rather efficient.
-                    buf.reserve(max_datagrams * segment_size);
+                    buf.buf.reserve(buf.max_datagrams * buf.segment_size);
                 }
-                num_datagrams += 1;
+                buf.num_datagrams += 1;
                 coalesce = true;
                 pad_datagram = false;
-                datagram_start = buf.len();
+                buf.datagram_start = buf.len();
 
                 debug_assert_eq!(
-                    datagram_start % segment_size,
+                    buf.datagram_start % buf.segment_size,
                     0,
                     "datagrams in a GSO batch must be aligned to the segment size"
                 );
@@ -729,11 +728,11 @@ impl Connection {
                 // datagram.
                 // Finish current packet without adding extra padding
                 if let Some(builder) = builder_storage.take() {
-                    builder.finish_and_track(now, self, sent_frames.take(), buf);
+                    builder.finish_and_track(now, self, sent_frames.take(), buf.buf);
                 }
             }
 
-            debug_assert!(buf_capacity - buf.len() >= MIN_PACKET_SPACE);
+            debug_assert!(buf.buf_capacity - buf.len() >= MIN_PACKET_SPACE);
 
             //
             // From here on, we've determined that a packet will definitely be sent.
@@ -760,9 +759,9 @@ impl Connection {
                 now,
                 space_id,
                 self.rem_cids.active(),
-                buf,
-                buf_capacity,
-                datagram_start,
+                buf.buf,
+                buf.buf_capacity,
+                buf.datagram_start,
                 ack_eliciting,
                 self,
             )?);
@@ -784,7 +783,7 @@ impl Connection {
                         self.receiving_ecn,
                         &mut SentFrames::default(),
                         &mut self.spaces[space_id],
-                        buf,
+                        buf.buf,
                         &mut self.stats,
                     );
                 }
@@ -801,14 +800,14 @@ impl Connection {
                     match self.state {
                         State::Closed(state::Closed { ref reason }) => {
                             if space_id == SpaceId::Data || reason.is_transport_layer() {
-                                reason.encode(buf, max_frame_size)
+                                reason.encode(&mut buf, max_frame_size)
                             } else {
                                 frame::ConnectionClose {
                                     error_code: TransportErrorCode::APPLICATION_ERROR,
                                     frame_type: None,
                                     reason: Bytes::new(),
                                 }
-                                .encode(buf, max_frame_size)
+                                .encode(&mut buf, max_frame_size)
                             }
                         }
                         State::Draining => frame::ConnectionClose {
@@ -816,7 +815,7 @@ impl Connection {
                             frame_type: None,
                             reason: Bytes::new(),
                         }
-                        .encode(buf, max_frame_size),
+                        .encode(&mut buf, max_frame_size),
                         _ => unreachable!(
                             "tried to make a close packet when the connection wasn't closed"
                         ),
@@ -838,7 +837,7 @@ impl Connection {
 
             // Send an off-path PATH_RESPONSE. Prioritized over on-path data to ensure that path
             // validation can occur while the link is saturated.
-            if space_id == SpaceId::Data && num_datagrams == 1 {
+            if space_id == SpaceId::Data && buf.num_datagrams == 1 {
                 if let Some((token, remote)) = self.path_responses.pop_off_path(self.path.remote) {
                     // `unwrap` guaranteed to succeed because `builder_storage` was populated just
                     // above.
@@ -855,7 +854,7 @@ impl Connection {
                             non_retransmits: true,
                             ..SentFrames::default()
                         }),
-                        buf,
+                        buf.buf,
                     );
                     self.stats.udp_tx.on_sent(1, buf.len());
                     return Some(Transmit {
@@ -868,8 +867,13 @@ impl Connection {
                 }
             }
 
-            let sent =
-                self.populate_packet(now, space_id, buf, builder.max_size, builder.exact_number);
+            let sent = self.populate_packet(
+                now,
+                space_id,
+                buf.buf,
+                builder.max_size,
+                builder.exact_number,
+            );
 
             // ACK-only packets should only be sent when explicitly allowed. If we write them due to
             // any other reason, there is a bug which leads to one component announcing write
@@ -881,7 +885,8 @@ impl Connection {
                 !(sent.is_ack_only(&self.streams)
                     && !can_send.acks
                     && can_send.other
-                    && (buf_capacity - builder.datagram_start) == self.path.current_mtu() as usize
+                    && (buf.buf_capacity - builder.datagram_start)
+                        == self.path.current_mtu() as usize
                     && self.datagrams.outgoing.is_empty()),
                 "SendableFrames was {can_send:?}, but only ACKs have been written"
             );
@@ -905,7 +910,7 @@ impl Connection {
                 builder.pad_to(MIN_INITIAL_SIZE);
             }
             let last_packet_number = builder.exact_number;
-            builder.finish_and_track(now, self, sent_frames, buf);
+            builder.finish_and_track(now, self, sent_frames, buf.buf);
             self.path
                 .congestion
                 .on_sent(now, buf.len() as u64, last_packet_number);
@@ -921,15 +926,15 @@ impl Connection {
                 .mtud
                 .poll_transmit(now, self.packet_number_filter.peek(&self.spaces[space_id]))?;
 
-            let buf_capacity = probe_size as usize;
-            buf.reserve(buf_capacity);
+            buf.buf_capacity = probe_size as usize;
+            buf.buf.reserve(buf.buf_capacity);
 
             let mut builder = PacketBuilder::new(
                 now,
                 space_id,
                 self.rem_cids.active(),
-                buf,
-                buf_capacity,
+                buf.buf,
+                buf.buf_capacity,
                 0,
                 true,
                 self,
@@ -950,10 +955,10 @@ impl Connection {
                 non_retransmits: true,
                 ..Default::default()
             };
-            builder.finish_and_track(now, self, Some(sent_frames), buf);
+            builder.finish_and_track(now, self, Some(sent_frames), buf.buf);
 
             self.stats.path.sent_plpmtud_probes += 1;
-            num_datagrams = 1;
+            buf.num_datagrams = 1;
 
             trace!(?probe_size, "writing MTUD probe");
         }
@@ -962,10 +967,16 @@ impl Connection {
             return None;
         }
 
-        trace!("sending {} bytes in {} datagrams", buf.len(), num_datagrams);
+        trace!(
+            "sending {} bytes in {} datagrams",
+            buf.len(),
+            buf.num_datagrams
+        );
         self.path.total_sent = self.path.total_sent.saturating_add(buf.len() as u64);
 
-        self.stats.udp_tx.on_sent(num_datagrams as u64, buf.len());
+        self.stats
+            .udp_tx
+            .on_sent(buf.num_datagrams as u64, buf.len());
 
         Some(Transmit {
             destination: self.path.remote,
@@ -975,16 +986,16 @@ impl Connection {
             } else {
                 None
             },
-            segment_size: match num_datagrams {
+            segment_size: match buf.num_datagrams {
                 1 => None,
-                _ => Some(segment_size),
+                _ => Some(buf.segment_size),
             },
             src_ip: self.local_ip,
         })
     }
 
     /// Send PATH_CHALLENGE for a previous path if necessary
-    fn send_path_challenge(&mut self, now: Instant, buf: &mut Vec<u8>) -> Option<Transmit> {
+    fn send_path_challenge(&mut self, now: Instant, buf: &mut TransmitBuf<'_>) -> Option<Transmit> {
         let (prev_cid, prev_path) = self.prev_path.as_mut()?;
         if !prev_path.challenge_pending {
             return None;
@@ -999,9 +1010,9 @@ impl Connection {
             SpaceId::Data,
             "PATH_CHALLENGE queued without 1-RTT keys"
         );
-        buf.reserve(MIN_INITIAL_SIZE as usize);
+        buf.buf.reserve(MIN_INITIAL_SIZE as usize);
 
-        let buf_capacity = buf.capacity();
+        let buf_capacity = buf.buf.capacity();
 
         // Use the previous CID to avoid linking the new path with the previous path. We
         // don't bother accounting for possible retirement of that prev_cid because this is
@@ -1012,7 +1023,7 @@ impl Connection {
             now,
             SpaceId::Data,
             *prev_cid,
-            buf,
+            buf.buf,
             buf_capacity,
             0,
             false,
@@ -1029,7 +1040,7 @@ impl Connection {
         // sending a datagram of this size
         builder.pad_to(MIN_INITIAL_SIZE);
 
-        builder.finish(self, buf);
+        builder.finish(self, buf.buf);
         self.stats.udp_tx.on_sent(1, buf.len());
 
         Some(Transmit {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -755,8 +755,7 @@ impl Connection {
                     !(sent_frames.is_ack_only(&self.streams)
                         && !can_send.acks
                         && can_send.other
-                        && (builder.buf.datagram_max_offset() - builder.datagram_start)
-                            == self.path.current_mtu() as usize
+                        && builder.buf.segment_size() == self.path.current_mtu() as usize
                         && self.datagrams.outgoing.is_empty()),
                     "SendableFrames was {can_send:?}, but only ACKs have been written"
                 );

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -20,7 +20,6 @@ use crate::{
 /// implements [`BufMut`] to write frames into the packet.
 pub(super) struct PacketBuilder<'a, 'b> {
     pub(super) buf: &'a mut TransmitBuf<'b>,
-    pub(super) datagram_start: usize,
     pub(super) space: SpaceId,
     pub(super) partial_encode: PartialEncode,
     pub(super) ack_eliciting: bool,
@@ -165,10 +164,8 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
         let max_size = buffer.datagram_max_offset() - tag_len;
         debug_assert!(max_size >= min_size);
 
-        let datagram_start = buffer.datagram_start_offset();
         Some(Self {
             buf: buffer,
-            datagram_start,
             space: space_id,
             partial_encode,
             exact_number,
@@ -189,7 +186,7 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
         // already.
         self.min_size = Ord::max(
             self.min_size,
-            self.datagram_start + (min_size as usize) - self.tag_len,
+            self.buf.datagram_start_offset() + (min_size as usize) - self.tag_len,
         );
     }
 

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -182,17 +182,13 @@ impl PacketBuilder {
         self,
         now: Instant,
         conn: &mut Connection,
-        sent: Option<SentFrames>,
+        sent: SentFrames,
         buffer: &mut TransmitBuf<'_>,
     ) {
         let ack_eliciting = self.ack_eliciting;
         let exact_number = self.exact_number;
         let space_id = self.space;
         let (size, padded) = self.finish(conn, buffer);
-        let sent = match sent {
-            Some(sent) => sent,
-            None => return,
-        };
 
         let size = match padded || ack_eliciting {
             true => size as u16,

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -1,4 +1,4 @@
-use bytes::Bytes;
+use bytes::{BufMut, Bytes};
 use rand::Rng;
 use tracing::{trace, trace_span};
 
@@ -120,9 +120,9 @@ impl PacketBuilder {
                 version,
             }),
         };
-        let partial_encode = header.encode(buffer.buf);
+        let partial_encode = header.encode(buffer);
         if conn.peer_params.grease_quic_bit && conn.rng.random() {
-            buffer.buf[partial_encode.start] ^= FIXED_BIT;
+            buffer.as_mut_slice()[partial_encode.start] ^= FIXED_BIT;
         }
 
         let (sample_size, tag_len) = if let Some(ref crypto) = space.crypto {
@@ -183,7 +183,7 @@ impl PacketBuilder {
         now: Instant,
         conn: &mut Connection,
         sent: Option<SentFrames>,
-        buffer: &mut Vec<u8>,
+        buffer: &mut TransmitBuf<'_>,
     ) {
         let ack_eliciting = self.ack_eliciting;
         let exact_number = self.exact_number;
@@ -226,11 +226,15 @@ impl PacketBuilder {
     }
 
     /// Encrypt packet, returning the length of the packet and whether padding was added
-    pub(super) fn finish(self, conn: &mut Connection, buffer: &mut Vec<u8>) -> (usize, bool) {
+    pub(super) fn finish(
+        self,
+        conn: &mut Connection,
+        buffer: &mut TransmitBuf<'_>,
+    ) -> (usize, bool) {
         let pad = buffer.len() < self.min_size;
         if pad {
             trace!("PADDING * {}", self.min_size - buffer.len());
-            buffer.resize(self.min_size, 0);
+            buffer.put_bytes(0, self.min_size - buffer.len());
         }
 
         let space = &conn.spaces[self.space];
@@ -249,9 +253,9 @@ impl PacketBuilder {
             "Mismatching crypto tag len"
         );
 
-        buffer.resize(buffer.len() + packet_crypto.tag_len(), 0);
+        buffer.put_bytes(0, packet_crypto.tag_len());
         let encode_start = self.partial_encode.start;
-        let packet_buf = &mut buffer[encode_start..];
+        let packet_buf = &mut buffer.as_mut_slice()[encode_start..];
         self.partial_encode.finish(
             packet_buf,
             header_crypto,

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use rand::Rng;
 use tracing::{trace, trace_span};
 
-use super::{Connection, SentFrames, spaces::SentPacket};
+use super::{Connection, SentFrames, TransmitBuf, spaces::SentPacket};
 use crate::{
     ConnectionId, Instant, TransportError, TransportErrorCode,
     connection::ConnectionSide,
@@ -36,9 +36,7 @@ impl PacketBuilder {
         now: Instant,
         space_id: SpaceId,
         dst_cid: ConnectionId,
-        buffer: &mut Vec<u8>,
-        buffer_capacity: usize,
-        datagram_start: usize,
+        buffer: &mut TransmitBuf<'_>,
         ack_eliciting: bool,
         conn: &mut Connection,
     ) -> Option<Self> {
@@ -122,9 +120,9 @@ impl PacketBuilder {
                 version,
             }),
         };
-        let partial_encode = header.encode(buffer);
+        let partial_encode = header.encode(buffer.buf);
         if conn.peer_params.grease_quic_bit && conn.rng.random() {
-            buffer[partial_encode.start] ^= FIXED_BIT;
+            buffer.buf[partial_encode.start] ^= FIXED_BIT;
         }
 
         let (sample_size, tag_len) = if let Some(ref crypto) = space.crypto {
@@ -151,11 +149,11 @@ impl PacketBuilder {
             buffer.len() + (sample_size + 4).saturating_sub(number.len() + tag_len),
             partial_encode.start + dst_cid.len() + 6,
         );
-        let max_size = buffer_capacity - tag_len;
+        let max_size = buffer.buf_capacity - tag_len;
         debug_assert!(max_size >= min_size);
 
         Some(Self {
-            datagram_start,
+            datagram_start: buffer.datagram_start,
             space: space_id,
             partial_encode,
             exact_number,

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -149,11 +149,11 @@ impl PacketBuilder {
             buffer.len() + (sample_size + 4).saturating_sub(number.len() + tag_len),
             partial_encode.start + dst_cid.len() + 6,
         );
-        let max_size = buffer.buf_capacity - tag_len;
+        let max_size = buffer.datagram_max_offset() - tag_len;
         debug_assert!(max_size >= min_size);
 
         Some(Self {
-            datagram_start: buffer.datagram_start,
+            datagram_start: buffer.datagram_start_offset(),
             space: space_id,
             partial_encode,
             exact_number,

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -268,15 +268,17 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
             Some((self.exact_number, packet_crypto)),
         );
 
-        (self.buf.len() - encode_start, pad)
+        let packet_len = self.buf.len() - encode_start;
+        trace!(size = %packet_len, short_header = %self.short_header, "wrote packet");
+        (packet_len, pad)
     }
 
-    /// Predicts the size of the packet if it were finished now without additional padding
+    /// The number of additional bytes the current packet would take up if it was finished now
     ///
     /// This will include any padding which is required to make the size large enough to be
     /// encrypted correctly.
-    pub(super) fn predict_packet_size(&self) -> usize {
-        self.buf.len().max(self.min_size) - self.buf.datagram_start_offset() + self.tag_len
+    pub(super) fn predict_packet_end(&self) -> usize {
+        self.buf.len().max(self.min_size) + self.tag_len - self.buf.len()
     }
 
     /// Returns the remaining space in the packet that can be taken up by QUIC frames

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -29,8 +29,9 @@ pub(super) struct PacketBuilder<'a, 'b> {
     /// Smallest absolute position in the associated buffer that must be occupied by this packet's
     /// frames
     pub(super) min_size: usize,
-    /// Largest absolute position in the associated buffer that may be occupied by this packet's
-    /// frames
+    /// Largest absolute position in the buffer that may be occupied by this packet's frames
+    ///
+    /// This takes the size of the cryptographic tag into account.
     pub(super) max_size: usize,
     pub(super) tag_len: usize,
     pub(super) _span: tracing::span::EnteredSpan,
@@ -192,6 +193,15 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
         );
     }
 
+    /// Returns a writable buffer limited to the remaining frame space
+    ///
+    /// The [`BufMut::remaining_mut`] call on the returned buffer indicates the amount of
+    /// space available to write QUIC frames into.
+    // In rust 1.82 we can use `-> impl BufMut + use<'_, 'a, 'b>`
+    pub(super) fn frame_space_mut(&mut self) -> bytes::buf::Limit<&mut Self> {
+        self.limit(self.frame_space_remaining())
+    }
+
     pub(super) fn finish_and_track(self, now: Instant, conn: &mut Connection, sent: SentFrames) {
         let ack_eliciting = self.ack_eliciting;
         let exact_number = self.exact_number;
@@ -231,6 +241,10 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
 
     /// Encrypt packet, returning the length of the packet and whether padding was added
     pub(super) fn finish(self, conn: &mut Connection) -> (usize, bool) {
+        debug_assert!(
+            self.buf.len() <= self.max_size,
+            "packet exceeds maximum size"
+        );
         let pad = self.buf.len() < self.min_size;
         if pad {
             trace!("PADDING * {}", self.min_size - self.buf.len());
@@ -263,6 +277,15 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
         );
 
         (self.buf.len() - encode_start, pad)
+    }
+
+    /// Returns the remaining space in the packet that can be taken up by QUIC frames
+    ///
+    /// This leaves space in the datagram for the cryptographic tag that needs to be written
+    /// when the packet is finished.
+    pub(super) fn frame_space_remaining(&self) -> usize {
+        debug_assert!(self.max_size >= self.buf.len(), "packet exceeds bounds");
+        self.max_size.saturating_sub(self.buf.len())
     }
 }
 

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -2,7 +2,7 @@ use bytes::{BufMut, Bytes};
 use rand::Rng;
 use tracing::{trace, trace_span};
 
-use super::{BufLen, Connection, SentFrames, TransmitBuf, spaces::SentPacket};
+use super::{Connection, SentFrames, TransmitBuf, spaces::SentPacket};
 use crate::{
     ConnectionId, Instant, TransportError, TransportErrorCode,
     connection::ConnectionSide,
@@ -198,8 +198,8 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
     /// The [`BufMut::remaining_mut`] call on the returned buffer indicates the amount of
     /// space available to write QUIC frames into.
     // In rust 1.82 we can use `-> impl BufMut + use<'_, 'a, 'b>`
-    pub(super) fn frame_space_mut(&mut self) -> bytes::buf::Limit<&mut Self> {
-        self.limit(self.frame_space_remaining())
+    pub(super) fn frame_space_mut(&mut self) -> bytes::buf::Limit<&mut TransmitBuf<'b>> {
+        self.buf.limit(self.frame_space_remaining())
     }
 
     pub(super) fn finish_and_track(self, now: Instant, conn: &mut Connection, sent: SentFrames) {
@@ -279,6 +279,14 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
         (self.buf.len() - encode_start, pad)
     }
 
+    /// Predicts the size of the packet if it were finished now without additional padding
+    ///
+    /// This will include any padding which is required to make the size large enough to be
+    /// encrypted correctly.
+    pub(super) fn predict_packet_size(&self) -> usize {
+        self.buf.len().max(self.min_size) - self.buf.datagram_start_offset() + self.tag_len
+    }
+
     /// Returns the remaining space in the packet that can be taken up by QUIC frames
     ///
     /// This leaves space in the datagram for the cryptographic tag that needs to be written
@@ -286,25 +294,5 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
     pub(super) fn frame_space_remaining(&self) -> usize {
         debug_assert!(self.max_size >= self.buf.len(), "packet exceeds bounds");
         self.max_size.saturating_sub(self.buf.len())
-    }
-}
-
-unsafe impl BufMut for PacketBuilder<'_, '_> {
-    fn remaining_mut(&self) -> usize {
-        self.buf.remaining_mut()
-    }
-
-    unsafe fn advance_mut(&mut self, cnt: usize) {
-        self.buf.advance_mut(cnt);
-    }
-
-    fn chunk_mut(&mut self) -> &mut bytes::buf::UninitSlice {
-        self.buf.chunk_mut()
-    }
-}
-
-impl BufLen for PacketBuilder<'_, '_> {
-    fn len(&self) -> usize {
-        self.buf.len()
     }
 }

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -15,7 +15,7 @@ use super::{
 use crate::{
     Dir, MAX_STREAM_COUNT, Side, StreamId, TransportError, VarInt,
     coding::BufMutExt,
-    connection::{BufLen, stats::FrameStats},
+    connection::stats::FrameStats,
     frame::{self, FrameStruct, StreamMetaVec},
     transport_parameters::TransportParameters,
 };
@@ -411,14 +411,13 @@ impl StreamsState {
 
     pub(in crate::connection) fn write_control_frames(
         &mut self,
-        buf: &mut (impl BufMut + BufLen),
+        buf: &mut impl BufMut,
         pending: &mut Retransmits,
         retransmits: &mut ThinRetransmits,
         stats: &mut FrameStats,
-        max_size: usize,
     ) {
         // RESET_STREAM
-        while buf.len() + frame::ResetStream::SIZE_BOUND < max_size {
+        while buf.remaining_mut() > frame::ResetStream::SIZE_BOUND {
             let (id, error_code) = match pending.reset_stream.pop() {
                 Some(x) => x,
                 None => break,
@@ -442,7 +441,7 @@ impl StreamsState {
         }
 
         // STOP_SENDING
-        while buf.len() + frame::StopSending::SIZE_BOUND < max_size {
+        while buf.remaining_mut() > frame::StopSending::SIZE_BOUND {
             let frame = match pending.stop_sending.pop() {
                 Some(x) => x,
                 None => break,
@@ -461,7 +460,7 @@ impl StreamsState {
         }
 
         // MAX_DATA
-        if pending.max_data && buf.len() + 9 < max_size {
+        if pending.max_data && buf.remaining_mut() > 9 {
             pending.max_data = false;
 
             // `local_max_data` can grow bigger than `VarInt`.
@@ -484,7 +483,7 @@ impl StreamsState {
         }
 
         // MAX_STREAM_DATA
-        while buf.len() + 17 < max_size {
+        while buf.remaining_mut() > 17 {
             let id = match pending.max_stream_data.iter().next() {
                 Some(x) => *x,
                 None => break,
@@ -516,7 +515,7 @@ impl StreamsState {
 
         // MAX_STREAMS
         for dir in Dir::iter() {
-            if !pending.max_stream_id[dir as usize] || buf.len() + 9 >= max_size {
+            if !pending.max_stream_id[dir as usize] || buf.remaining_mut() <= 9 {
                 continue;
             }
 
@@ -541,21 +540,14 @@ impl StreamsState {
 
     pub(crate) fn write_stream_frames(
         &mut self,
-        buf: &mut (impl BufMut + BufLen),
-        max_buf_size: usize,
+        buf: &mut impl BufMut,
         fair: bool,
     ) -> StreamMetaVec {
         let mut stream_frames = StreamMetaVec::new();
-        while buf.len() + frame::Stream::SIZE_BOUND < max_buf_size {
-            if max_buf_size
-                .checked_sub(buf.len() + frame::Stream::SIZE_BOUND)
-                .is_none()
-            {
-                break;
-            }
-
-            // Pop the stream of the highest priority that currently has pending data
-            // If the stream still has some pending data left after writing, it will be reinserted, otherwise not
+        while buf.remaining_mut() > frame::Stream::SIZE_BOUND {
+            // Pop the stream of the highest priority that currently has pending data. If
+            // the stream still has some pending data left after writing, it will be
+            // reinserted, otherwise not
             let Some(stream) = self.pending.pop() else {
                 break;
             };
@@ -577,7 +569,7 @@ impl StreamsState {
 
             // Now that we know the `StreamId`, we can better account for how many bytes
             // are required to encode it.
-            let max_buf_size = max_buf_size - buf.len() - 1 - VarInt::size(id.into());
+            let max_buf_size = buf.remaining_mut() - 1 - VarInt::size(id.into());
             let (offsets, encode_length) = stream.pending.poll_transmit(max_buf_size);
             let fin = offsets.end == stream.pending.offset()
                 && matches!(stream.state, SendState::DataSent { .. });
@@ -1380,7 +1372,7 @@ mod tests {
         high.write(b"high").unwrap();
 
         let mut buf = Vec::with_capacity(40);
-        let meta = server.write_stream_frames(&mut buf, 40, true);
+        let meta = server.write_stream_frames(&mut buf, true);
         assert_eq!(meta[0].id, id_high);
         assert_eq!(meta[1].id, id_mid);
         assert_eq!(meta[2].id, id_low);
@@ -1438,16 +1430,18 @@ mod tests {
         };
         high.set_priority(-1).unwrap();
 
-        let mut buf = Vec::with_capacity(1000);
-        let meta = server.write_stream_frames(&mut buf, 40, true);
+        let mut buf = Vec::with_capacity(1000).limit(40);
+        let meta = server.write_stream_frames(&mut buf, true);
         assert_eq!(meta.len(), 1);
         assert_eq!(meta[0].id, id_high);
 
         // After requeuing we should end up with 2 priorities - not 3
         assert_eq!(server.pending.len(), 2);
 
+        let mut buf = buf.into_inner();
+
         // Send the remaining data. The initial mid priority one should go first now
-        let meta = server.write_stream_frames(&mut buf, 1000, true);
+        let meta = server.write_stream_frames(&mut buf, true);
         assert_eq!(meta.len(), 2);
         assert_eq!(meta[0].id, id_mid);
         assert_eq!(meta[1].id, id_high);
@@ -1507,12 +1501,13 @@ mod tests {
 
             // loop until all the streams are written
             loop {
-                let buf_len = buf.len();
-                let meta = server.write_stream_frames(&mut buf, buf_len + 40, fair);
+                let mut chunk_buf = buf.limit(40);
+                let meta = server.write_stream_frames(&mut chunk_buf, fair);
                 if meta.is_empty() {
                     break;
                 }
                 metas.extend(meta);
+                buf = chunk_buf.into_inner();
             }
 
             assert!(!server.can_send_stream_data());
@@ -1575,11 +1570,12 @@ mod tests {
         stream_b.write(&[b'b'; 100]).unwrap();
 
         let mut metas = vec![];
-        let mut buf = Vec::with_capacity(1024);
+        let buf = Vec::with_capacity(1024);
 
         // Write the first chunk of stream_a
-        let buf_len = buf.len();
-        let meta = server.write_stream_frames(&mut buf, buf_len + 40, false);
+        let mut chunk_buf = buf.limit(40);
+        let meta = server.write_stream_frames(&mut chunk_buf, false);
+        let mut buf = chunk_buf.into_inner();
         assert!(!meta.is_empty());
         metas.extend(meta);
 
@@ -1595,8 +1591,9 @@ mod tests {
 
         // loop until all the streams are written
         loop {
-            let buf_len = buf.len();
-            let meta = server.write_stream_frames(&mut buf, buf_len + 40, false);
+            let mut chunk_buf = buf.limit(40);
+            let meta = server.write_stream_frames(&mut chunk_buf, false);
+            buf = chunk_buf.into_inner();
             if meta.is_empty() {
                 break;
             }

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -15,7 +15,7 @@ use super::{
 use crate::{
     Dir, MAX_STREAM_COUNT, Side, StreamId, TransportError, VarInt,
     coding::BufMutExt,
-    connection::stats::FrameStats,
+    connection::{BufLen, stats::FrameStats},
     frame::{self, FrameStruct, StreamMetaVec},
     transport_parameters::TransportParameters,
 };
@@ -411,7 +411,7 @@ impl StreamsState {
 
     pub(in crate::connection) fn write_control_frames(
         &mut self,
-        buf: &mut Vec<u8>,
+        buf: &mut (impl BufMut + BufLen),
         pending: &mut Retransmits,
         retransmits: &mut ThinRetransmits,
         stats: &mut FrameStats,
@@ -541,7 +541,7 @@ impl StreamsState {
 
     pub(crate) fn write_stream_frames(
         &mut self,
-        buf: &mut Vec<u8>,
+        buf: &mut (impl BufMut + BufLen),
         max_buf_size: usize,
         fair: bool,
     ) -> StreamMetaVec {

--- a/quinn-proto/src/connection/transmit_buf.rs
+++ b/quinn-proto/src/connection/transmit_buf.rs
@@ -1,5 +1,7 @@
 use bytes::BufMut;
 
+use super::BufLen;
+
 /// The buffer in which to write datagrams for [`Connection::poll_transmit`]
 ///
 /// The `poll_transmit` function writes zero or more datagrams to a buffer. Multiple
@@ -198,5 +200,11 @@ unsafe impl BufMut for TransmitBuf<'_> {
 
     fn chunk_mut(&mut self) -> &mut bytes::buf::UninitSlice {
         self.buf.chunk_mut()
+    }
+}
+
+impl BufLen for TransmitBuf<'_> {
+    fn len(&self) -> usize {
+        self.len()
     }
 }

--- a/quinn-proto/src/connection/transmit_buf.rs
+++ b/quinn-proto/src/connection/transmit_buf.rs
@@ -27,7 +27,7 @@ use super::BufLen;
 #[derive(Debug)]
 pub(super) struct TransmitBuf<'a> {
     /// The buffer itself, packets are written to this buffer
-    pub(super) buf: &'a mut Vec<u8>,
+    buf: &'a mut Vec<u8>,
     /// Offset into the buffer at which the current datagram starts
     ///
     /// Note that when coalescing packets this might be before the start of the current
@@ -186,6 +186,11 @@ impl<'a> TransmitBuf<'a> {
     /// The number of bytes written into the buffer so far
     pub(super) fn len(&self) -> usize {
         self.buf.len()
+    }
+
+    /// Returns the already written bytes in the buffer
+    pub(super) fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.buf.as_mut_slice()
     }
 }
 

--- a/quinn-proto/src/connection/transmit_buf.rs
+++ b/quinn-proto/src/connection/transmit_buf.rs
@@ -1,0 +1,91 @@
+use bytes::BufMut;
+
+/// The buffer in which to write datagrams for [`Connection::poll_transmit`]
+///
+/// The `poll_transmit` function writes zero or more datagrams to a buffer. Multiple
+/// datagrams are possible in case GSO (Generic Segmentation Offload) is supported.
+///
+/// This buffer tracks datagrams being written to it. There is always a "current" datagram,
+/// which is started by calling [`TransmitBuf::start_new_datagram`]. Writing to the buffer
+/// is done through the [`BufMut`] interface.
+///
+/// Usually a datagram contains one QUIC packet, though QUIC-TRANSPORT 12.2 Coalescing
+/// Packets allows for placing multiple packets into a single datagram provided all but the
+/// last packet uses long headers. This is normally used during connection setup where often
+/// the initial, handshake and sometimes even a 1-RTT packet can be coalesced into a single
+/// datagram.
+///
+/// Inside a single packet multiple QUIC frames are written.
+///
+/// The buffer managed here is passed straight to the OS' `sendmsg` call (or variant) once
+/// `poll_transmit` returns.  So needs to contain the datagrams as they are sent on the
+/// wire.
+///
+/// [`Connection::poll_transmit`]: super::Connection::poll_transmit
+#[derive(Debug)]
+pub(super) struct TransmitBuf<'a> {
+    /// The buffer itself, packets are written to this buffer
+    pub(super) buf: &'a mut Vec<u8>,
+    /// Offset into the buffer at which the current datagram starts
+    ///
+    /// Note that when coalescing packets this might be before the start of the current
+    /// packet.
+    pub(super) datagram_start: usize,
+    /// The maximum offset allowed to be used for the current datagram in the buffer
+    ///
+    /// The first and last datagram in a batch are allowed to be smaller then the maximum
+    /// size. All datagrams in between need to be exactly this size.
+    pub(super) buf_capacity: usize,
+    /// The maximum number of datagrams allowed to write into [`TransmitBuf::buf`]
+    pub(super) max_datagrams: usize,
+    /// The number of datagrams already (partially) written into the buffer
+    ///
+    /// Incremented by a call to [`TransmitBuf::start_new_datagram`].
+    pub(super) num_datagrams: usize,
+    /// The segment size of this GSO batch
+    ///
+    /// The segment size is the size of each datagram in the GSO batch, only the last
+    /// datagram in the batch may be smaller.
+    ///
+    /// For the first datagram this is set to the maximum size a datagram is allowed to be:
+    /// the current path MTU. After the first datagram is finished this is reduced to the
+    /// size of the first datagram and can no longer change.
+    pub(super) segment_size: usize,
+}
+
+impl<'a> TransmitBuf<'a> {
+    pub(super) fn new(buf: &'a mut Vec<u8>, max_datagrams: usize, mtu: usize) -> Self {
+        Self {
+            buf,
+            datagram_start: 0,
+            buf_capacity: 0,
+            max_datagrams,
+            num_datagrams: 0,
+            segment_size: mtu,
+        }
+    }
+
+    /// Returns `true` if the buffer did not have anything written into it
+    pub(super) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The number of bytes written into the buffer so far
+    pub(super) fn len(&self) -> usize {
+        self.buf.len()
+    }
+}
+
+unsafe impl BufMut for TransmitBuf<'_> {
+    fn remaining_mut(&self) -> usize {
+        self.buf.remaining_mut()
+    }
+
+    unsafe fn advance_mut(&mut self, cnt: usize) {
+        self.buf.advance_mut(cnt);
+    }
+
+    fn chunk_mut(&mut self) -> &mut bytes::buf::UninitSlice {
+        self.buf.chunk_mut()
+    }
+}

--- a/quinn-proto/src/connection/transmit_buf.rs
+++ b/quinn-proto/src/connection/transmit_buf.rs
@@ -1,6 +1,6 @@
 use bytes::BufMut;
 
-use super::BufLen;
+use crate::packet::BufLen;
 
 /// The buffer in which to write datagrams for [`Connection::poll_transmit`]
 ///

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -899,13 +899,13 @@ impl FrameStruct for Datagram {
 }
 
 impl Datagram {
-    pub(crate) fn encode(&self, length: bool, out: &mut Vec<u8>) {
+    pub(crate) fn encode(&self, length: bool, out: &mut impl BufMut) {
         out.write(FrameType(*DATAGRAM_TYS.start() | u64::from(length))); // 1 byte
         if length {
             // Safe to unwrap because we check length sanity before queueing datagrams
             out.write(VarInt::from_u64(self.data.len() as u64).unwrap()); // <= 8 bytes
         }
-        out.extend_from_slice(&self.data);
+        out.put_slice(&self.data);
     }
 
     pub(crate) fn size(&self, length: bool) -> usize {

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -6,7 +6,6 @@ use thiserror::Error;
 use crate::{
     ConnectionId,
     coding::{self, BufExt, BufMutExt},
-    connection::BufLen,
     crypto,
 };
 
@@ -217,6 +216,23 @@ impl PartialDecode {
 
         let len = PacketNumber::decode_len(buf.get_ref()[0]);
         PacketNumber::decode(len, buf)
+    }
+}
+
+/// A buffer that can tell how much has been written to it already
+///
+/// This is commonly used for when a buffer is passed and the user may not write past a
+/// given size. It allows the user of such a buffer to know the current cursor position in
+/// the buffer. The maximum write size is usually passed in the same unit as
+/// [`BufLen::len`]: bytes since the buffer start.
+pub(crate) trait BufLen {
+    /// Returns the number of bytes written into the buffer so far
+    fn len(&self) -> usize;
+}
+
+impl BufLen for Vec<u8> {
+    fn len(&self) -> usize {
+        self.len()
     }
 }
 

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -895,6 +895,17 @@ impl SpaceId {
     pub fn iter() -> impl Iterator<Item = Self> {
         [Self::Initial, Self::Handshake, Self::Data].iter().cloned()
     }
+
+    /// Returns the next higher packet space.
+    ///
+    /// Keeps returning [`SpaceId::Data`] as the highest space.
+    pub fn next(&self) -> Self {
+        match self {
+            Self::Initial => Self::Handshake,
+            Self::Handshake => Self::Data,
+            Self::Data => Self::Data,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 use crate::{
     ConnectionId,
     coding::{self, BufExt, BufMutExt},
+    connection::BufLen,
     crypto,
 };
 
@@ -281,7 +282,7 @@ pub(crate) enum Header {
 }
 
 impl Header {
-    pub(crate) fn encode(&self, w: &mut Vec<u8>) -> PartialEncode {
+    pub(crate) fn encode(&self, w: &mut (impl BufMut + BufLen)) -> PartialEncode {
         use Header::*;
         let start = w.len();
         match *self {


### PR DESCRIPTION
This is a continuation of #2168 and concentrates on further simplifying the logic needed in the  poll_transmit function.

* The buffer to write into is now owned by the `PacketBuilder` while building a packet.
* This allows using `BufMut::remaining_mut` to know how much space is still available to write for frames.  The intermediate `BufLen` trait is no longer needed for building packets.
* The poll_transmit function and it's helpers that write frames now no longer deals with offsets into an abstract buffer.  It removes the amount of state they need to track and the logical conditions end up being simpler.
* The main loop has been modified: the goal here was to finish the packet before the loop re-started.
  * This allows the `PacketBuilder` to own the buffer, which is what allows using `BufMut::remaining_mut` for the buffer size.
  * It also reduces the amount of state that needs to be carried between loop iterations.  Which reduces the cognitive load for readers.
  * Finally, my hope is that this loop construction with `.next_send_space()` is easier to adapt to mutlipath.  Though that's kind of out-of scope and not yet proven.

The downside of using `BufMut::limit` is that `bytes`' `Limit` (and in general `BufMut`) will panic if you try to write more than allowed.  This is an invariant that should not occur, though in general `poll_transmit` can not propagate errors or even close the connection.  So while a custom trait could allow us to survive this we'd still build an invalid packet and then who knows what the remaining state of the connection would be.  Perhaps it could be interesting to some day allow poll_transmit to return an error which would result in the connection being closed.  But for now I think this choice of `BufMut::remaining_mut` is fine.

## What's next?

The `TransmitBuf` still exposes absolute offsets which are used by both `PacketBuilder` and `PartialEncode`.  I think the logic of `PacketBuilder` and `PartialEncode` could probably be further simplified by taking the same approach there and not use absolute offsets in the `TransmitBuf`.  Though I've limited the scope of this PR to mainly improving poll_transmit, as this needs more maintenance that the packet building.  Just as for #2168, this PR should not be judged on what could happen next.

----

This PR is **on top of #2168**.  Unfortunately I can't target that PR since the branch does not live in the quinn-rs/quinn repo.  So you get the entire diff of #2168 and this together.

This PR starts at `Finish packets at end of each poll_transmit loop` (currently e7ea03832f5ad7dc29067899efb94b068d83e06b)