### PR TITLE
quinn-udp: refactor control-flow in `send` and `recv` impls

### DIFF
--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -338,10 +338,8 @@ fn send(
 
         let e = io::Error::last_os_error();
         match e.kind() {
-            io::ErrorKind::Interrupted => {
-                // Retry the transmission
-                continue;
-            }
+            // Retry the transmission
+            io::ErrorKind::Interrupted => continue,
             io::ErrorKind::WouldBlock => return Err(e),
             _ => {
                 // Some network adapters and drivers do not support GSO. Unfortunately, Linux
@@ -425,10 +423,8 @@ fn send(state: &UdpSocketState, io: SockRef<'_>, transmit: &Transmit<'_>) -> io:
 
         let e = io::Error::last_os_error();
         match e.kind() {
-            io::ErrorKind::Interrupted => {
-                // Retry the transmission
-                continue;
-            }
+            // Retry the transmission
+            io::ErrorKind::Interrupted => continue,
             io::ErrorKind::WouldBlock => return Err(e),
             _ => return Err(e),
         }
@@ -459,10 +455,8 @@ fn send(state: &UdpSocketState, io: SockRef<'_>, transmit: &Transmit<'_>) -> io:
 
         let e = io::Error::last_os_error();
         match e.kind() {
-            io::ErrorKind::Interrupted => {
-                // Retry the transmission
-                continue;
-            }
+            // Retry the transmission
+            io::ErrorKind::Interrupted => continue,
             io::ErrorKind::WouldBlock => return Err(e),
             _ => return Err(e),
         }

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -491,11 +491,11 @@ fn recv(io: SockRef<'_>, bufs: &mut [IoSliceMut<'_>], meta: &mut [RecvMeta]) -> 
         }
 
         let e = io::Error::last_os_error();
-        if e.kind() == io::ErrorKind::Interrupted {
-            continue;
+        match e.kind() {
+            // Retry receiving
+            io::ErrorKind::Interrupted => continue,
+            _ => return Err(e),
         }
-
-        return Err(e);
     };
     for i in 0..(msg_count as usize) {
         meta[i] = decode_recv(&names[i], &hdrs[i].msg_hdr, hdrs[i].msg_len as usize);
@@ -520,11 +520,11 @@ fn recv(io: SockRef<'_>, bufs: &mut [IoSliceMut<'_>], meta: &mut [RecvMeta]) -> 
         }
 
         let e = io::Error::last_os_error();
-        if e.kind() == io::ErrorKind::Interrupted {
-            continue;
+        match e.kind() {
+            // Retry receiving
+            io::ErrorKind::Interrupted => continue,
+            _ => return Err(e),
         }
-
-        return Err(e);
     };
     for i in 0..(msg_count as usize) {
         meta[i] = decode_recv(&names[i], &hdrs[i], hdrs[i].msg_datalen as usize);
@@ -550,11 +550,11 @@ fn recv(io: SockRef<'_>, bufs: &mut [IoSliceMut<'_>], meta: &mut [RecvMeta]) -> 
         }
 
         let e = io::Error::last_os_error();
-        if e.kind() == io::ErrorKind::Interrupted {
-            continue;
+        match e.kind() {
+            // Retry receiving
+            io::ErrorKind::Interrupted => continue,
+            _ => return Err(e),
         }
-
-        return Err(e);
     };
     meta[0] = decode_recv(&name, &hdr, n as usize);
     Ok(1)

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -425,7 +425,6 @@ fn send(state: &UdpSocketState, io: SockRef<'_>, transmit: &Transmit<'_>) -> io:
         match e.kind() {
             // Retry the transmission
             io::ErrorKind::Interrupted => continue,
-            io::ErrorKind::WouldBlock => return Err(e),
             _ => return Err(e),
         }
     }
@@ -457,7 +456,6 @@ fn send(state: &UdpSocketState, io: SockRef<'_>, transmit: &Transmit<'_>) -> io:
         match e.kind() {
             // Retry the transmission
             io::ErrorKind::Interrupted => continue,
-            io::ErrorKind::WouldBlock => return Err(e),
             _ => return Err(e),
         }
     }


### PR DESCRIPTION
This is based on top of https://github.com/quinn-rs/quinn/pull/2199 so ignore the first commit when reviewing. Will rebase once that is merged.

As part of dealing with this code, I figured it could be easier to understand if it were more consistent and used early-returns to reduce indentation.