### PR TITLE
fix(quinn-udp): only inspect `cmsg_len` when reading cmsg's

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,6 +122,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --locked --all-targets
       - run: cargo test --locked
+      - run: cargo test --locked -p quinn-udp --features fast-apple-datapath
+        if: ${{ runner.os }} == "macOS"
       - run: cargo test --locked -- --ignored stress
       - run: cargo test --locked --manifest-path fuzz/Cargo.toml
         if: ${{ matrix.rust }} == "stable"

--- a/quinn-udp/src/cmsg/mod.rs
+++ b/quinn-udp/src/cmsg/mod.rs
@@ -61,7 +61,7 @@ impl<'a, M: MsgHdr> Encoder<'a, M> {
             ptr::write(cmsg.cmsg_data() as *const T as *mut T, value);
         }
         self.len += space;
-        self.cmsg = unsafe { self.hdr.cmsg_nxt_hdr(cmsg).as_mut() };
+        self.cmsg = unsafe { self.hdr.reserve_cmsg_nxt_hdr(cmsg).as_mut() };
     }
 
     /// Finishes appending control messages to the buffer
@@ -111,7 +111,7 @@ impl<'a, M: MsgHdr> Iterator for Iter<'a, M> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let current = self.cmsg.take()?;
-        self.cmsg = unsafe { self.hdr.cmsg_nxt_hdr(current).as_ref() };
+        self.cmsg = unsafe { self.hdr.decode_cmsg_nxt_hdr(current).as_ref() };
         Some(current)
     }
 }
@@ -122,7 +122,9 @@ pub(crate) trait MsgHdr {
 
     fn cmsg_first_hdr(&self) -> *mut Self::ControlMessage;
 
-    fn cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage;
+    fn decode_cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage;
+
+    fn reserve_cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage;
 
     /// Sets the number of control messages added to this `struct msghdr`.
     ///

--- a/quinn-udp/src/cmsg/unix.rs
+++ b/quinn-udp/src/cmsg/unix.rs
@@ -14,7 +14,11 @@ impl MsgHdr for libc::msghdr {
         unsafe { libc::CMSG_FIRSTHDR(self) }
     }
 
-    fn cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage {
+    fn decode_cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage {
+        unsafe { libc::CMSG_NXTHDR(self, cmsg) }
+    }
+
+    fn reserve_cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage {
         unsafe { libc::CMSG_NXTHDR(self, cmsg) }
     }
 
@@ -41,7 +45,7 @@ impl MsgHdr for crate::imp::msghdr_x {
         unsafe { libc::CMSG_FIRSTHDR(selfp) }
     }
 
-    fn cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage {
+    fn decode_cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage {
         let selfp = self as *const _ as *mut libc::msghdr;
         let next = unsafe { libc::CMSG_NXTHDR(selfp, cmsg) };
 
@@ -55,6 +59,12 @@ impl MsgHdr for crate::imp::msghdr_x {
         }
 
         next
+    }
+
+    fn reserve_cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage {
+        let selfp = self as *const _ as *mut libc::msghdr;
+
+        unsafe { libc::CMSG_NXTHDR(selfp, cmsg) }
     }
 
     fn set_control_len(&mut self, len: usize) {

--- a/quinn-udp/src/cmsg/windows.rs
+++ b/quinn-udp/src/cmsg/windows.rs
@@ -25,7 +25,18 @@ impl MsgHdr for WinSock::WSAMSG {
         }
     }
 
-    fn cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage {
+    fn decode_cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage {
+        let next =
+            (cmsg as *const _ as usize + cmsghdr_align(cmsg.cmsg_len)) as *mut WinSock::CMSGHDR;
+        let max = self.Control.buf as usize + self.Control.len as usize;
+        if unsafe { next.offset(1) } as usize > max {
+            ptr::null_mut()
+        } else {
+            next
+        }
+    }
+
+    fn reserve_cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage {
         let next =
             (cmsg as *const _ as usize + cmsghdr_align(cmsg.cmsg_len)) as *mut WinSock::CMSGHDR;
         let max = self.Control.buf as usize + self.Control.len as usize;

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -32,6 +32,29 @@ fn basic() {
 }
 
 #[test]
+fn basic_src_ip_ipv6() {
+    let send = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0))
+        .or_else(|_| UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)))
+        .unwrap();
+    let recv = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0))
+        .or_else(|_| UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)))
+        .unwrap();
+    let src_ip = send.local_addr().unwrap().ip();
+    let dst_addr = recv.local_addr().unwrap();
+    test_send_recv(
+        &send.into(),
+        &recv.into(),
+        Transmit {
+            destination: dst_addr,
+            ecn: None,
+            contents: b"hello",
+            segment_size: None,
+            src_ip: Some(src_ip),
+        },
+    );
+}
+
+#[test]
 fn ecn_v6() {
     let send = Socket::from(UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap());
     let recv = Socket::from(UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap());


### PR DESCRIPTION
This PR is a version of https://github.com/quinn-rs/quinn/pull/2205 with a clean commit history that should be ready for merging.

Resolves: #2206