### PR TITLE
fix(quinn-udp): move cmsg-len check to Iterator

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -127,7 +127,7 @@ jobs:
         if: ${{ matrix.rust }} == "stable"
       - run: cargo test --locked -p quinn-udp --benches
       - run: cargo test --locked -p quinn-udp --benches --features fast-apple-datapath
-        if: ${{ matrix.os }} == "macos-latest"
+        if: ${{ runner.os }} == "macOS"
 
   test-aws-lc-rs:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,6 +122,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --locked --all-targets
       - run: cargo test --locked
+      - run: cargo test --locked -p quinn-udp --features fast-apple-datapath
+        if: ${{ runner.os }} == "macOS"
       - run: cargo test --locked -- --ignored stress
       - run: cargo test --locked --manifest-path fuzz/Cargo.toml
         if: ${{ matrix.rust }} == "stable"

--- a/quinn-udp/src/cmsg/unix.rs
+++ b/quinn-udp/src/cmsg/unix.rs
@@ -43,18 +43,7 @@ impl MsgHdr for crate::imp::msghdr_x {
 
     fn cmsg_nxt_hdr(&self, cmsg: &Self::ControlMessage) -> *mut Self::ControlMessage {
         let selfp = self as *const _ as *mut libc::msghdr;
-        let next = unsafe { libc::CMSG_NXTHDR(selfp, cmsg) };
-
-        // On MacOS < 14 CMSG_NXTHDR might continuously return a zeroed cmsg. In
-        // such case, return a null pointer instead, thus indicating the end of
-        // the cmsghdr chain.
-        if unsafe { next.as_ref() }
-            .is_some_and(|n| (n.cmsg_len as usize) < std::mem::size_of::<libc::cmsghdr>())
-        {
-            return std::ptr::null_mut();
-        }
-
-        next
+        unsafe { libc::CMSG_NXTHDR(selfp, cmsg) }
     }
 
     fn set_control_len(&mut self, len: usize) {

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -32,6 +32,29 @@ fn basic() {
 }
 
 #[test]
+fn basic_src_ip() {
+    let send = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0))
+        .or_else(|_| UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)))
+        .unwrap();
+    let recv = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0))
+        .or_else(|_| UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)))
+        .unwrap();
+    let src_ip = send.local_addr().unwrap().ip();
+    let dst_addr = recv.local_addr().unwrap();
+    test_send_recv(
+        &send.into(),
+        &recv.into(),
+        Transmit {
+            destination: dst_addr,
+            ecn: None,
+            contents: b"hello",
+            segment_size: None,
+            src_ip: Some(src_ip),
+        },
+    );
+}
+
+#[test]
 fn ecn_v6() {
     let send = Socket::from(UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap());
     let recv = Socket::from(UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap());


### PR DESCRIPTION
This is an alternative version to #2207 that has a smaller change to the API surface.

Resolves: #2206 