### PR TITLE
Bump the quinn-proto version to 0.11.11 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "arbitrary",
  "assert_matches",

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-proto"
-version = "0.11.10"
+version = "0.11.11"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Bumping the version to be able to get a patch release of `quinn-proto`, in order to have a version with the fix for #2167 on crates.io. I think we only need `quinn-proto` for this, not `quinn` itself, right?

I'm not sure if there is any other ceremony around releases? I saw nothing interesting in the history, and no contributions-file.