### PR TITLE
feat: Make the future returned by `SendStream::stopped` static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "rustls-pemfile",
+ "slab",
  "smol",
  "socket2",
  "thiserror 2.0.12",

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -54,6 +54,7 @@ rustc-hash = { workspace = true }
 pin-project-lite = { workspace = true }
 proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.11.10", default-features = false }
 rustls = { workspace = true, optional = true }
+slab = { workspace = true }
 smol = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing =  { workspace = true }


### PR DESCRIPTION
Currently, the future returned by `SendStream::stopped` is bound to `&mut self`, and therefore cannot be stored and polled while also sending on the stream. This makes the future returned by `SendStream::stopped` be `'static`, so that it can be stored in futures combinators while also still sending on the stream.

This is useful when you want to clean up local state once the corresponding receiver to a send stream is closed or dropped, independently of actually using the stream. Especially if sends occur infrequently, tracking the stopped notification allows to clean up state at the earliest time and not only once you try to send again.

There's a complication though: Once `SendStream::stopped` returns a `'static` future, we'd have to account for the fact that there may be multiple futures waiting for a wakeup once the stream is stopped. Therefore, we'd need to store a *list* of wakers instead of a single waker per stream. I used a `Slab`, open to other ideas how to achieve this.

For the intended functionality I don't actually need the possibility to create multiple futures waiting for the stopped wakeup. However, I didn't yet come up with an API that encodes that only the last future returned from `SendStream::stopped` would be woken up reliably - if you have ideas here, please share.

I added two tests with various combinations of using stopped while stopping and/or dropping the send stream.