### PR TITLE
Bump quinn version to 0.11.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "async-io",

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn"
-version = "0.11.7"
+version = "0.11.8"
 license.workspace = true
 repository.workspace = true
 description = "Versatile QUIC transport protocol implementation"


### PR DESCRIPTION
Bump the version of `quinn` so that #2221 may be fixed. Feel free to ping me if you need me to do anything else.