### PR TITLE
proto: bump version to 0.11.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "arbitrary",
  "assert_matches",

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-proto"
-version = "0.11.11"
+version = "0.11.12"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -52,7 +52,7 @@ bytes = { workspace = true }
 futures-io = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 pin-project-lite = { workspace = true }
-proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.11.10", default-features = false }
+proto = { package = "quinn-proto", path = "../quinn-proto", version = "0.11.12", default-features = false }
 rustls = { workspace = true, optional = true }
 smol = { workspace = true, optional = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
In order to release quinn 0.11.8 (see #2222, #2221), we need to bump quinn-proto to 0.11.12 (since #2136 landed in the mean time):

```rust
djc-2021 main quinn $ cargo publish
    Updating crates.io index
   Packaging quinn v0.11.8 (/Users/djc/src/quinn/quinn)
    Updating crates.io index
error: failed to prepare local package for uploading

Caused by:
  failed to select a version for `quinn-proto`.
      ... required by package `quinn v0.11.8 (/Users/djc/src/quinn/quinn)`
  versions that meet the requirements `^0.11.10` are: 0.11.11, 0.11.10

  the package `quinn` depends on `quinn-proto`, with features: `bloom` but `quinn-proto` does not have these features.
```