### PR TITLE
(Draft) Public `write_source` API

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -81,7 +81,7 @@ pub use streams::StreamsState;
 use streams::StreamsState;
 pub use streams::{
     Chunks, ClosedStream, FinishError, ReadError, ReadableError, RecvStream, SendStream,
-    ShouldTransmit, StreamEvent, Streams, WriteError, Written,
+    ShouldTransmit, StreamEvent, Streams, WriteError, Written, stage_buf, stage_chunks,
 };
 
 mod timer;

--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -381,7 +381,7 @@ impl<'a> SendStream<'a> {
 ///
 /// Copies the largest prefix of `data` that is not longer than `limit` to a new `Bytes`
 /// allocation, pushes it to `chunks`, and returns how many bytes were transferred.
-fn stage_buf(data: &[u8], limit: usize, chunks: &mut Vec<Bytes>) -> usize {
+pub fn stage_buf(data: &[u8], limit: usize, chunks: &mut Vec<Bytes>) -> usize {
     let prefix = &data[..limit.min(data.len())];
     chunks.push(prefix.to_vec().into());
     prefix.len()
@@ -394,7 +394,7 @@ fn stage_buf(data: &[u8], limit: usize, chunks: &mut Vec<Bytes>) -> usize {
 /// Mutates each element of `data` so they no longer contain the parts of the chunks that were
 /// taken. Returns a [`Written`] indicating the number of chunks that were *fully* transferred as
 /// well as the total number of bytes that were transferred.
-fn stage_chunks(data: &mut [Bytes], limit: usize, chunks: &mut Vec<Bytes>) -> Written {
+pub fn stage_chunks(data: &mut [Bytes], limit: usize, chunks: &mut Vec<Bytes>) -> Written {
     let mut written = Written::default();
     for chunk in data {
         let prefix = chunk.split_to(chunk.len().min(limit - written.bytes));

--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -264,7 +264,7 @@ impl<'a> SendStream<'a> {
     /// guaranteed they will all be written. If it provides more bytes than this, it is guaranteed
     /// that a prefix of the provided cumulative bytes will be written equal in length to the
     /// provided limit.
-    fn write_source<F, R>(&mut self, source: F) -> Result<R, (WriteError, F)>
+    pub fn write_source<F, R>(&mut self, source: F) -> Result<R, (WriteError, F)>
     where
         F: FnOnce(usize, &mut Vec<Bytes>) -> R,
     {

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -47,7 +47,7 @@ pub use crate::connection::{
     Chunk, Chunks, ClosedStream, Connection, ConnectionError, ConnectionStats, Datagrams, Event,
     FinishError, FrameStats, PathStats, ReadError, ReadableError, RecvStream, RttEstimator,
     SendDatagramError, SendStream, ShouldTransmit, StreamEvent, Streams, UdpStats, WriteError,
-    Written,
+    Written, stage_buf, stage_chunks,
 };
 
 #[cfg(feature = "rustls")]

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -241,14 +241,14 @@ impl SendStream {
         cx: &mut Context,
         buf: &[u8],
     ) -> Poll<Result<usize, WriteError>> {
-        self.get_mut().execute_poll(cx, |stream| stream.write(buf))
+        pin!(self.get_mut().write(buf)).as_mut().poll(cx)
     }
 }
 
 #[cfg(feature = "futures-io")]
 impl futures_io::AsyncWrite for SendStream {
     fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
-        Self::execute_poll(self.get_mut(), cx, |stream| stream.write(buf)).map_err(Into::into)
+        self.poll_write(cx, buf).map_err(Into::into)
     }
 
     fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<io::Result<()>> {
@@ -266,7 +266,7 @@ impl tokio::io::AsyncWrite for SendStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        Self::execute_poll(self.get_mut(), cx, |stream| stream.write(buf)).map_err(Into::into)
+        self.poll_write(cx, buf).map_err(Into::into)
     }
 
     fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<io::Result<()>> {


### PR DESCRIPTION
This draft PR currently targets a temporary base branch formed by merging #2230 and #2226 into main.

---

Overall, this PR makes the refactored `write_source` API proposed in #2230 public and threads it through to a public API in Quinn as well. This has value both for simplicity and utility. From the simplicity side, it allows us to supersede and delete the `quinn::SendStream::execute_poll` function.

From the utility side, this API, for example, should be considered to close #2229, as it could be used to implement a `write_atomic` method purely on top of existing public methods as such:

```diff
diff --git a/quinn/src/send_stream.rs b/quinn/src/send_stream.rs
index fcea07cf..b5a4240c 100644
--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -1,4 +1,5 @@
 use std::{
+    convert::identity,
     fmt,
     future::{Future, poll_fn},
     io,
@@ -101,6 +102,20 @@ impl SendStream {
         Ok(())
     }
 
+    pub async fn write_atomic(&mut self, buf: &[u8]) -> Result<(), WriteAtomicError> {
+        self.write_source(|limit, chunks| {
+            if limit >= buf.len() {
+                chunks.push(buf.to_vec().into());
+                Ok(())
+            } else {
+                Err(WriteAtomicError::TooLarge)
+            }
+        })
+        .await
+        .map_err(|e| WriteAtomicError::WriteError(e.error))
+        .and_then(identity)
+    }
+
     /// Attempts to write bytes into this stream from a byte-providing callback
     ///
     /// This is a low-level writing API that can be used to perform writes in a way that is atomic
@@ -465,3 +480,14 @@ impl<F> From<WriteSourceError<F>> for io::Error {
         e.error.into()
     }
 }
+
+/// Errors that arise from writing to a stream atomically
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum WriteAtomicError {
+    /// The write was too large to send atomically at this time
+    #[error("too large for atomic write")]
+    TooLarge,
+    /// Some other write error occurred
+    #[error("stream write error")]
+    WriteError(WriteError),
+}
```