### PR TITLE
proto: Make BytesSource private

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -80,8 +80,8 @@ pub use streams::StreamsState;
 #[cfg(not(fuzzing))]
 use streams::StreamsState;
 pub use streams::{
-    BytesSource, Chunks, ClosedStream, FinishError, ReadError, ReadableError, RecvStream,
-    SendStream, ShouldTransmit, StreamEvent, Streams, WriteError, Written,
+    Chunks, ClosedStream, FinishError, ReadError, ReadableError, RecvStream, SendStream,
+    ShouldTransmit, StreamEvent, Streams, WriteError, Written,
 };
 
 mod timer;

--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -20,8 +20,8 @@ pub use recv::{Chunks, ReadError, ReadableError};
 
 mod send;
 pub(crate) use send::{ByteSlice, BytesArray};
-pub use send::{BytesSource, FinishError, WriteError, Written};
-use send::{Send, SendState};
+use send::{BytesSource, Send, SendState};
+pub use send::{FinishError, WriteError, Written};
 
 mod state;
 #[allow(unreachable_pub)] // fuzzing only

--- a/quinn-proto/src/connection/streams/send.rs
+++ b/quinn-proto/src/connection/streams/send.rs
@@ -227,7 +227,7 @@ impl BytesSource for ByteSlice<'_> {
 ///
 /// The purpose of this data type is to defer conversion as long as possible,
 /// so that no heap allocation is required in case no data is writable.
-pub trait BytesSource {
+pub(super) trait BytesSource {
     /// Returns the next chunk from the source of owned chunks.
     ///
     /// This method will consume parts of the source.

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -44,10 +44,10 @@ pub use bloom_token_log::BloomTokenLog;
 
 mod connection;
 pub use crate::connection::{
-    BytesSource, Chunk, Chunks, ClosedStream, Connection, ConnectionError, ConnectionStats,
-    Datagrams, Event, FinishError, FrameStats, PathStats, ReadError, ReadableError, RecvStream,
-    RttEstimator, SendDatagramError, SendStream, ShouldTransmit, StreamEvent, Streams, UdpStats,
-    WriteError, Written,
+    Chunk, Chunks, ClosedStream, Connection, ConnectionError, ConnectionStats, Datagrams, Event,
+    FinishError, FrameStats, PathStats, ReadError, ReadableError, RecvStream, RttEstimator,
+    SendDatagramError, SendStream, ShouldTransmit, StreamEvent, Streams, UdpStats, WriteError,
+    Written,
 };
 
 #[cfg(feature = "rustls")]


### PR DESCRIPTION
There are no public APIs that accept BytesSource. This commit makes it not be re-exported publically.

---

I am cherry-picking this commit from #2230. Djc and Ralith [both seemed to agree](https://github.com/quinn-rs/quinn/pull/2230#issuecomment-2869218721) in that PR that, although this is technically a breaking change, we're ok with acting like it's not because we assume nobody is using `BytesSource` (because we provide no way to use it and seemingly made it public by accident).

I am splitting this out from 2230 because that way we don't have to think about that quirk of the change in 2230.

Closes #2228.