### PR TITLE
Fix new clippy warnings about large errors

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -516,6 +516,8 @@ impl Endpoint {
     }
 
     /// Attempt to accept this incoming connection (an error may still occur)
+    // AcceptError cannot be made smaller without semver breakage
+    #[allow(clippy::result_large_err)]
     pub fn accept(
         &mut self,
         mut incoming: Incoming,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -723,7 +723,7 @@ impl Endpoint {
     /// Errors if `incoming.may_retry()` is false.
     pub fn retry(&mut self, incoming: Incoming, buf: &mut Vec<u8>) -> Result<Transmit, RetryError> {
         if !incoming.may_retry() {
-            return Err(RetryError(incoming));
+            return Err(RetryError(Box::new(incoming)));
         }
 
         self.clean_up_incoming(&incoming);
@@ -1278,12 +1278,12 @@ pub struct AcceptError {
 /// Error for attempting to retry an [`Incoming`] which already bears a token from a previous retry
 #[derive(Debug, Error)]
 #[error("retry() with validated Incoming")]
-pub struct RetryError(Incoming);
+pub struct RetryError(Box<Incoming>);
 
 impl RetryError {
     /// Get the [`Incoming`]
     pub fn into_incoming(self) -> Incoming {
-        self.0
+        *self.0
     }
 }
 

--- a/quinn/src/incoming.rs
+++ b/quinn/src/incoming.rs
@@ -52,10 +52,10 @@ impl Incoming {
     pub fn retry(mut self) -> Result<(), RetryError> {
         let state = self.0.take().unwrap();
         state.endpoint.retry(state.inner).map_err(|e| {
-            RetryError(Self(Some(State {
+            RetryError(Box::new(Self(Some(State {
                 inner: e.into_incoming(),
                 endpoint: state.endpoint,
-            })))
+            }))))
         })
     }
 
@@ -118,12 +118,12 @@ struct State {
 /// Error for attempting to retry an [`Incoming`] which already bears a token from a previous retry
 #[derive(Debug, Error)]
 #[error("retry() with validated Incoming")]
-pub struct RetryError(Incoming);
+pub struct RetryError(Box<Incoming>);
 
 impl RetryError {
     /// Get the [`Incoming`]
     pub fn into_incoming(self) -> Incoming {
-        self.0
+        *self.0
     }
 }
 


### PR DESCRIPTION
It seems that clippy added some new warnings about `Result::Err` variants with large byte sizes. This is interfering with attempts to merge #2245 (and presumably, any other PR). This PR:

- Suppresses the warning for `AcceptError`, since it is impossible to fix that one without semver breakage. In the next breaking release, we could consider fixing it somehow, such as by changing error type for that method to `Box<AcceptError>`.
- Fixes the warning for `RetryError` by boxing the contents. 