### PR TITLE
feat: add event and function to wait for resumption tickets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rand = "0.9"
 rcgen = "0.14"
 ring = "0.17"
 rustc-hash = "2"
-rustls = { version = "0.23.5", default-features = false, features = ["std"] }
+rustls = { version = "0.23.31", default-features = false, features = ["std"] }
 rustls-pemfile = "2"
 rustls-platform-verifier = "0.6"
 rustls-pki-types = "1.7"

--- a/perf/src/noprotection.rs
+++ b/perf/src/noprotection.rs
@@ -127,6 +127,10 @@ impl crypto::Session for NoProtectionSession {
     ) -> Result<(), crypto::ExportKeyingMaterialError> {
         self.inner.export_keying_material(output, label, context)
     }
+
+    fn resumption_tickets_received(&self) -> Option<u32> {
+        self.inner.resumption_tickets_received()
+    }
 }
 
 impl crypto::ClientConfig for NoProtectionClientConfig {

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -91,6 +91,11 @@ pub trait Session: Send + Sync + 'static {
         label: &[u8],
         context: &[u8],
     ) -> Result<(), ExportKeyingMaterialError>;
+
+    /// Returns the number of TLS1.3 session resumption tickets that were received
+    ///
+    /// Returns `None` on the server side.
+    fn resumption_tickets_received(&self) -> Option<u32>;
 }
 
 /// A pair of keys for bidirectional communication

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -209,6 +209,13 @@ impl crypto::Session for TlsSession {
             .map_err(|_| ExportKeyingMaterialError)?;
         Ok(())
     }
+
+    fn resumption_tickets_received(&self) -> Option<u32> {
+        match &self.inner {
+            Connection::Client(conn) => Some(conn.tls13_tickets_received()),
+            Connection::Server(_) => None,
+        }
+    }
 }
 
 const RETRY_INTEGRITY_KEY_DRAFT: [u8; 16] = [

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -128,6 +128,10 @@ fn lifecycle() {
     let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ResumptionEnabled)
+    );
     assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
     assert!(pair.client_conn_mut(client_ch).using_ecn());
     assert!(pair.server_conn_mut(server_ch).using_ecn());
@@ -161,6 +165,10 @@ fn draft_version_compat() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect_with(client_config);
 
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ResumptionEnabled)
+    );
     assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
     assert!(pair.client_conn_mut(client_ch).using_ecn());
     assert!(pair.server_conn_mut(server_ch).using_ecn());
@@ -206,6 +214,10 @@ fn server_stateless_reset() {
     pair.client.connections.get_mut(&client_ch).unwrap().ping();
     info!("resetting");
     pair.drive();
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ResumptionEnabled)
+    );
     assert_matches!(
         pair.client_conn_mut(client_ch).poll(),
         Some(Event::ConnectionLost {
@@ -329,6 +341,10 @@ fn finish_stream_simple() {
 
     assert_matches!(
         pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ResumptionEnabled)
+    );
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
         Some(Event::Stream(StreamEvent::Finished { id })) if id == s
     );
     assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
@@ -379,6 +395,10 @@ fn reset_stream() {
     let mut chunks = recv.read(false).unwrap();
     assert_matches!(chunks.next(usize::MAX), Err(ReadError::Reset(ERROR)));
     let _ = chunks.finalize();
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ResumptionEnabled)
+    );
     assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
 }
 
@@ -597,6 +617,10 @@ fn zero_rtt_happypath() {
     );
     let _ = chunks.finalize();
     assert_eq!(pair.client_conn_mut(client_ch).stats().path.lost_packets, 0);
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ResumptionEnabled)
+    );
 }
 
 #[test]
@@ -907,6 +931,10 @@ fn stream_id_limit() {
     pair.drive();
     assert_matches!(
         pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ResumptionEnabled)
+    );
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
         Some(Event::Stream(StreamEvent::Finished { id })) if id == s
     );
     assert_eq!(
@@ -1194,6 +1222,10 @@ fn idle_timeout() {
     assert!(pair.time - start < Duration::from_millis(2 * IDLE_TIMEOUT));
     assert_matches!(
         pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ResumptionEnabled)
+    );
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
         Some(Event::ConnectionLost {
             reason: ConnectionError::TimedOut,
         })
@@ -1271,6 +1303,10 @@ fn migration() {
     assert_ne!(pair.server_conn_mut(server_ch).total_recvd(), 0);
 
     pair.drive();
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ResumptionEnabled)
+    );
     assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
     assert_eq!(
         pair.server_conn_mut(server_ch).remote_address(),
@@ -1659,6 +1695,10 @@ fn finish_stream_flow_control_reordered() {
 
     assert_matches!(
         pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ResumptionEnabled)
+    );
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
         Some(Event::Stream(StreamEvent::Finished { id })) if id == s
     );
     assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
@@ -1749,6 +1789,10 @@ fn stop_during_finish() {
     pair.drive_server();
     pair.client_send(client_ch, s).finish().unwrap();
     pair.drive_client();
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ResumptionEnabled)
+    );
     assert_matches!(
         pair.client_conn_mut(client_ch).poll(),
         Some(Event::Stream(StreamEvent::Stopped { id, error_code: ERROR })) if id == s
@@ -2036,6 +2080,10 @@ fn finish_acked() {
     // Send FIN, receive data ack
     info!("client receives ACK, sends FIN");
     pair.drive_client();
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ResumptionEnabled)
+    );
     // Check for premature finish from data ack
     assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
     // Process FIN ack
@@ -2074,6 +2122,10 @@ fn finish_retransmit() {
     // Receive FIN ack, but no data ack
     pair.drive_client();
     // Check for premature finish from FIN ack
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::ResumptionEnabled)
+    );
     assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
     // Recover
     pair.drive();


### PR DESCRIPTION
This adds a new connection event to quinn-proto: `ResumptionEnabled`. This event is emitted if TLS13 resumption tickets were received. The event is emitted at most once and only on the client side.

In `quinn`, this adds a new function `resumption_tickets_received`, which returns a future that completes once the connection received TLS resumption tickets. The future will be pending forever on the server side. On the client side, it will complete immediately if tickets were already received, or complete once tickets are received, or stay pending forever if the server does not send us tickets.

This new feature is useful when doing many short-lived 0rtt connections: It may happen easily that the application-level data exchange is done in a single roundtrip (eg when doing a single, small request-response) but the resumption tickets from the server are only sent in the next packet. If closing the connection after the application data exchange completes, we did not yet receive the new tickets and thus cannot issue further 0rtt connections when our initial tickets are consumed. With this new API, a client-side 0rtt connection can wait for `conn.resumption_tickets_received()` before closing the connection (should also apply a timeout in case the server does not send any tickets). Thus, it can issue further 0rtt connections without having to go back to 1rtt inbetween.

The PR uses the functionality added in [this rustls PR](https://github.com/rustls/rustls/pull/2476) to expose the number of TLS13 resumption tickets that were received so far.