### PR TITLE
feat(quinn): Pass in `&mut self` for `AsyncUdpSocket`'s `poll_recv` and re-introduce `poll_send`

### DIFF
--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -129,7 +129,7 @@ impl Endpoint {
     pub fn new_with_abstract_socket(
         config: EndpointConfig,
         server_config: Option<ServerConfig>,
-        socket: Arc<dyn AsyncUdpSocket>,
+        socket: Box<dyn AsyncUdpSocket>,
         runtime: Arc<dyn Runtime>,
     ) -> io::Result<Self> {
         let addr = socket.local_addr()?;
@@ -224,7 +224,7 @@ impl Endpoint {
             .inner
             .connect(self.runtime.now(), config, addr, server_name)?;
 
-        let sender = endpoint.socket.clone().create_sender();
+        let sender = endpoint.socket.create_sender();
         endpoint.stats.outgoing_handshakes += 1;
         Ok(endpoint
             .recv_state
@@ -246,7 +246,7 @@ impl Endpoint {
     /// connections and connections to servers unreachable from the new address will be lost.
     ///
     /// On error, the old UDP socket is retained.
-    pub fn rebind_abstract(&self, socket: Arc<dyn AsyncUdpSocket>) -> io::Result<()> {
+    pub fn rebind_abstract(&self, socket: Box<dyn AsyncUdpSocket>) -> io::Result<()> {
         let addr = socket.local_addr()?;
         let mut inner = self.inner.state.lock().unwrap();
         inner.prev_socket = Some(mem::replace(&mut inner.socket, socket));
@@ -255,9 +255,7 @@ impl Endpoint {
         // Update connection socket references
         for sender in inner.recv_state.connections.senders.values() {
             // Ignoring errors from dropped connections
-            let _ = sender.send(ConnectionEvent::Rebind(
-                inner.socket.clone().create_sender(),
-            ));
+            let _ = sender.send(ConnectionEvent::Rebind(inner.socket.create_sender()));
         }
         if let Some(driver) = inner.driver.take() {
             // Ensure the driver can register for wake-ups from the new socket
@@ -426,7 +424,7 @@ impl EndpointInner {
         {
             Ok((handle, conn)) => {
                 state.stats.accepted_handshakes += 1;
-                let sender = state.socket.clone().create_sender();
+                let sender = state.socket.create_sender();
                 let runtime = state.runtime.clone();
                 Ok(state
                     .recv_state
@@ -467,11 +465,11 @@ impl EndpointInner {
 
 #[derive(Debug)]
 pub(crate) struct State {
-    socket: Arc<dyn AsyncUdpSocket>,
+    socket: Box<dyn AsyncUdpSocket>,
     sender: Pin<Box<dyn UdpSender>>,
     /// During an active migration, abandoned_socket receives traffic
     /// until the first packet arrives on the new socket.
-    prev_socket: Option<Arc<dyn AsyncUdpSocket>>,
+    prev_socket: Option<Box<dyn AsyncUdpSocket>>,
     inner: proto::Endpoint,
     recv_state: RecvState,
     driver: Option<Waker>,
@@ -494,12 +492,12 @@ impl State {
     fn drive_recv(&mut self, cx: &mut Context, now: Instant) -> Result<bool, io::Error> {
         let get_time = || self.runtime.now();
         self.recv_state.recv_limiter.start_cycle(get_time);
-        if let Some(socket) = &self.prev_socket {
+        if let Some(socket) = &mut self.prev_socket {
             // We don't care about the `PollProgress` from old sockets.
             let poll_res = self.recv_state.poll_socket(
                 cx,
                 &mut self.inner,
-                &**socket,
+                &mut **socket,
                 &mut self.sender,
                 &*self.runtime,
                 now,
@@ -511,7 +509,7 @@ impl State {
         let poll_res = self.recv_state.poll_socket(
             cx,
             &mut self.inner,
-            &*self.socket,
+            &mut *self.socket,
             &mut self.sender,
             &*self.runtime,
             now,
@@ -712,14 +710,14 @@ pub(crate) struct EndpointRef(Arc<EndpointInner>);
 
 impl EndpointRef {
     pub(crate) fn new(
-        socket: Arc<dyn AsyncUdpSocket>,
+        socket: Box<dyn AsyncUdpSocket>,
         inner: proto::Endpoint,
         ipv6: bool,
         runtime: Arc<dyn Runtime>,
     ) -> Self {
         let (sender, events) = mpsc::unbounded_channel();
         let recv_state = RecvState::new(sender, socket.max_receive_segments(), &inner);
-        let sender = socket.clone().create_sender();
+        let sender = socket.create_sender();
         Self(Arc::new(EndpointInner {
             shared: Shared {
                 incoming: Notify::new(),
@@ -809,7 +807,7 @@ impl RecvState {
         &mut self,
         cx: &mut Context,
         endpoint: &mut proto::Endpoint,
-        socket: &dyn AsyncUdpSocket,
+        socket: &mut dyn AsyncUdpSocket,
         sender: &mut Pin<Box<dyn UdpSender>>,
         runtime: &dyn Runtime,
         now: Instant,

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -41,7 +41,7 @@
 #![warn(unreachable_pub)]
 #![warn(clippy::use_self)]
 
-use std::sync::Arc;
+use std::pin::Pin;
 
 mod connection;
 mod endpoint;
@@ -85,7 +85,7 @@ pub use crate::recv_stream::{ReadError, ReadExactError, ReadToEndError, RecvStre
 pub use crate::runtime::SmolRuntime;
 #[cfg(feature = "runtime-tokio")]
 pub use crate::runtime::TokioRuntime;
-pub use crate::runtime::{AsyncTimer, AsyncUdpSocket, Runtime, UdpPoller, default_runtime};
+pub use crate::runtime::{AsyncTimer, AsyncUdpSocket, Runtime, UdpSender, default_runtime};
 pub use crate::send_stream::{SendStream, StoppedError, WriteError};
 
 #[cfg(test)]
@@ -98,7 +98,7 @@ enum ConnectionEvent {
         reason: bytes::Bytes,
     },
     Proto(proto::ConnectionEvent),
-    Rebind(Arc<dyn AsyncUdpSocket>),
+    Rebind(Pin<Box<dyn UdpSender>>),
 }
 
 fn udp_transmit<'a>(t: &proto::Transmit, buffer: &'a [u8]) -> udp::Transmit<'a> {

--- a/quinn/src/runtime.rs
+++ b/quinn/src/runtime.rs
@@ -21,7 +21,7 @@ pub trait Runtime: Send + Sync + Debug + 'static {
     fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>);
     /// Convert `t` into the socket type used by this runtime
     #[cfg(not(wasm_browser))]
-    fn wrap_udp_socket(&self, t: std::net::UdpSocket) -> io::Result<Arc<dyn AsyncUdpSocket>>;
+    fn wrap_udp_socket(&self, t: std::net::UdpSocket) -> io::Result<Box<dyn AsyncUdpSocket>>;
     /// Look up the current time
     ///
     /// Allows simulating the flow of time for testing.
@@ -50,11 +50,11 @@ pub trait AsyncUdpSocket: Send + Sync + Debug + 'static {
     /// [`Waker`].
     ///
     /// [`Waker`]: std::task::Waker
-    fn create_sender(self: Arc<Self>) -> Pin<Box<dyn UdpSender>>;
+    fn create_sender(&self) -> Pin<Box<dyn UdpSender>>;
 
     /// Receive UDP datagrams, or register to be woken if receiving may succeed in the future
     fn poll_recv(
-        &self,
+        &mut self,
         cx: &mut Context,
         bufs: &mut [IoSliceMut<'_>],
         meta: &mut [RecvMeta],

--- a/quinn/src/runtime.rs
+++ b/quinn/src/runtime.rs
@@ -1,5 +1,5 @@
 use std::{
-    fmt::Debug,
+    fmt::{self, Debug},
     future::Future,
     io::{self, IoSliceMut},
     net::SocketAddr,
@@ -40,23 +40,17 @@ pub trait AsyncTimer: Send + Debug + 'static {
 
 /// Abstract implementation of a UDP socket for runtime independence
 pub trait AsyncUdpSocket: Send + Sync + Debug + 'static {
-    /// Create a [`UdpPoller`] that can register a single task for write-readiness notifications
+    /// Create a [`UdpSender`] that can register a single task for write-readiness notifications
+    /// and send a transmit, if ready.
     ///
     /// A `poll_send` method on a single object can usually store only one [`Waker`] at a time,
     /// i.e. allow at most one caller to wait for an event. This method allows any number of
-    /// interested tasks to construct their own [`UdpPoller`] object. They can all then wait for the
-    /// same event and be notified concurrently, because each [`UdpPoller`] can store a separate
+    /// interested tasks to construct their own [`UdpSender`] object. They can all then wait for the
+    /// same event and be notified concurrently, because each [`UdpSender`] can store a separate
     /// [`Waker`].
     ///
     /// [`Waker`]: std::task::Waker
-    fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn UdpPoller>>;
-
-    /// Send UDP datagrams from `transmits`, or return `WouldBlock` and clear the underlying
-    /// socket's readiness, or return an I/O error
-    ///
-    /// If this returns [`io::ErrorKind::WouldBlock`], [`UdpPoller::poll_writable`] must be called
-    /// to register the calling task to be woken when a send should be attempted again.
-    fn try_send(&self, transmit: &Transmit) -> io::Result<()>;
+    fn create_sender(self: Arc<Self>) -> Pin<Box<dyn UdpSender>>;
 
     /// Receive UDP datagrams, or register to be woken if receiving may succeed in the future
     fn poll_recv(
@@ -68,11 +62,6 @@ pub trait AsyncUdpSocket: Send + Sync + Debug + 'static {
 
     /// Look up the local IP address and port used by this socket
     fn local_addr(&self) -> io::Result<SocketAddr>;
-
-    /// Maximum number of datagrams that a [`Transmit`] may encode
-    fn max_transmit_segments(&self) -> usize {
-        1
-    }
 
     /// Maximum number of datagrams that might be described by a single [`RecvMeta`]
     fn max_receive_segments(&self) -> usize {
@@ -88,71 +77,141 @@ pub trait AsyncUdpSocket: Send + Sync + Debug + 'static {
     }
 }
 
-/// An object polled to detect when an associated [`AsyncUdpSocket`] is writable
+/// An object for asynchronously writing to an associated [`AsyncUdpSocket`].
 ///
-/// Any number of `UdpPoller`s may exist for a single [`AsyncUdpSocket`]. Each `UdpPoller` is
-/// responsible for notifying at most one task when that socket becomes writable.
-pub trait UdpPoller: Send + Sync + Debug + 'static {
-    /// Check whether the associated socket is likely to be writable
+/// Any number of [`UdpSender`]s may exist for a single [`AsyncUdpSocket`]. Each [`UdpSender`] is
+/// responsible for notifying at most one task for send readiness.
+pub trait UdpSender: Send + Sync + Debug + 'static {
+    /// Send a UDP datagram, or register to be woken if sending may succeed in the future.
     ///
-    /// Must be called after [`AsyncUdpSocket::try_send`] returns [`io::ErrorKind::WouldBlock`] to
-    /// register the task associated with `cx` to be woken when a send should be attempted
-    /// again. Unlike in [`Future::poll`], a [`UdpPoller`] may be reused indefinitely no matter how
-    /// many times `poll_writable` returns [`Poll::Ready`].
-    fn poll_writable(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>>;
+    /// Usually implementations of this will poll the socket for writability before trying to
+    /// write to them, and retry both if writing fails.
+    ///
+    /// Quinn will create multiple [`UdpSender`]s, one for each task it's using it from. Thus it's
+    /// important to poll the underlying socket in a way that doesn't overwrite wakers.
+    ///
+    /// A single [`UdpSender`] will be re-used, even if `poll_send` returns `Poll::Ready` once,
+    /// unlike [`Future::poll`], so calling it again after readiness should not panic.
+    fn poll_send(
+        self: Pin<&mut Self>,
+        transmit: &Transmit,
+        cx: &mut Context,
+    ) -> Poll<io::Result<()>>;
+
+    /// Maximum number of datagrams that a [`Transmit`] may encode.
+    fn max_transmit_segments(&self) -> usize {
+        1
+    }
 }
 
 pin_project_lite::pin_project! {
-    /// Helper adapting a function `MakeFut` that constructs a single-use future `Fut` into a
-    /// [`UdpPoller`] that may be reused indefinitely
-    struct UdpPollHelper<MakeFut, Fut> {
-        make_fut: MakeFut,
+    /// A helper for constructing [`UdpSender`]s from an underlying `Socket` type.
+    ///
+    /// This struct implements [`UdpSender`] if `MakeWritableFn` produces a `WritableFut`.
+    ///
+    /// Also serves as a trick, since `WritableFut` doesn't need to be a named future,
+    /// it can be an anonymous async block, as long as `MakeWritableFn` produces that
+    /// anonymous async block type.
+    ///
+    /// The `UdpSenderHelper` generic type parameters don't need to named, as it will be
+    /// used in its dyn-compatible form as a `Pin<Box<dyn UdpSender>>`.
+    struct UdpSenderHelper<Socket, MakeWritableFutFn, WritableFut> {
+        socket: Socket,
+        make_writable_fut_fn: MakeWritableFutFn,
         #[pin]
-        fut: Option<Fut>,
+        writable_fut: Option<WritableFut>,
     }
 }
 
-impl<MakeFut, Fut> UdpPollHelper<MakeFut, Fut> {
-    /// Construct a [`UdpPoller`] that calls `make_fut` to get the future to poll, storing it until
-    /// it yields [`Poll::Ready`], then creating a new one on the next
-    /// [`poll_writable`](UdpPoller::poll_writable)
-    #[cfg(any(feature = "runtime-smol", feature = "runtime-tokio",))]
-    fn new(make_fut: MakeFut) -> Self {
-        Self {
-            make_fut,
-            fut: None,
-        }
-    }
-}
-
-impl<MakeFut, Fut> UdpPoller for UdpPollHelper<MakeFut, Fut>
-where
-    MakeFut: Fn() -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = io::Result<()>> + Send + Sync + 'static,
+impl<Socket, MakeWritableFutFn, WritableFut> Debug
+    for UdpSenderHelper<Socket, MakeWritableFutFn, WritableFut>
 {
-    fn poll_writable(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
-        let mut this = self.project();
-        if this.fut.is_none() {
-            this.fut.set(Some((this.make_fut)()));
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("UdpSender")
+    }
+}
+
+impl<Socket, MakeWritableFutFn, WriteableFut>
+    UdpSenderHelper<Socket, MakeWritableFutFn, WriteableFut>
+{
+    /// Create helper that implements [`UdpSender`] from a socket.
+    ///
+    /// Additionally you need to provide what is essentially an async function
+    /// that resolves once the socket is write-ready.
+    ///
+    /// See also the bounds on this struct's [`UdpSender`] implementation.
+    #[cfg(any(feature = "runtime-smol", feature = "runtime-tokio",))]
+    fn new(inner: Socket, make_fut: MakeWritableFutFn) -> Self {
+        Self {
+            socket: inner,
+            make_writable_fut_fn: make_fut,
+            writable_fut: None,
         }
-        // We're forced to `unwrap` here because `Fut` may be `!Unpin`, which means we can't safely
-        // obtain an `&mut Fut` after storing it in `self.fut` when `self` is already behind `Pin`,
-        // and if we didn't store it then we wouldn't be able to keep it alive between
-        // `poll_writable` calls.
-        let result = this.fut.as_mut().as_pin_mut().unwrap().poll(cx);
-        if result.is_ready() {
+    }
+}
+
+impl<Socket, MakeWritableFutFn, WritableFut> super::UdpSender
+    for UdpSenderHelper<Socket, MakeWritableFutFn, WritableFut>
+where
+    Socket: UdpSenderHelperSocket,
+    MakeWritableFutFn: Fn(&Socket) -> WritableFut + Send + Sync + 'static,
+    WritableFut: Future<Output = io::Result<()>> + Send + Sync + 'static,
+{
+    fn poll_send(
+        self: Pin<&mut Self>,
+        transmit: &udp::Transmit,
+        cx: &mut Context,
+    ) -> Poll<io::Result<()>> {
+        let mut this = self.project();
+        loop {
+            if this.writable_fut.is_none() {
+                this.writable_fut
+                    .set(Some((this.make_writable_fut_fn)(this.socket)));
+            }
+            // We're forced to `unwrap` here because `Fut` may be `!Unpin`, which means we can't safely
+            // obtain an `&mut WritableFut` after storing it in `self.writable_fut` when `self` is already behind `Pin`,
+            // and if we didn't store it then we wouldn't be able to keep it alive between
+            // `poll_send` calls.
+            let result =
+                std::task::ready!(this.writable_fut.as_mut().as_pin_mut().unwrap().poll(cx));
+
             // Polling an arbitrary `Future` after it becomes ready is a logic error, so arrange for
             // a new `Future` to be created on the next call.
-            this.fut.set(None);
+            this.writable_fut.set(None);
+
+            // If .writable() fails, propagate the error
+            result?;
+
+            match this.socket.try_send(transmit) {
+                // We thought the socket was writable, but it wasn't, then retry so that either another
+                // `writable().await` call determines that the socket is indeed not writable and
+                // registers us for a wakeup, or the send succeeds if this really was just a
+                // transient failure.
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                // In all other cases, either propagate the error or we're Ok
+                result => return Poll::Ready(result),
+            }
         }
-        result
+    }
+
+    fn max_transmit_segments(&self) -> usize {
+        self.socket.max_transmit_segments()
     }
 }
 
-impl<MakeFut, Fut> Debug for UdpPollHelper<MakeFut, Fut> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("UdpPollHelper").finish_non_exhaustive()
-    }
+/// Parts of the [`UdpSender`] trait that aren't asynchronous or require storing wakers.
+///
+/// This trait is used by [`UdpSenderHelper`] to help construct [`UdpSender`]s.
+trait UdpSenderHelperSocket: Send + Sync + 'static {
+    /// Try to send a transmit, if the socket happens to be write-ready.
+    ///
+    /// If not write-ready, this is allowed to return [`std::io::ErrorKind::WouldBlock`].
+    ///
+    /// The [`UdpSenderHelper`] will use this to implement [`UdpSender::poll_send`].
+    fn try_send(&self, transmit: &udp::Transmit) -> io::Result<()>;
+
+    /// See [`UdpSender::max_transmit_segments`].
+    fn max_transmit_segments(&self) -> usize;
 }
 
 /// Automatically select an appropriate runtime from those enabled at compile time


### PR DESCRIPTION
This PR contains some changes to the `AsyncUdpSocket` trait. In short:
- `poll_recv` now takes `&mut self` instead of `&self`
- `try_send` is removed from `AsyncUdpSocket`
- `create_io_poller` and the `UdpPoller` trait are now replaced with `create_sender` and the `UdpSender` trait
- the `UdpSender` trait has a `try_send` as well as a `poll_send` function (that takes `self: Pin<&mut Self>`) instead of a `poll_writable` function

The final traits look like this:
```rs
pub trait AsyncUdpSocket: Send + Sync + Debug + 'static {
    fn create_sender(&self) -> Pin<Box<dyn UdpSender>>;

    fn poll_recv(
        &mut self,
        cx: &mut Context,
        bufs: &mut [IoSliceMut<'_>],
        meta: &mut [RecvMeta],
    ) -> Poll<io::Result<usize>>;

    fn local_addr(&self) -> io::Result<SocketAddr>;

    fn max_receive_segments(&self) -> usize;

    fn may_fragment(&self) -> bool;
}

pub trait UdpSender: Send + Sync + Debug + 'static {
    fn poll_send(
        self: Pin<&mut Self>,
        transmit: &Transmit,
        cx: &mut Context,
    ) -> Poll<io::Result<()>>;

    fn max_transmit_segments(&self) -> usize;
    
    fn try_send(self: Pin<&mut Self>, transmit: &Transmit) -> io::Result<()>;
}
```

## Motivation

The general idea is to encode the invariants that the runtime and socket implementations need to adhere to into rust's type system.
One of the harder things for me was to understand initially when I was working with quinn's `AsyncUdpSocket` was when you're allowed to overwrite the waker you're getting from `poll_recv` and when you can't, and similarly for the old `UdpPoller`.
Also, with iroh we had annoying issues with passing state from `poll_writable` to `try_send`. With a single `poll_send` that gives you (essentially) `&mut self` access, this gets *much* easier.

With all of these changes it's also a lot clearer when it's fine to overwrite wakers in your custom implementation. If `&mut self` is passed in from your `poll` function, then you *know* you can only be called from a single task that owns you at a time, thus you can safely overwrite old wakers (and even do so without any use of mutexes or fancy linked lists or anything like that).

## Performance

I've tried testing the performance of this on various systems (my laptop, dedicated bare metal servers, etc.). I wasn't able to determine any differences, but at the same time, I always got very inconsistent results (both on quinn `main` and this PR).
I'd really appreciate any help from someone who knows how to benchmark quinn effectively. There's some more things I can try, such as fiddling with the constants mentioned in https://github.com/quinn-rs/quinn/issues/1126, but other than that I'm out of ideas.
Looking at the code, this *should not* have a negative performance impact. I think there's technically 1 more Arc clone for initiating connections, but other than that it should result in pretty much the same amount of work/same sequence of syscalls.