### PR TITLE
proto: Remove write_source (pull in `IndexMap` to avoid borrowing issues)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +919,12 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "hdrhistogram"
@@ -1088,6 +1100,16 @@ checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1559,6 +1581,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.3",
  "hex-literal",
+ "indexmap",
  "lazy_static",
  "lru-slab",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ futures-io = "0.3.19"
 getrandom = { version = "0.3", default-features = false }
 hdrhistogram = { version = "7.2", default-features = false }
 hex-literal = "0.4"
+indexmap = "2.9.0"
 lru-slab = "0.1.2"
 lazy_static = "1"
 log = "0.4"

--- a/fuzz/fuzz_targets/streams.rs
+++ b/fuzz/fuzz_targets/streams.rs
@@ -50,7 +50,8 @@ fuzz_target!(|input: (StreamParams, Vec<Operation>)| {
                 Streams::new(&mut state, &conn_state).accept(dir);
             }
             Operation::Finish(id) => {
-                let _ = SendStream::new(id, &mut state, &mut pending, &conn_state).finish();
+                let _ =
+                    SendStream::new_for_fuzzing(id, &mut state, &mut pending, &conn_state).finish();
             }
             Operation::ReceivedStopSending(sid, err_code) => {
                 Streams::new(&mut state, &conn_state)
@@ -63,8 +64,8 @@ fuzz_target!(|input: (StreamParams, Vec<Operation>)| {
                     .received_reset(rs);
             }
             Operation::Reset(id) => {
-                let _ =
-                    SendStream::new(id, &mut state, &mut pending, &conn_state).reset(0u32.into());
+                let _ = SendStream::new_for_fuzzing(id, &mut state, &mut pending, &conn_state)
+                    .reset(0u32.into());
             }
         }
     }

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -39,6 +39,7 @@ arbitrary = { workspace = true, optional = true }
 aws-lc-rs = { workspace = true, optional = true }
 bytes = { workspace = true }
 fastbloom = { workspace = true, optional = true }
+indexmap = { workspace = true }
 lru-slab = { workspace = true }
 rustc-hash = { workspace = true }
 rand = { workspace = true }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -426,12 +426,12 @@ impl Connection {
     #[must_use]
     pub fn send_stream(&mut self, id: StreamId) -> SendStream<'_> {
         assert!(id.dir() == Dir::Bi || id.initiator() == self.side.side());
-        SendStream {
+        SendStream::new(
             id,
-            state: &mut self.streams,
-            pending: &mut self.spaces[SpaceId::Data].pending,
-            conn_state: &self.state,
-        }
+            &mut self.streams,
+            &mut self.spaces[SpaceId::Data].pending,
+            &self.state,
+        )
     }
 
     /// Returns packets to transmit

--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -203,7 +203,16 @@ pub struct SendStream<'a> {
 #[allow(clippy::needless_lifetimes)] // Needed for cfg(fuzzing)
 impl<'a> SendStream<'a> {
     #[cfg(fuzzing)]
-    pub fn new(
+    pub fn new_for_fuzzing(
+        id: StreamId,
+        state: &'a mut StreamsState,
+        pending: &'a mut Retransmits,
+        conn_state: &'a super::State,
+    ) -> Self {
+        Self::new(id, state, pending, conn_state)
+    }
+
+    pub(super) fn new(
         id: StreamId,
         state: &'a mut StreamsState,
         pending: &'a mut Retransmits,

--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -8,20 +8,15 @@ use thiserror::Error;
 use tracing::trace;
 
 use super::spaces::{Retransmits, ThinRetransmits};
-use crate::{
-    Dir, StreamId, VarInt,
-    connection::streams::state::get_or_insert_recv,
-    frame,
-};
+use crate::{Dir, StreamId, VarInt, connection::streams::state::get_or_insert_recv, frame};
 
 mod recv;
 use recv::Recv;
 pub use recv::{Chunks, ReadError, ReadableError};
 
 mod send;
-pub(crate) use send::{ByteSlice, BytesArray};
-use send::{BytesSource, Send, SendState};
 pub use send::{FinishError, WriteError, Written};
+use send::{Send, SendState};
 
 mod state;
 #[allow(unreachable_pub)] // fuzzing only
@@ -233,7 +228,9 @@ impl<'a> SendStream<'a> {
     ///
     /// Returns the number of bytes successfully written.
     pub fn write(&mut self, data: &[u8]) -> Result<usize, WriteError> {
-        Ok(self.write_source(&mut ByteSlice::from_slice(data))?.bytes)
+        let prefix_len = self.write_limit()?.min(data.len());
+        self.write_unchecked(data[..prefix_len].to_vec().into());
+        Ok(prefix_len)
     }
 
     /// Send data on the given stream
@@ -243,10 +240,27 @@ impl<'a> SendStream<'a> {
     /// [`Written::chunks`] will not count this chunk as fully written. However
     /// the chunk will be advanced and contain only non-written data after the call.
     pub fn write_chunks(&mut self, data: &mut [Bytes]) -> Result<Written, WriteError> {
-        self.write_source(&mut BytesArray::from_chunks(data))
+        let limit = self.write_limit()?;
+        let mut written = Written::default();
+        for chunk in data {
+            let prefix = chunk.split_to(chunk.len().min(limit - written.bytes));
+            written.bytes += prefix.len();
+            self.write_unchecked(prefix);
+
+            if chunk.is_empty() {
+                written.chunks += 1;
+            }
+
+            debug_assert!(written.bytes <= limit);
+            if written.bytes == limit {
+                break;
+            }
+        }
+        Ok(written)
     }
 
-    fn write_source<B: BytesSource>(&mut self, source: &mut B) -> Result<Written, WriteError> {
+    /// Get how many bytes could be written immediately, or mark as blocked if zero
+    fn write_limit(&mut self) -> Result<usize, WriteError> {
         if self.conn_state.is_closed() {
             trace!(%self.id, "write blocked; connection draining");
             return Err(WriteError::Blocked);
@@ -271,15 +285,20 @@ impl<'a> SendStream<'a> {
             return Err(WriteError::Blocked);
         }
 
+        stream.write_limit(limit)
+    }
+
+    /// Write bytes under the assumption that `write_limit().unwrap() <= chunk.len()`
+    fn write_unchecked(&mut self, chunk: Bytes) {
+        let stream = self.state.send[self.index.unwrap()].as_mut().unwrap();
         let was_pending = stream.is_pending();
-        let written = stream.write(source, limit)?;
-        self.state.data_sent += written.bytes as u64;
-        self.state.unacked_data += written.bytes as u64;
-        trace!(stream = %self.id, "wrote {} bytes", written.bytes);
+        self.state.data_sent += chunk.len() as u64;
+        self.state.unacked_data += chunk.len() as u64;
+        trace!(stream = %self.id, "wrote {} bytes", chunk.len());
+        stream.pending.write(chunk);
         if !was_pending {
             self.state.pending.push_pending(self.id, stream.priority);
         }
-        Ok(written)
     }
 
     /// Check if this stream was stopped, get the reason if it was

--- a/quinn-proto/src/connection/streams/send.rs
+++ b/quinn-proto/src/connection/streams/send.rs
@@ -1,4 +1,3 @@
-use bytes::Bytes;
 use thiserror::Error;
 
 use crate::{VarInt, connection::send_buffer::SendBuffer, frame};
@@ -49,11 +48,7 @@ impl Send {
         }
     }
 
-    pub(super) fn write<S: BytesSource>(
-        &mut self,
-        source: &mut S,
-        limit: u64,
-    ) -> Result<Written, WriteError> {
+    pub(super) fn write_limit(&self, limit: u64) -> Result<usize, WriteError> {
         if !self.is_writable() {
             return Err(WriteError::ClosedStream);
         }
@@ -64,23 +59,7 @@ impl Send {
         if budget == 0 {
             return Err(WriteError::Blocked);
         }
-        let mut limit = limit.min(budget) as usize;
-
-        let mut result = Written::default();
-        loop {
-            let (chunk, chunks_consumed) = source.pop_chunk(limit);
-            result.chunks += chunks_consumed;
-            result.bytes += chunk.len();
-
-            if chunk.is_empty() {
-                break;
-            }
-
-            limit -= chunk.len();
-            self.pending.write(chunk);
-        }
-
-        Ok(result)
+        Ok(limit.min(budget) as usize)
     }
 
     /// Update stream state due to a reset sent by the local application
@@ -143,106 +122,6 @@ impl Send {
     }
 }
 
-/// A [`BytesSource`] implementation for `&'a mut [Bytes]`
-///
-/// The type allows to dequeue [`Bytes`] chunks from an array of chunks, up to
-/// a configured limit.
-pub(crate) struct BytesArray<'a> {
-    /// The wrapped slice of `Bytes`
-    chunks: &'a mut [Bytes],
-    /// The amount of chunks consumed from this source
-    consumed: usize,
-}
-
-impl<'a> BytesArray<'a> {
-    pub(crate) fn from_chunks(chunks: &'a mut [Bytes]) -> Self {
-        Self {
-            chunks,
-            consumed: 0,
-        }
-    }
-}
-
-impl BytesSource for BytesArray<'_> {
-    fn pop_chunk(&mut self, limit: usize) -> (Bytes, usize) {
-        // The loop exists to skip empty chunks while still marking them as
-        // consumed
-        let mut chunks_consumed = 0;
-
-        while self.consumed < self.chunks.len() {
-            let chunk = &mut self.chunks[self.consumed];
-
-            if chunk.len() <= limit {
-                let chunk = std::mem::take(chunk);
-                self.consumed += 1;
-                chunks_consumed += 1;
-                if chunk.is_empty() {
-                    continue;
-                }
-                return (chunk, chunks_consumed);
-            } else if limit > 0 {
-                let chunk = chunk.split_to(limit);
-                return (chunk, chunks_consumed);
-            } else {
-                break;
-            }
-        }
-
-        (Bytes::new(), chunks_consumed)
-    }
-}
-
-/// A [`BytesSource`] implementation for `&[u8]`
-///
-/// The type allows to dequeue a single [`Bytes`] chunk, which will be lazily
-/// created from a reference. This allows to defer the allocation until it is
-/// known how much data needs to be copied.
-pub(crate) struct ByteSlice<'a> {
-    /// The wrapped byte slice
-    data: &'a [u8],
-}
-
-impl<'a> ByteSlice<'a> {
-    pub(crate) fn from_slice(data: &'a [u8]) -> Self {
-        Self { data }
-    }
-}
-
-impl BytesSource for ByteSlice<'_> {
-    fn pop_chunk(&mut self, limit: usize) -> (Bytes, usize) {
-        let limit = limit.min(self.data.len());
-        if limit == 0 {
-            return (Bytes::new(), 0);
-        }
-
-        let chunk = Bytes::from(self.data[..limit].to_owned());
-        self.data = &self.data[chunk.len()..];
-
-        let chunks_consumed = usize::from(self.data.is_empty());
-        (chunk, chunks_consumed)
-    }
-}
-
-/// A source of one or more buffers which can be converted into `Bytes` buffers on demand
-///
-/// The purpose of this data type is to defer conversion as long as possible,
-/// so that no heap allocation is required in case no data is writable.
-pub(super) trait BytesSource {
-    /// Returns the next chunk from the source of owned chunks.
-    ///
-    /// This method will consume parts of the source.
-    /// Calling it will yield `Bytes` elements up to the configured `limit`.
-    ///
-    /// The method returns a tuple:
-    /// - The first item is the yielded `Bytes` element. The element will be
-    ///   empty if the limit is zero or no more data is available.
-    /// - The second item returns how many complete chunks inside the source had
-    ///   had been consumed. This can be less than 1, if a chunk inside the
-    ///   source had been truncated in order to adhere to the limit. It can also
-    ///   be more than 1, if zero-length chunks had been skipped.
-    fn pop_chunk(&mut self, limit: usize) -> (Bytes, usize);
-}
-
 /// Indicates how many bytes and chunks had been transferred in a write operation
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 pub struct Written {
@@ -302,101 +181,4 @@ pub enum FinishError {
     /// The stream has not been opened or was already finished or reset
     #[error("closed stream")]
     ClosedStream,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn bytes_array() {
-        let full = b"Hello World 123456789 ABCDEFGHJIJKLMNOPQRSTUVWXYZ".to_owned();
-        for limit in 0..full.len() {
-            let mut chunks = [
-                Bytes::from_static(b""),
-                Bytes::from_static(b"Hello "),
-                Bytes::from_static(b"Wo"),
-                Bytes::from_static(b""),
-                Bytes::from_static(b"r"),
-                Bytes::from_static(b"ld"),
-                Bytes::from_static(b""),
-                Bytes::from_static(b" 12345678"),
-                Bytes::from_static(b"9 ABCDE"),
-                Bytes::from_static(b"F"),
-                Bytes::from_static(b"GHJIJKLMNOPQRSTUVWXYZ"),
-            ];
-            let num_chunks = chunks.len();
-            let last_chunk_len = chunks[chunks.len() - 1].len();
-
-            let mut array = BytesArray::from_chunks(&mut chunks);
-
-            let mut buf = Vec::new();
-            let mut chunks_popped = 0;
-            let mut chunks_consumed = 0;
-            let mut remaining = limit;
-            loop {
-                let (chunk, consumed) = array.pop_chunk(remaining);
-                chunks_consumed += consumed;
-
-                if !chunk.is_empty() {
-                    buf.extend_from_slice(&chunk);
-                    remaining -= chunk.len();
-                    chunks_popped += 1;
-                } else {
-                    break;
-                }
-            }
-
-            assert_eq!(&buf[..], &full[..limit]);
-
-            if limit == full.len() {
-                // Full consumption of the last chunk
-                assert_eq!(chunks_consumed, num_chunks);
-                // Since there are empty chunks, we consume more than there are popped
-                assert_eq!(chunks_consumed, chunks_popped + 3);
-            } else if limit > full.len() - last_chunk_len {
-                // Partial consumption of the last chunk
-                assert_eq!(chunks_consumed, num_chunks - 1);
-                assert_eq!(chunks_consumed, chunks_popped + 2);
-            }
-        }
-    }
-
-    #[test]
-    fn byte_slice() {
-        let full = b"Hello World 123456789 ABCDEFGHJIJKLMNOPQRSTUVWXYZ".to_owned();
-        for limit in 0..full.len() {
-            let mut array = ByteSlice::from_slice(&full[..]);
-
-            let mut buf = Vec::new();
-            let mut chunks_popped = 0;
-            let mut chunks_consumed = 0;
-            let mut remaining = limit;
-            loop {
-                let (chunk, consumed) = array.pop_chunk(remaining);
-                chunks_consumed += consumed;
-
-                if !chunk.is_empty() {
-                    buf.extend_from_slice(&chunk);
-                    remaining -= chunk.len();
-                    chunks_popped += 1;
-                } else {
-                    break;
-                }
-            }
-
-            assert_eq!(&buf[..], &full[..limit]);
-            if limit != 0 {
-                assert_eq!(chunks_popped, 1);
-            } else {
-                assert_eq!(chunks_popped, 0);
-            }
-
-            if limit == full.len() {
-                assert_eq!(chunks_consumed, 1);
-            } else {
-                assert_eq!(chunks_consumed, 0);
-            }
-        }
-    }
 }

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -1290,12 +1290,7 @@ mod tests {
         .open(Dir::Uni)
         .unwrap();
 
-        let mut stream = SendStream {
-            id,
-            state: &mut server,
-            pending: &mut pending,
-            conn_state: &state,
-        };
+        let mut stream = SendStream::new(id, &mut server, &mut pending, &state);
 
         let error_code = 0u32.into();
         stream.state.received_stop_sending(id, error_code);
@@ -1353,29 +1348,14 @@ mod tests {
         let id_mid = streams.open(Dir::Bi).unwrap();
         let id_low = streams.open(Dir::Bi).unwrap();
 
-        let mut mid = SendStream {
-            id: id_mid,
-            state: &mut server,
-            pending: &mut pending,
-            conn_state: &state,
-        };
+        let mut mid = SendStream::new(id_mid, &mut server, &mut pending, &state);
         mid.write(b"mid").unwrap();
 
-        let mut low = SendStream {
-            id: id_low,
-            state: &mut server,
-            pending: &mut pending,
-            conn_state: &state,
-        };
+        let mut low = SendStream::new(id_low, &mut server, &mut pending, &state);
         low.set_priority(-1).unwrap();
         low.write(b"low").unwrap();
 
-        let mut high = SendStream {
-            id: id_high,
-            state: &mut server,
-            pending: &mut pending,
-            conn_state: &state,
-        };
+        let mut high = SendStream::new(id_high, &mut server, &mut pending, &state);
         high.set_priority(1).unwrap();
         high.write(b"high").unwrap();
 
@@ -1408,21 +1388,11 @@ mod tests {
         let id_high = streams.open(Dir::Bi).unwrap();
         let id_mid = streams.open(Dir::Bi).unwrap();
 
-        let mut mid = SendStream {
-            id: id_mid,
-            state: &mut server,
-            pending: &mut pending,
-            conn_state: &state,
-        };
+        let mut mid = SendStream::new(id_mid, &mut server, &mut pending, &state);
         assert_eq!(mid.write(b"mid").unwrap(), 3);
         assert_eq!(server.pending.len(), 1);
 
-        let mut high = SendStream {
-            id: id_high,
-            state: &mut server,
-            pending: &mut pending,
-            conn_state: &state,
-        };
+        let mut high = SendStream::new(id_high, &mut server, &mut pending, &state);
         high.set_priority(1).unwrap();
         assert_eq!(high.write(&[0; 200]).unwrap(), 200);
         assert_eq!(server.pending.len(), 2);
@@ -1430,12 +1400,7 @@ mod tests {
         // Requeue the high priority stream to lowest priority. The initial send
         // still uses high priority since it's queued that way. After that it will
         // switch to low priority
-        let mut high = SendStream {
-            id: id_high,
-            state: &mut server,
-            pending: &mut pending,
-            conn_state: &state,
-        };
+        let mut high = SendStream::new(id_high, &mut server, &mut pending, &state);
         high.set_priority(-1).unwrap();
 
         let mut buf = Vec::with_capacity(1000);
@@ -1478,28 +1443,13 @@ mod tests {
             let id_b = streams.open(Dir::Bi).unwrap();
             let id_c = streams.open(Dir::Bi).unwrap();
 
-            let mut stream_a = SendStream {
-                id: id_a,
-                state: &mut server,
-                pending: &mut pending,
-                conn_state: &state,
-            };
+            let mut stream_a = SendStream::new(id_a, &mut server, &mut pending, &state);
             stream_a.write(&[b'a'; 100]).unwrap();
 
-            let mut stream_b = SendStream {
-                id: id_b,
-                state: &mut server,
-                pending: &mut pending,
-                conn_state: &state,
-            };
+            let mut stream_b = SendStream::new(id_b, &mut server, &mut pending, &state);
             stream_b.write(&[b'b'; 100]).unwrap();
 
-            let mut stream_c = SendStream {
-                id: id_c,
-                state: &mut server,
-                pending: &mut pending,
-                conn_state: &state,
-            };
+            let mut stream_c = SendStream::new(id_c, &mut server, &mut pending, &state);
             stream_c.write(&[b'c'; 100]).unwrap();
 
             let mut metas = vec![];
@@ -1558,20 +1508,10 @@ mod tests {
         let id_b = streams.open(Dir::Bi).unwrap();
         let id_c = streams.open(Dir::Bi).unwrap();
 
-        let mut stream_a = SendStream {
-            id: id_a,
-            state: &mut server,
-            pending: &mut pending,
-            conn_state: &state,
-        };
+        let mut stream_a = SendStream::new(id_a, &mut server, &mut pending, &state);
         stream_a.write(&[b'a'; 100]).unwrap();
 
-        let mut stream_b = SendStream {
-            id: id_b,
-            state: &mut server,
-            pending: &mut pending,
-            conn_state: &state,
-        };
+        let mut stream_b = SendStream::new(id_b, &mut server, &mut pending, &state);
         stream_b.write(&[b'b'; 100]).unwrap();
 
         let mut metas = vec![];
@@ -1584,12 +1524,7 @@ mod tests {
         metas.extend(meta);
 
         // Queue stream_c which has higher priority
-        let mut stream_c = SendStream {
-            id: id_c,
-            state: &mut server,
-            pending: &mut pending,
-            conn_state: &state,
-        };
+        let mut stream_c = SendStream::new(id_c, &mut server, &mut pending, &state);
         stream_c.set_priority(1).unwrap();
         stream_c.write(&[b'b'; 100]).unwrap();
 
@@ -1658,12 +1593,7 @@ mod tests {
         };
 
         let id = streams.open(Dir::Uni).unwrap();
-        let mut stream = SendStream {
-            id,
-            state: &mut server,
-            pending: &mut pending,
-            conn_state: &state,
-        };
+        let mut stream = SendStream::new(id, &mut server, &mut pending, &state);
         stream.write(b"hello").unwrap();
         stream.reset(0u32.into()).unwrap();
 


### PR DESCRIPTION
This PR is competing with and mutually exclusive with my previous #2242 and #2230. I think this is the best iteration so far.

Successfully removes `WriteSource` without utilizing a callback (per #2230) nor introducing lifetime stuff (per #2242), and successfully splits up the `write_source` method's logic more deeply than those two.

Introduces dependency on `indexmap` crate. This seems fine to me. It's an extremely common crate and likely to be useful for other things too.

#### Notes on possible follow-up work

As I've expressed on the other PRs, I like the idea of introducing some sort of public API capable of doing what `WriteSource` can do. This PR is actually more helpful to that goal than #2242. In #2242, introducing some sort of quinn version of `WriteGuard<'_>` would mean we'd want to create a struct which contains both a mutex guard and a `proto::WriteGuard<'_>` which borrows from that mutex guard. This probably would require us to either pull in the ouroboros crate or write equivalent unsafe code manually, or to complicate the API in some ugly way. Conversely, with the approach implemented in this PR, we could conceivably just make `write_limit` and `write_unchecked` public and give quinn a `WriteGuard` struct which contains a mutex guard and a `usize` write budget. Or something like that.

Also, a different bit of follow-up work that could be done after that would be to modify `RecvStream` to do a similar sort of preemptive hashmap lookup, if we wanted.