### PR TITLE
expose `Connection::side()` in `quinn`

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -25,8 +25,8 @@ use crate::{
     udp_transmit,
 };
 use proto::{
-    ConnectionError, ConnectionHandle, ConnectionStats, Dir, EndpointEvent, StreamEvent, StreamId,
-    congestion::Controller,
+    ConnectionError, ConnectionHandle, ConnectionStats, Dir, EndpointEvent, Side, StreamEvent,
+    StreamId, congestion::Controller,
 };
 
 /// In-progress connection attempt future
@@ -494,6 +494,11 @@ impl Connection {
             .inner
             .datagrams()
             .send_buffer_space()
+    }
+
+    /// The side of the connection (client or server)
+    pub fn side(&self) -> Side {
+        self.0.state.lock("side").inner.side()
     }
 
     /// The peer's UDP address


### PR DESCRIPTION
[`Side` is exported in `quinn`](https://docs.rs/quinn/latest/quinn/enum.Side.html) but there's no actual way to get it from `Connection`. Seems like a simple oversight. 

Otherwise, this means it must be passed around separately to do any kind of client- or server-specific logic, which gets quite annoying. 