### PR TITLE
refactor(quinn): Configure out `async_io::UdpSocket` when unused

### DIFF
--- a/quinn/src/runtime.rs
+++ b/quinn/src/runtime.rs
@@ -119,7 +119,6 @@ impl<MakeFut, Fut> UdpPollHelper<MakeFut, Fut> {
         feature = "runtime-async-std",
         feature = "runtime-smol",
         feature = "runtime-tokio",
-        feature = "async-io"
     ))]
     fn new(make_fut: MakeFut) -> Self {
         Self {


### PR DESCRIPTION
For some reason I'm not getting a "`UdpSocket` is unused" when I run `cargo check -p quinn --no-default-features --features async-io", even though cfg-ing it out totally works and it fails in conjunction with other changes (see #2259).

Previous discussion: https://github.com/quinn-rs/quinn/pull/2259#discussion_r2127726193