### PR TITLE
feat: add `Connection::set_send_window()`

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1421,6 +1421,11 @@ impl Connection {
         self.streams.max_concurrent(dir)
     }
 
+    /// See [`TransportConfig::send_window()`]
+    pub fn set_send_window(&mut self, send_window: u64) {
+        self.streams.set_send_window(send_window);
+    }
+
     /// See [`TransportConfig::receive_window()`]
     pub fn set_receive_window(&mut self, receive_window: VarInt) {
         if self.streams.set_receive_window(receive_window) {

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -627,6 +627,13 @@ impl Connection {
         conn.wake();
     }
 
+    /// See [`proto::TransportConfig::send_window()`]
+    pub fn set_send_window(&self, send_window: u64) {
+        let mut conn = self.0.state.lock("set_send_window");
+        conn.inner.set_send_window(send_window);
+        conn.wake();
+    }
+
     /// See [`proto::TransportConfig::receive_window()`]
     pub fn set_receive_window(&self, receive_window: VarInt) {
         let mut conn = self.0.state.lock("set_receive_window");


### PR DESCRIPTION
We have a desire to limit the amount of bandwidth used for a given peer in both directions, but by the nature of the application, we can't decide that limit is until we're already connected to the peer and have verified their identity.

We already make use of backpressure throughout the application, so we can use the connection itself to limit the bandwidth used without everything backing up elsewhere.

I think we can most easily affect this by setting the `receive_window` to our desired bandwidth times the RTT, but that only gives us control over inbound bandwidth; we don't currently have a way to set the `send_window` after the connection is established.

Looking through the implementation, the handling of `send_window` doesn't look to be _nearly_ as complex as `read_window` since it's a purely local control knob, so I feel like letting the user set it dynamically shouldn't cause any issues.

I do have a question about how best to _test_ this. I see there's tests for `set_receive_window` that I can copy, but I've only got an inkling of how the `send_window` tests should work:

* Create a `stream::State` with a set `send_window`
* Open and try to write to a stream, observe that it only accepts `send_window` bytes
* Increase `send_window` and see if `State::poll()` generates a `Writable` event?

How would I test the shrinkage of `send_window`? Write N bytes, ack them, set `send_window < N` and try to write the same amount again?


