### PR TITLE
chore(udp): increase patch version to v0.5.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "cfg_aliases",
  "criterion",

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.5.12"
+version = "0.5.13"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Thanks to @inetic `quinn-udp` no longer falsely detects GSO support in kernel <4.18 (https://github.com/quinn-rs/quinn/pull/2248).

Any objections shipping this patch as a new `quinn-udp` patch release?

Background: I am working on GSO support in Firefox's QUIC stack. See https://github.com/mozilla/neqo/pull/2593 for details.