### PR TITLE
Catch EOPNOTSUPP for opportunistic socket flags

### DIFF
--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -1028,6 +1028,7 @@ fn set_socket_option_supported(
     match set_socket_option(socket, level, name, value) {
         Ok(()) => Ok(true),
         Err(err) if err.raw_os_error() == Some(libc::ENOPROTOOPT) => Ok(false),
+        Err(err) if err.raw_os_error() == Some(libc::EOPNOTSUPP) => Ok(false),
         Err(err) => Err(err),
     }
 }


### PR DESCRIPTION
The [OS error raised by gvisor](https://github.com/google/gvisor/blob/master/pkg/sentry/socket/netstack/netstack.go#L1638) when setting `SOL_IP` options on UDP sockets is `EOPNOTSUPP`.

Since the flags are labeled as opportunistic on Linux, this patch allows the connection to be made by considering `EOPNOTSUPP` an acceptable code.