### PR TITLE
Implement spurious loss recovery

### DIFF
--- a/quinn-proto/src/congestion.rs
+++ b/quinn-proto/src/congestion.rs
@@ -56,8 +56,15 @@ pub trait Controller: Send + Sync {
         now: Instant,
         sent: Instant,
         is_persistent_congestion: bool,
+        is_ecn: bool,
         lost_bytes: u64,
     );
+
+    /// Packets were incorrectly deemed lost
+    ///
+    /// This function is called when all packets that were deemed lost (for instance because
+    /// of packet reordering) are acknowledged after the congestion event was raised.
+    fn on_spurious_congestion_event(&mut self) {}
 
     /// The known MTU for the current network path has been updated
     fn on_mtu_update(&mut self, new_mtu: u16);

--- a/quinn-proto/src/congestion/bbr/mod.rs
+++ b/quinn-proto/src/congestion/bbr/mod.rs
@@ -465,6 +465,7 @@ impl Controller for Bbr {
         _now: Instant,
         _sent: Instant,
         _is_persistent_congestion: bool,
+        _is_ecn: bool,
         lost_bytes: u64,
     ) {
         self.loss_state.lost_bytes += lost_bytes;

--- a/quinn-proto/src/congestion/new_reno.rs
+++ b/quinn-proto/src/congestion/new_reno.rs
@@ -87,6 +87,7 @@ impl Controller for NewReno {
         now: Instant,
         sent: Instant,
         is_persistent_congestion: bool,
+        _is_ecn: bool,
         _lost_bytes: u64,
     ) {
         if sent <= self.recovery_start_time {

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -39,6 +39,9 @@ pub(super) struct PacketSpace {
     /// Transmitted but not acked
     // We use a BTreeMap here so we can efficiently query by range on ACK and for loss detection
     pub(super) sent_packets: BTreeMap<u64, SentPacket>,
+    /// Packets that were deemed lost
+    // Older packets are regularly removed in `Connection::drain_lost_packets`.
+    pub(super) lost_packets: BTreeMap<u64, LostPacket>,
     /// Number of explicit congestion notification codepoints seen on incoming packets
     pub(super) ecn_counters: frame::EcnCounts,
     /// Recent ECN counters sent by the peer in ACK frames
@@ -84,6 +87,7 @@ impl PacketSpace {
             largest_ack_eliciting_sent: 0,
             unacked_non_ack_eliciting_tail: 0,
             sent_packets: BTreeMap::new(),
+            lost_packets: BTreeMap::new(),
             ecn_counters: frame::EcnCounts::ZERO,
             ecn_feedback: frame::EcnCounts::ZERO,
 
@@ -300,6 +304,13 @@ pub(super) struct SentPacket {
     ///
     /// The actual application data is stored with the stream state.
     pub(super) stream_frames: frame::StreamMetaVec,
+}
+
+/// Represents one or more packets that are deemed lost.
+#[derive(Debug)]
+pub(super) struct LostPacket {
+    /// The time the packet was sent.
+    pub(super) time_sent: Instant,
 }
 
 /// Retransmittable data queue


### PR DESCRIPTION
Benchmarks in the cloud between two Linux machines on a 10ms/1Gbps link revealed that `quinn` performs consistently worse than `msquic`. Plotting the congestion window for both implementations shows that `msquic` reaches higher congestion window sizes, in part because [it implements spurious loss recovery](https://github.com/microsoft/msquic/blob/2623c07df62b4bd171f469fb29c2714b6735b676/src/core/loss_detection.c#L1400) (as described in [rfc8312bis](https://datatracker.ietf.org/doc/html/draft-ietf-tcpm-rfc8312bis-15#section-4.9) which is now [rfc9438](https://datatracker.ietf.org/doc/html/rfc9438#section-4.9)).

This PR implements a similar spurious loss recovery mechanism (`quinn` implements `rfc8312`)

Lost packets are stored in the `PacketSpace` and used on ACK reception to determine if all the packets we deemed lost were in fact acknowledged. This list is regularly purged from packets that were sent more than 2 PTO ago (this is the value used in `msquic`: https://github.com/microsoft/msquic/blob/2623c07df62b4bd171f469fb29c2714b6735b676/src/core/loss_detection.c#L925).

Overall, this appears to effectively improve throughput on the benchmark I described above: we've seen up to a 30% increase in upload bandwidth.

|         | main     | patch    | gain |
|---------|----------|----------|------|
| average | 314 Mbps | 391 Mbps | 25%  |
| P50     | 302 Mbps | 402 Mbps | 33%  |