### PR TITLE
chore(Cargo.toml): support both socket2 v0.5 and v0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 slab = "0.4.6"
 smol = "2"
-socket2 = "0.6"
+socket2 = ">=0.5, <0.7"
 thiserror = "2.0.3"
 tinyvec = { version = "1.1", features = ["alloc"] }
 tokio = { version = "1.28.1", features = ["sync"] }


### PR DESCRIPTION
Enables quinn-udp users like Firefox to gradually upgrade to socket2 v0.6.

---

//CC @Thomasdezeeuw

See discussion in https://github.com/quinn-rs/quinn/pull/2291.