### PR TITLE
Configure qlog in TransportConfig

### DIFF
--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -8,11 +8,11 @@ publish = false
 [features]
 # NOTE: Please keep this in sync with the feature list in `.github/workflows/codecov.yml`, see
 # comment in that file for more information.
-default = ["json-output", "__qlog"]
+default = ["json-output", "qlog"]
 # Allow for json output from the perf client
 json-output = ["serde", "serde_json"]
 # Enable qlog support
-__qlog = ["quinn/__qlog"]
+qlog = ["quinn/qlog"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -83,7 +83,7 @@ struct Opt {
     #[clap(long = "congestion")]
     cong_alg: Option<CongestionAlgorithm>,
     /// qlog output file
-    #[cfg(feature = "__qlog")]
+    #[cfg(feature = "qlog")]
     #[clap(long = "qlog")]
     qlog_file: Option<PathBuf>,
 }
@@ -165,7 +165,7 @@ async fn run(opt: Opt) -> Result<()> {
         transport.congestion_controller_factory(cong_alg.build());
     }
 
-    #[cfg(feature = "__qlog")]
+    #[cfg(feature = "qlog")]
     if let Some(qlog_file) = &opt.qlog_file {
         let mut qlog = quinn::QlogConfig::default();
         qlog.writer(Box::new(File::create(qlog_file)?))

--- a/perf/src/bin/perf_server.rs
+++ b/perf/src/bin/perf_server.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "__qlog")]
+#[cfg(feature = "qlog")]
 use std::fs::File;
 use std::{fs, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
@@ -53,7 +53,7 @@ struct Opt {
     #[clap(long = "congestion")]
     cong_alg: Option<CongestionAlgorithm>,
     /// qlog output file
-    #[cfg(feature = "__qlog")]
+    #[cfg(feature = "qlog")]
     #[clap(long = "qlog")]
     qlog_file: Option<PathBuf>,
 }
@@ -123,7 +123,7 @@ async fn run(opt: Opt) -> Result<()> {
         transport.congestion_controller_factory(cong_alg.build());
     }
 
-    #[cfg(feature = "__qlog")]
+    #[cfg(feature = "qlog")]
     if let Some(qlog_file) = &opt.qlog_file {
         let mut qlog = quinn::QlogConfig::default();
         qlog.writer(Box::new(File::create(qlog_file)?))

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -34,7 +34,7 @@ log = ["tracing/log"]
 # Enable rustls logging
 rustls-log = ["rustls?/logging"]
 # Enable qlog support
-__qlog = ["dep:qlog"]
+qlog = ["dep:qlog"]
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }

--- a/quinn-proto/src/config/mod.rs
+++ b/quinn-proto/src/config/mod.rs
@@ -26,9 +26,9 @@ use crate::{
 };
 
 mod transport;
-pub use transport::{AckFrequencyConfig, IdleTimeout, MtuDiscoveryConfig, TransportConfig};
 #[cfg(feature = "qlog")]
-pub use transport::{QlogConfig, QlogStream};
+pub use transport::QlogConfig;
+pub use transport::{AckFrequencyConfig, IdleTimeout, MtuDiscoveryConfig, TransportConfig};
 
 /// Global configuration for the endpoint, affecting all connections
 ///

--- a/quinn-proto/src/config/mod.rs
+++ b/quinn-proto/src/config/mod.rs
@@ -27,7 +27,7 @@ use crate::{
 
 mod transport;
 pub use transport::{AckFrequencyConfig, IdleTimeout, MtuDiscoveryConfig, TransportConfig};
-#[cfg(feature = "__qlog")]
+#[cfg(feature = "qlog")]
 pub use transport::{QlogConfig, QlogStream};
 
 /// Global configuration for the endpoint, affecting all connections

--- a/quinn-proto/src/config/mod.rs
+++ b/quinn-proto/src/config/mod.rs
@@ -27,6 +27,8 @@ use crate::{
 
 mod transport;
 pub use transport::{AckFrequencyConfig, IdleTimeout, MtuDiscoveryConfig, TransportConfig};
+#[cfg(feature = "__qlog")]
+pub use transport::{QlogConfig, QlogStream};
 
 /// Global configuration for the endpoint, affecting all connections
 ///

--- a/quinn-proto/src/config/transport.rs
+++ b/quinn-proto/src/config/transport.rs
@@ -1,8 +1,8 @@
 use std::{fmt, sync::Arc};
-#[cfg(feature = "__qlog")]
+#[cfg(feature = "qlog")]
 use std::{io, sync::Mutex, time::Instant};
 
-#[cfg(feature = "__qlog")]
+#[cfg(feature = "qlog")]
 use qlog::streamer::QlogStreamer;
 
 use crate::{Duration, INITIAL_MTU, MAX_UDP_PAYLOAD, VarInt, VarIntBoundsExceeded, congestion};
@@ -50,7 +50,7 @@ pub struct TransportConfig {
 
     pub(crate) enable_segmentation_offload: bool,
 
-    #[cfg(feature = "__qlog")]
+    #[cfg(feature = "qlog")]
     pub(crate) qlog_stream: Option<QlogStream>,
 }
 
@@ -339,7 +339,7 @@ impl TransportConfig {
     }
 
     /// qlog capture configuration to use for a particular connection
-    #[cfg(feature = "__qlog")]
+    #[cfg(feature = "qlog")]
     pub fn qlog_stream(&mut self, stream: Option<QlogStream>) -> &mut Self {
         self.qlog_stream = stream;
         self
@@ -386,7 +386,7 @@ impl Default for TransportConfig {
 
             enable_segmentation_offload: true,
 
-            #[cfg(feature = "__qlog")]
+            #[cfg(feature = "qlog")]
             qlog_stream: None,
         }
     }
@@ -420,7 +420,7 @@ impl fmt::Debug for TransportConfig {
                 deterministic_packet_numbers: _,
             congestion_controller_factory: _,
             enable_segmentation_offload,
-            #[cfg(feature = "__qlog")]
+            #[cfg(feature = "qlog")]
             qlog_stream,
         } = self;
         let mut s = fmt.debug_struct("TransportConfig");
@@ -451,7 +451,7 @@ impl fmt::Debug for TransportConfig {
             .field("datagram_send_buffer_size", datagram_send_buffer_size)
             // congestion_controller_factory not debug
             .field("enable_segmentation_offload", enable_segmentation_offload);
-        #[cfg(feature = "__qlog")]
+        #[cfg(feature = "qlog")]
         {
             s.field("qlog_stream", &qlog_stream.is_some());
         }
@@ -539,12 +539,12 @@ impl Default for AckFrequencyConfig {
 }
 
 /// Shareable handle to a single qlog output stream
-#[cfg(feature = "__qlog")]
+#[cfg(feature = "qlog")]
 #[derive(Clone)]
 pub struct QlogStream(pub(crate) Arc<Mutex<QlogStreamer>>);
 
 /// Configuration for qlog trace logging
-#[cfg(feature = "__qlog")]
+#[cfg(feature = "qlog")]
 pub struct QlogConfig {
     writer: Option<Box<dyn io::Write + Send + Sync>>,
     title: Option<String>,
@@ -552,7 +552,7 @@ pub struct QlogConfig {
     start_time: Instant,
 }
 
-#[cfg(feature = "__qlog")]
+#[cfg(feature = "qlog")]
 impl QlogConfig {
     /// Where to write a qlog `TraceSeq`
     pub fn writer(&mut self, writer: Box<dyn io::Write + Send + Sync>) -> &mut Self {
@@ -619,7 +619,7 @@ impl QlogConfig {
     }
 }
 
-#[cfg(feature = "__qlog")]
+#[cfg(feature = "qlog")]
 impl Default for QlogConfig {
     fn default() -> Self {
         Self {

--- a/quinn-proto/src/congestion.rs
+++ b/quinn-proto/src/congestion.rs
@@ -92,7 +92,7 @@ pub struct ControllerMetrics {
     pub congestion_window: u64,
     /// Slow start threshold (bytes)
     pub ssthresh: Option<u64>,
-    /// Pacing rate (bytes/s)
+    /// Pacing rate (bits/s)
     pub pacing_rate: Option<u64>,
 }
 

--- a/quinn-proto/src/congestion/bbr/mod.rs
+++ b/quinn-proto/src/congestion/bbr/mod.rs
@@ -490,7 +490,7 @@ impl Controller for Bbr {
         ControllerMetrics {
             congestion_window: self.window(),
             ssthresh: None,
-            pacing_rate: Some(self.pacing_rate),
+            pacing_rate: Some(self.pacing_rate * 8),
         }
     }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1934,6 +1934,14 @@ impl Connection {
             // Update outgoing spin bit, inverting iff we're the client
             self.spin = self.side.is_client() ^ spin;
         }
+
+        self.config.qlog_sink.emit_packet_received(
+            packet,
+            space_id,
+            !is_1rtt,
+            now,
+            self.orig_rem_cid,
+        );
     }
 
     fn reset_idle_timeout(&mut self, now: Instant, space: SpaceId) {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1738,6 +1738,14 @@ impl Connection {
 
             for &packet in &lost_packets {
                 let info = self.spaces[pn_space].take(packet).unwrap(); // safe: lost_packets is populated just above
+                self.config.qlog_sink.emit_packet_lost(
+                    packet,
+                    &info,
+                    lost_send_time,
+                    pn_space,
+                    now,
+                    self.orig_rem_cid,
+                );
                 self.remove_in_flight(packet, &info);
                 for frame in info.stream_frames {
                     self.streams.retransmit(frame);

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1050,7 +1050,7 @@ impl Connection {
         // sending a datagram of this size
         builder.pad_to(MIN_INITIAL_SIZE);
 
-        builder.finish(self, buf);
+        builder.finish(self, now, buf);
         self.stats.udp_tx.on_sent(1, buf.len());
 
         Some(Transmit {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -9,7 +9,7 @@ use std::{
 
 use bytes::{Bytes, BytesMut};
 use frame::StreamMetaVec;
-#[cfg(feature = "__qlog")]
+#[cfg(feature = "qlog")]
 use qlog::events::EventData;
 
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -364,11 +364,11 @@ impl Connection {
 
     /// Emit a `MetricsUpdated` event to the qlog streamer containing only updated values
     fn emit_qlog_recovery_metrics(&mut self, now: Instant) {
-        #[cfg(not(feature = "__qlog"))]
+        #[cfg(not(feature = "qlog"))]
         {
             _ = now;
         }
-        #[cfg(feature = "__qlog")]
+        #[cfg(feature = "qlog")]
         {
             let Some(qlog_stream) = self.config.qlog_stream.as_ref() else {
                 return;

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -378,10 +378,12 @@ impl Connection {
                 return;
             };
 
-            let event = EventData::MetricsUpdated(metrics);
+            // Time will be overwritten by `add_event_with_instant`
+            let mut event = qlog::events::Event::with_time(0.0, EventData::MetricsUpdated(metrics));
+            event.group_id = Some(self.orig_rem_cid.to_string());
 
             let mut qlog_streamer = qlog_stream.0.lock().unwrap();
-            if let Err(e) = qlog_streamer.add_event_data_with_instant(event, now) {
+            if let Err(e) = qlog_streamer.add_event_with_instant(event, now) {
                 warn!("could not emit qlog event: {e}");
             }
         }

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{Duration, Instant, TIMER_GRANULARITY, TransportConfig, congestion, packet::SpaceId};
 
-#[cfg(feature = "__qlog")]
+#[cfg(feature = "qlog")]
 use qlog::events::quic::MetricsUpdated;
 
 /// Description of a particular network path
@@ -47,7 +47,7 @@ pub(super) struct PathData {
     first_packet: Option<u64>,
 
     /// Snapshot of the qlog recovery metrics
-    #[cfg(feature = "__qlog")]
+    #[cfg(feature = "qlog")]
     congestion_metrics: CongestionMetrics,
 }
 
@@ -97,7 +97,7 @@ impl PathData {
             first_packet_after_rtt_sample: None,
             in_flight: InFlight::new(),
             first_packet: None,
-            #[cfg(feature = "__qlog")]
+            #[cfg(feature = "qlog")]
             congestion_metrics: CongestionMetrics::default(),
         }
     }
@@ -120,7 +120,7 @@ impl PathData {
             first_packet_after_rtt_sample: prev.first_packet_after_rtt_sample,
             in_flight: InFlight::new(),
             first_packet: None,
-            #[cfg(feature = "__qlog")]
+            #[cfg(feature = "qlog")]
             congestion_metrics: prev.congestion_metrics.clone(),
         }
     }
@@ -167,7 +167,7 @@ impl PathData {
         true
     }
 
-    #[cfg(feature = "__qlog")]
+    #[cfg(feature = "qlog")]
     pub(super) fn qlog_congestion_metrics(&mut self, pto_count: u32) -> Option<MetricsUpdated> {
         let controller_metrics = self.congestion.metrics();
 
@@ -194,7 +194,7 @@ impl PathData {
 /// Congestion metrics as described in [`recovery_metrics_updated`].
 ///
 /// [`recovery_metrics_updated`]: https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-quic-events.html#name-recovery_metrics_updated
-#[cfg(feature = "__qlog")]
+#[cfg(feature = "qlog")]
 #[derive(Default, Clone, PartialEq)]
 #[non_exhaustive]
 struct CongestionMetrics {
@@ -210,7 +210,7 @@ struct CongestionMetrics {
     pub pacing_rate: Option<u64>,
 }
 
-#[cfg(feature = "__qlog")]
+#[cfg(feature = "qlog")]
 impl CongestionMetrics {
     /// Retain only values that have been updated since the last snapshot.
     fn retain_updated(&self, previous: &Self) -> Self {

--- a/quinn-proto/src/connection/qlog.rs
+++ b/quinn-proto/src/connection/qlog.rs
@@ -72,7 +72,7 @@ impl QlogSink {
                 return;
             };
 
-            let Some(metrics) = path.qlog_congestion_metrics(pto_count) else {
+            let Some(metrics) = path.qlog_recovery_metrics(pto_count) else {
                 return;
             };
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -58,6 +58,8 @@ pub use config::{
     AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig,
     ServerConfig, StdSystemTime, TimeSource, TransportConfig, ValidationTokenConfig,
 };
+#[cfg(feature = "__qlog")]
+pub use config::{QlogConfig, QlogStream};
 
 pub mod crypto;
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -58,7 +58,7 @@ pub use config::{
     AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig,
     ServerConfig, StdSystemTime, TimeSource, TransportConfig, ValidationTokenConfig,
 };
-#[cfg(feature = "__qlog")]
+#[cfg(feature = "qlog")]
 pub use config::{QlogConfig, QlogStream};
 
 pub mod crypto;

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -49,17 +49,19 @@ pub use crate::connection::{
     SendDatagramError, SendStream, ShouldTransmit, StreamEvent, Streams, UdpStats, WriteError,
     Written,
 };
+#[cfg(feature = "qlog")]
+pub use connection::qlog::QlogStream;
 
 #[cfg(feature = "rustls")]
 pub use rustls;
 
 mod config;
+#[cfg(feature = "qlog")]
+pub use config::QlogConfig;
 pub use config::{
     AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig,
     ServerConfig, StdSystemTime, TimeSource, TransportConfig, ValidationTokenConfig,
 };
-#[cfg(feature = "qlog")]
-pub use config::{QlogConfig, QlogStream};
 
 pub mod crypto;
 

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -44,7 +44,7 @@ log = ["tracing/log", "proto/log", "udp/log"]
 # Enable rustls logging
 rustls-log = ["rustls?/logging"]
 # Enable qlog support
-__qlog = ["proto/__qlog"]
+qlog = ["proto/qlog"]
 
 [dependencies]
 async-io = { workspace = true, optional = true }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -644,20 +644,6 @@ impl Connection {
         // May need to send MAX_STREAMS to make progress
         conn.wake();
     }
-
-    /// Set up qlog for this connection.
-    #[cfg(feature = "__qlog")]
-    pub fn set_qlog(
-        &mut self,
-        writer: Box<dyn std::io::Write + Send + Sync>,
-        title: Option<String>,
-        description: Option<String>,
-    ) {
-        let mut state = self.0.state.lock("__qlog");
-        state
-            .inner
-            .set_qlog(writer, title, description, Instant::now());
-    }
 }
 
 pin_project! {

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -68,7 +68,7 @@ pub use proto::{
     TransportConfig, TransportErrorCode, UdpStats, ValidationTokenConfig, VarInt,
     VarIntBoundsExceeded, Written, congestion, crypto,
 };
-#[cfg(feature = "__qlog")]
+#[cfg(feature = "qlog")]
 pub use proto::{QlogConfig, QlogStream};
 #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
 pub use rustls;

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -68,6 +68,8 @@ pub use proto::{
     TransportConfig, TransportErrorCode, UdpStats, ValidationTokenConfig, VarInt,
     VarIntBoundsExceeded, Written, congestion, crypto,
 };
+#[cfg(feature = "__qlog")]
+pub use proto::{QlogConfig, QlogStream};
 #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
 pub use rustls;
 pub use udp;


### PR DESCRIPTION
Follow-up for https://github.com/quinn-rs/quinn/pull/2278.

This reworks qlog configuration to be consistent with other connection configuration, allows it to be specified when connections are first created, and allows users to control whether a qlog file is exclusive to a connection or arbitrarily shared.

Future work could include adding a `QlogStream` option to `EndpointConfig` for non-connection-related events, subject to the same optional sharing.