### PR TITLE
proto: fix NewConnectionId size bound

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     coding::BufMutExt,
     config::{ServerConfig, TransportConfig},
     crypto::{self, KeyPair, Keys, PacketKey},
-    frame::{self, Close, Datagram, FrameStruct, NewToken},
+    frame::{self, Close, Datagram, FrameStruct, NewConnectionId, NewToken},
     packet::{
         FixedLengthConnectionIdParser, Header, InitialHeader, InitialPacket, LongType, Packet,
         PacketNumber, PartialDecode, SpaceId,
@@ -3334,7 +3334,7 @@ impl Connection {
         }
 
         // NEW_CONNECTION_ID
-        while buf.len() + 44 < max_size {
+        while buf.len() + NewConnectionId::SIZE_BOUND < max_size {
             let issued = match space.pending.new_cids.pop() {
                 Some(x) => x,
                 None => break,

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -884,6 +884,10 @@ impl NewConnectionId {
     }
 }
 
+impl FrameStruct for NewConnectionId {
+    const SIZE_BOUND: usize = 1 + 8 + 8 + 1 + MAX_CID_SIZE + RESET_TOKEN_SIZE;
+}
+
 /// Smallest number of bytes this type of frame is guaranteed to fit within.
 pub(crate) const RETIRE_CONNECTION_ID_SIZE_BOUND: usize = 9;
 


### PR DESCRIPTION
Fixes #2310.

This code was first added in

- #124

Later it was updated in

- #394 

but we neglected to update the size bound.

Introduce a constant to see if we can do better.

Also checked for other constants being compared to -- the only ones remaining seem to be `PATH_CHALLENGE` and `PATH_RESPONSE` which are written more directly and are still correct.