### PR TITLE
Inline StepRng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,9 +1684,9 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core",


### PR DESCRIPTION
This has been [deprecated](https://github.com/rust-random/rand/pull/1634) upstream. Inlining a simplified copy of the upstream code seems like the easiest solution to the problem we're solving here (testing the reserved transport parameter ID generation code for edge cases).