### PR TITLE
Add interface_index to RecvMeta

### DIFF
--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -72,6 +72,7 @@ impl UdpSocketState {
             addr: addr.as_socket().unwrap(),
             ecn: None,
             dst_ip: None,
+            interface_index: None,
         };
         Ok(1)
     }

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -115,6 +115,8 @@ pub struct RecvMeta {
     /// Populated on platforms: Windows, Linux, Android (API level > 25),
     /// FreeBSD, OpenBSD, NetBSD, macOS, and iOS.
     pub dst_ip: Option<IpAddr>,
+    /// The interface index of the interface on which the datagram was received
+    pub interface_index: Option<u32>,
 }
 
 impl Default for RecvMeta {
@@ -126,6 +128,7 @@ impl Default for RecvMeta {
             stride: 0,
             ecn: None,
             dst_ip: None,
+            interface_index: None,
         }
     }
 }


### PR DESCRIPTION
I wanna use `quinn-udp`, but I also need the interface index information.

Currently `quinn-udp` reads the `IP_PKTINFO` header and extracts only `destination_ip`, discarding `interface_index`.

This PR adds `interface_index` to `RecvMeta`