### PR TITLE
Various  enhancement for perf binaries

### DIFF
--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -15,7 +15,7 @@ use tokio::sync::Semaphore;
 use tracing::{debug, error, info};
 
 use perf::{
-    CommonOpt, bind_socket, build_transport_config,
+    CommonOpt, bind_socket, build_transport_config, init_tracing,
     noprotection::NoProtectionClientConfig,
     stats::{OpenStreamStats, Stats},
 };
@@ -64,7 +64,7 @@ struct Opt {
 async fn main() {
     let opt = Opt::parse();
 
-    tracing_subscriber::fmt::init();
+    init_tracing(&opt.common);
 
     if let Err(e) = run(opt).await {
         error!("{:#}", e);

--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "json-output")]
-use std::{fs::File, path::PathBuf};
+use std::path::PathBuf;
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
@@ -15,7 +15,7 @@ use tokio::sync::Semaphore;
 use tracing::{debug, error, info};
 
 use perf::{
-    CongestionAlgorithm, bind_socket,
+    CommonOpt, bind_socket, build_transport_config,
     noprotection::NoProtectionClientConfig,
     stats::{OpenStreamStats, Stats},
 };
@@ -30,6 +30,9 @@ struct Opt {
     /// Override DNS resolution for host
     #[clap(long)]
     ip: Option<IpAddr>,
+    /// Specify the local socket address
+    #[clap(long)]
+    local_addr: Option<SocketAddr>,
     /// Number of unidirectional requests to maintain concurrently
     #[clap(long, default_value = "0")]
     uni_requests: u64,
@@ -48,44 +51,13 @@ struct Opt {
     /// The interval in seconds at which stats are reported
     #[clap(long, default_value = "1")]
     interval: u64,
-    /// Send buffer size in bytes
-    #[clap(long, default_value = "2097152")]
-    send_buffer_size: usize,
-    /// Receive buffer size in bytes
-    #[clap(long, default_value = "2097152")]
-    recv_buffer_size: usize,
-    /// Specify the local socket address
-    #[clap(long)]
-    local_addr: Option<SocketAddr>,
-    /// Whether to print connection statistics
-    #[clap(long)]
-    conn_stats: bool,
     /// File path to output JSON statistics to. If the file is '-', stdout will be used
     #[cfg(feature = "json-output")]
     #[clap(long)]
     json: Option<PathBuf>,
-    /// Perform NSS-compatible TLS key logging to the file specified in `SSLKEYLOGFILE`.
-    #[clap(long = "keylog")]
-    keylog: bool,
-    /// UDP payload size that the network must be capable of carrying
-    #[clap(long, default_value = "1200")]
-    initial_mtu: u16,
-    /// Disable packet encryption/decryption (for debugging purpose)
-    #[clap(long = "no-protection")]
-    no_protection: bool,
-    /// The initial round-trip-time (in msecs)
-    #[clap(long)]
-    initial_rtt: Option<u64>,
-    /// Ack Frequency mode
-    #[clap(long = "ack-frequency")]
-    ack_frequency: bool,
-    /// Congestion algorithm to use
-    #[clap(long = "congestion")]
-    cong_alg: Option<CongestionAlgorithm>,
-    /// qlog output file
-    #[cfg(feature = "qlog")]
-    #[clap(long = "qlog")]
-    qlog_file: Option<PathBuf>,
+    /// Common options
+    #[command(flatten)]
+    common: CommonOpt,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -128,7 +100,11 @@ async fn run(opt: Opt) -> Result<()> {
 
     info!("local addr {:?}", bind_addr);
 
-    let socket = bind_socket(bind_addr, opt.send_buffer_size, opt.recv_buffer_size)?;
+    let socket = bind_socket(
+        bind_addr,
+        opt.common.send_buffer_size,
+        opt.common.recv_buffer_size,
+    )?;
 
     let endpoint = quinn::Endpoint::new(Default::default(), None, socket, Arc::new(TokioRuntime))?;
 
@@ -146,35 +122,18 @@ async fn run(opt: Opt) -> Result<()> {
         .with_no_client_auth();
     crypto.alpn_protocols = vec![b"perf".to_vec()];
 
-    if opt.keylog {
+    if opt.common.keylog {
         crypto.key_log = Arc::new(rustls::KeyLogFile::new());
     }
 
-    let mut transport = quinn::TransportConfig::default();
-    transport.initial_mtu(opt.initial_mtu);
-
-    if let Some(initial_rtt) = opt.initial_rtt {
-        transport.initial_rtt(Duration::from_millis(initial_rtt));
-    }
-
-    if opt.ack_frequency {
-        transport.ack_frequency_config(Some(quinn::AckFrequencyConfig::default()));
-    }
-
-    if let Some(cong_alg) = opt.cong_alg {
-        transport.congestion_controller_factory(cong_alg.build());
-    }
-
-    #[cfg(feature = "qlog")]
-    if let Some(qlog_file) = &opt.qlog_file {
-        let mut qlog = quinn::QlogConfig::default();
-        qlog.writer(Box::new(File::create(qlog_file)?))
-            .title(Some("perf-client".into()));
-        transport.qlog_stream(qlog.into_stream());
-    }
+    let transport = build_transport_config(
+        &opt.common,
+        #[cfg(feature = "qlog")]
+        "perf-client",
+    )?;
 
     let crypto = Arc::new(QuicClientConfig::try_from(crypto)?);
-    let mut config = quinn::ClientConfig::new(match opt.no_protection {
+    let mut config = quinn::ClientConfig::new(match opt.common.no_protection {
         true => Arc::new(NoProtectionClientConfig::new(crypto)),
         false => crypto,
     });
@@ -220,7 +179,7 @@ async fn run(opt: Opt) -> Result<()> {
                 stats.on_interval(start, &stream_stats);
 
                 stats.print();
-                if opt.conn_stats {
+                if opt.common.conn_stats {
                     println!("{:?}\n", connection.stats());
                 }
             }

--- a/perf/src/bin/perf_server.rs
+++ b/perf/src/bin/perf_server.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "qlog")]
-use std::fs::File;
 use std::{fs, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
 use anyhow::{Context, Result};
@@ -10,7 +8,8 @@ use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use tracing::{debug, error, info};
 
 use perf::{
-    CongestionAlgorithm, PERF_CIPHER_SUITES, bind_socket, noprotection::NoProtectionServerConfig,
+    CommonOpt, PERF_CIPHER_SUITES, bind_socket, build_transport_config,
+    noprotection::NoProtectionServerConfig,
 };
 
 #[derive(Parser)]
@@ -25,37 +24,9 @@ struct Opt {
     /// TLS certificate in PEM format
     #[clap(short = 'c', long = "cert", requires = "key")]
     cert: Option<PathBuf>,
-    /// Send buffer size in bytes
-    #[clap(long, default_value = "2097152")]
-    send_buffer_size: usize,
-    /// Receive buffer size in bytes
-    #[clap(long, default_value = "2097152")]
-    recv_buffer_size: usize,
-    /// Whether to print connection statistics
-    #[clap(long)]
-    conn_stats: bool,
-    /// Perform NSS-compatible TLS key logging to the file specified in `SSLKEYLOGFILE`.
-    #[clap(long = "keylog")]
-    keylog: bool,
-    /// UDP payload size that the network must be capable of carrying
-    #[clap(long, default_value = "1200")]
-    initial_mtu: u16,
-    /// Disable packet encryption/decryption (for debugging purpose)
-    #[clap(long = "no-protection")]
-    no_protection: bool,
-    /// The initial round-trip-time (in msecs)
-    #[clap(long)]
-    initial_rtt: Option<u64>,
-    /// Ack Frequency mode
-    #[clap(long = "ack-frequency")]
-    ack_frequency: bool,
-    /// Congestion algorithm to use
-    #[clap(long = "congestion")]
-    cong_alg: Option<CongestionAlgorithm>,
-    /// qlog output file
-    #[cfg(feature = "qlog")]
-    #[clap(long = "qlog")]
-    qlog_file: Option<PathBuf>,
+    /// Common options
+    #[command(flatten)]
+    common: CommonOpt,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -104,41 +75,28 @@ async fn run(opt: Opt) -> Result<()> {
         .unwrap();
     crypto.alpn_protocols = vec![b"perf".to_vec()];
 
-    if opt.keylog {
+    if opt.common.keylog {
         crypto.key_log = Arc::new(rustls::KeyLogFile::new());
     }
 
-    let mut transport = quinn::TransportConfig::default();
-    transport.initial_mtu(opt.initial_mtu);
-
-    if let Some(initial_rtt) = opt.initial_rtt {
-        transport.initial_rtt(Duration::from_millis(initial_rtt));
-    }
-
-    if opt.ack_frequency {
-        transport.ack_frequency_config(Some(quinn::AckFrequencyConfig::default()));
-    }
-
-    if let Some(cong_alg) = opt.cong_alg {
-        transport.congestion_controller_factory(cong_alg.build());
-    }
-
-    #[cfg(feature = "qlog")]
-    if let Some(qlog_file) = &opt.qlog_file {
-        let mut qlog = quinn::QlogConfig::default();
-        qlog.writer(Box::new(File::create(qlog_file)?))
-            .title(Some("perf-server".into()));
-        transport.qlog_stream(qlog.into_stream());
-    }
+    let transport = build_transport_config(
+        &opt.common,
+        #[cfg(feature = "qlog")]
+        "perf-server",
+    )?;
 
     let crypto = Arc::new(QuicServerConfig::try_from(crypto)?);
-    let mut config = quinn::ServerConfig::with_crypto(match opt.no_protection {
+    let mut config = quinn::ServerConfig::with_crypto(match opt.common.no_protection {
         true => Arc::new(NoProtectionServerConfig::new(crypto)),
         false => crypto,
     });
     config.transport_config(Arc::new(transport));
 
-    let socket = bind_socket(opt.listen, opt.send_buffer_size, opt.recv_buffer_size)?;
+    let socket = bind_socket(
+        opt.listen,
+        opt.common.send_buffer_size,
+        opt.common.recv_buffer_size,
+    )?;
 
     let endpoint = quinn::Endpoint::new(
         Default::default(),
@@ -177,7 +135,7 @@ async fn handle(handshake: quinn::Incoming, opt: Arc<Opt>) -> Result<()> {
 }
 
 async fn conn_stats(connection: quinn::Connection, opt: Arc<Opt>) -> Result<()> {
-    if opt.conn_stats {
+    if opt.common.conn_stats {
         loop {
             tokio::time::sleep(Duration::from_secs(2)).await;
             println!("{:?}\n", connection.stats());

--- a/perf/src/bin/perf_server.rs
+++ b/perf/src/bin/perf_server.rs
@@ -8,7 +8,7 @@ use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use tracing::{debug, error, info};
 
 use perf::{
-    CommonOpt, PERF_CIPHER_SUITES, bind_socket, build_transport_config,
+    CommonOpt, PERF_CIPHER_SUITES, bind_socket, build_transport_config, init_tracing,
     noprotection::NoProtectionServerConfig,
 };
 
@@ -33,7 +33,7 @@ struct Opt {
 async fn main() {
     let opt = Opt::parse();
 
-    tracing_subscriber::fmt::init();
+    init_tracing(&opt.common);
 
     if let Err(e) = run(opt).await {
         error!("{:#}", e);

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -93,8 +93,9 @@ pub fn build_transport_config(
     #[cfg(feature = "qlog")]
     if let Some(qlog_file) = &common.qlog_file {
         let mut qlog = quinn::QlogConfig::default();
-        qlog.writer(Box::new(std::fs::File::create(qlog_file)?))
-            .title(Some(name.into()));
+        let file = std::fs::File::create(qlog_file)?;
+        let writer = std::io::BufWriter::new(file);
+        qlog.writer(Box::new(writer)).title(Some(name.into()));
         transport.qlog_stream(qlog.into_stream());
     }
 

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -12,6 +12,7 @@ use quinn::{
 use rustls::crypto::ring::cipher_suite;
 use socket2::{Domain, Protocol, Socket, Type};
 use tracing::warn;
+use tracing_subscriber::prelude::*;
 
 #[cfg_attr(not(feature = "json-output"), allow(dead_code))]
 pub mod stats;
@@ -52,6 +53,9 @@ pub struct CommonOpt {
     #[cfg(feature = "qlog")]
     #[clap(long = "qlog")]
     pub qlog_file: Option<PathBuf>,
+    /// disable ansi colors in logs
+    #[clap(long)]
+    pub no_color: bool,
 }
 
 #[derive(Clone, Copy, ValueEnum)]
@@ -100,6 +104,18 @@ pub fn build_transport_config(
     }
 
     Ok(transport)
+}
+
+pub fn init_tracing(common: &CommonOpt) {
+    let fmt_layer = tracing_subscriber::fmt::layer().with_ansi(!common.no_color);
+    let filter_layer = tracing_subscriber::EnvFilter::try_from_default_env()
+        .or_else(|_| tracing_subscriber::EnvFilter::try_new("warn"))
+        .unwrap();
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .init();
 }
 
 pub fn bind_socket(

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -1,8 +1,11 @@
-use std::{net::SocketAddr, sync::Arc};
+#[cfg(feature = "qlog")]
+use std::path::PathBuf;
+use std::{io, net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::{Context, Result};
-use clap::ValueEnum;
+use clap::{Parser, ValueEnum};
 use quinn::{
+    TransportConfig,
     congestion::{self, ControllerFactory},
     udp::UdpSocketState,
 };
@@ -14,6 +17,42 @@ use tracing::warn;
 pub mod stats;
 
 pub mod noprotection;
+
+// Common options between client and server binary
+#[derive(Parser)]
+pub struct CommonOpt {
+    /// Send buffer size in bytes
+    #[clap(long, default_value = "2097152")]
+    pub send_buffer_size: usize,
+    /// Receive buffer size in bytes
+    #[clap(long, default_value = "2097152")]
+    pub recv_buffer_size: usize,
+    /// Whether to print connection statistics
+    #[clap(long)]
+    pub conn_stats: bool,
+    /// Perform NSS-compatible TLS key logging to the file specified in `SSLKEYLOGFILE`.
+    #[clap(long = "keylog")]
+    pub keylog: bool,
+    /// UDP payload size that the network must be capable of carrying
+    #[clap(long, default_value = "1200")]
+    pub initial_mtu: u16,
+    /// Disable packet encryption/decryption (for debugging purpose)
+    #[clap(long = "no-protection")]
+    pub no_protection: bool,
+    /// The initial round-trip-time (in msecs)
+    #[clap(long, group = "common")]
+    pub initial_rtt: Option<u64>,
+    /// Ack Frequency mode
+    #[clap(long = "ack-frequency")]
+    pub ack_frequency: bool,
+    /// Congestion algorithm to use
+    #[clap(long = "congestion")]
+    pub cong_alg: Option<CongestionAlgorithm>,
+    /// qlog output file
+    #[cfg(feature = "qlog")]
+    #[clap(long = "qlog")]
+    pub qlog_file: Option<PathBuf>,
+}
 
 #[derive(Clone, Copy, ValueEnum)]
 pub enum CongestionAlgorithm {
@@ -30,6 +69,36 @@ impl CongestionAlgorithm {
             CongestionAlgorithm::NewReno => Arc::new(congestion::NewRenoConfig::default()),
         }
     }
+}
+
+pub fn build_transport_config(
+    common: &CommonOpt,
+    #[cfg(feature = "qlog")] name: &str,
+) -> io::Result<TransportConfig> {
+    let mut transport = quinn::TransportConfig::default();
+    transport.initial_mtu(common.initial_mtu);
+
+    if let Some(initial_rtt) = common.initial_rtt {
+        transport.initial_rtt(Duration::from_millis(initial_rtt));
+    }
+
+    if common.ack_frequency {
+        transport.ack_frequency_config(Some(quinn::AckFrequencyConfig::default()));
+    }
+
+    if let Some(cong_alg) = common.cong_alg {
+        transport.congestion_controller_factory(cong_alg.build());
+    }
+
+    #[cfg(feature = "qlog")]
+    if let Some(qlog_file) = &common.qlog_file {
+        let mut qlog = quinn::QlogConfig::default();
+        qlog.writer(Box::new(std::fs::File::create(qlog_file)?))
+            .title(Some(name.into()));
+        transport.qlog_stream(qlog.into_stream());
+    }
+
+    Ok(transport)
 }
 
 pub fn bind_socket(


### PR DESCRIPTION
Factorize common options on clap side.

Factorize init code for TransportConfig.

Add option to disable ansi color codes in logs.

Use a bufered writer for qlogs, here are bench results on a internet link :
- qlog off -> 295 Mb/s
- qlog on (client) no buffered writer -> 240 Mbps
- qlog on (client) with buffered writer -> 284 Mbps
