### PR TITLE
perf: add max udp payload size option

### DIFF
--- a/perf/src/bin/perf_client.rs
+++ b/perf/src/bin/perf_client.rs
@@ -109,7 +109,10 @@ async fn run(opt: Opt) -> Result<()> {
 
     let socket = opt.common.bind_socket(bind_addr)?;
 
-    let endpoint = quinn::Endpoint::new(Default::default(), None, socket, Arc::new(TokioRuntime))?;
+    let mut endpoint_cfg = quinn::EndpointConfig::default();
+    endpoint_cfg.max_udp_payload_size(opt.common.max_udp_payload_size)?;
+
+    let endpoint = quinn::Endpoint::new(endpoint_cfg, None, socket, Arc::new(TokioRuntime))?;
 
     let default_provider = rustls::crypto::ring::default_provider();
     let provider = Arc::new(rustls::crypto::CryptoProvider {

--- a/perf/src/bin/perf_server.rs
+++ b/perf/src/bin/perf_server.rs
@@ -90,13 +90,11 @@ async fn run(opt: Opt) -> Result<()> {
 
     let socket = opt.common.bind_socket(opt.listen)?;
 
-    let endpoint = quinn::Endpoint::new(
-        Default::default(),
-        Some(config),
-        socket,
-        Arc::new(TokioRuntime),
-    )
-    .context("creating endpoint")?;
+    let mut endpoint_cfg = quinn::EndpointConfig::default();
+    endpoint_cfg.max_udp_payload_size(opt.common.max_udp_payload_size)?;
+
+    let endpoint = quinn::Endpoint::new(endpoint_cfg, Some(config), socket, Arc::new(TokioRuntime))
+        .context("creating endpoint")?;
 
     info!("listening on {}", endpoint.local_addr().unwrap());
 

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -77,6 +77,9 @@ pub struct CommonOpt {
     /// 1MiB, 10G will limit to 10GiB.
     #[clap(long, value_parser = parse_byte_size)]
     pub send_window: Option<u64>,
+    /// Max UDP payload size in bytes
+    #[clap(long, default_value = "1472")]
+    pub max_udp_payload_size: u16,
     /// qlog output file
     #[cfg(feature = "qlog")]
     #[clap(long = "qlog")]


### PR DESCRIPTION
Sometimes the actual MTU of the interface is not 1500, so I would like perf to customize this.

I noticed that #2342 also makes changes to perf, so I can wait until it's merged and adjust the code.