### PR TITLE
quinn: drop async-std support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,17 +105,6 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
@@ -152,21 +141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "async-io"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,7 +164,7 @@ version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -212,14 +186,14 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-lite",
  "rustix 1.0.8",
 ]
@@ -240,32 +214,6 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -488,7 +436,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -930,12 +878,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -951,7 +893,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1109,18 +1051,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "h2"
@@ -1538,15 +1468,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,9 +1554,6 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru-slab"
@@ -1999,7 +1917,6 @@ version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-io",
- "async-std",
  "bencher",
  "bytes",
  "cfg_aliases",
@@ -2527,7 +2444,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-executor",
  "async-fs",
  "async-io",
@@ -2962,12 +2879,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "value-bag"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,7 +2920,6 @@ checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
- "rustversion",
  "wasm-bindgen-macro",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,3 @@ private = { ignore = true }
 name = "ring"
 expression = "ISC AND MIT AND OpenSSL"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
-
-[advisories]
-ignore = ["RUSTSEC-2025-0052"]

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -36,7 +36,6 @@ rustls-ring = ["dep:rustls", "ring", "proto/rustls-ring", "proto/ring"]
 # Outside wasm*-unknown-unknown targets, this enables `Endpoint::client` and `Endpoint::server` conveniences.
 ring = ["proto/ring"]
 runtime-tokio = ["tokio/time", "tokio/rt", "tokio/net"]
-runtime-async-std = ["async-io", "async-std"]
 runtime-smol = ["async-io", "smol"]
 
 # Configure `tracing` to log events via `log` if no `tracing` subscriber exists.
@@ -53,7 +52,6 @@ __rustls-post-quantum-test =  ["rustls/prefer-post-quantum", "rustls-aws-lc-rs",
 
 [dependencies]
 async-io = { workspace = true, optional = true }
-async-std = { workspace = true, optional = true }
 bytes = { workspace = true }
 # Enables futures::io::{AsyncRead, AsyncWrite} support for streams
 futures-io = { workspace = true, optional = true }

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -81,8 +81,6 @@ pub use crate::connection::{
 pub use crate::endpoint::{Accept, Endpoint, EndpointStats};
 pub use crate::incoming::{Incoming, IncomingFuture, RetryError};
 pub use crate::recv_stream::{ReadError, ReadExactError, ReadToEndError, RecvStream, ResetError};
-#[cfg(feature = "runtime-async-std")]
-pub use crate::runtime::AsyncStdRuntime;
 #[cfg(feature = "runtime-smol")]
 pub use crate::runtime::SmolRuntime;
 #[cfg(feature = "runtime-tokio")]

--- a/quinn/src/runtime.rs
+++ b/quinn/src/runtime.rs
@@ -116,11 +116,7 @@ impl<MakeFut, Fut> UdpPollHelper<MakeFut, Fut> {
     /// Construct a [`UdpPoller`] that calls `make_fut` to get the future to poll, storing it until
     /// it yields [`Poll::Ready`], then creating a new one on the next
     /// [`poll_writable`](UdpPoller::poll_writable)
-    #[cfg(any(
-        feature = "runtime-async-std",
-        feature = "runtime-smol",
-        feature = "runtime-tokio",
-    ))]
+    #[cfg(any(feature = "runtime-smol", feature = "runtime-tokio",))]
     fn new(make_fut: MakeFut) -> Self {
         Self {
             make_fut,
@@ -174,17 +170,12 @@ pub fn default_runtime() -> Option<Arc<dyn Runtime>> {
         }
     }
 
-    #[cfg(feature = "runtime-async-std")]
-    {
-        return Some(Arc::new(AsyncStdRuntime));
-    }
-
-    #[cfg(all(feature = "runtime-smol", not(feature = "runtime-async-std")))]
+    #[cfg(feature = "runtime-smol")]
     {
         return Some(Arc::new(SmolRuntime));
     }
 
-    #[cfg(not(any(feature = "runtime-async-std", feature = "runtime-smol")))]
+    #[cfg(not(feature = "runtime-smol"))]
     None
 }
 
@@ -197,5 +188,5 @@ pub use self::tokio::TokioRuntime;
 #[cfg(feature = "async-io")]
 mod async_io;
 // Due to MSRV, we must specify `self::` where there's crate/module ambiguity
-#[cfg(any(feature = "runtime-smol", feature = "runtime-async-std"))]
+#[cfg(feature = "runtime-smol")]
 pub use self::async_io::*;

--- a/quinn/src/runtime/async_io.rs
+++ b/quinn/src/runtime/async_io.rs
@@ -4,15 +4,15 @@ use std::{
     task::{Context, Poll},
     time::Instant,
 };
-#[cfg(any(feature = "runtime-smol", feature = "runtime-async-std"))]
+#[cfg(feature = "runtime-smol")]
 use std::{io, sync::Arc, task::ready};
 
-#[cfg(any(feature = "runtime-smol", feature = "runtime-async-std"))]
+#[cfg(feature = "runtime-smol")]
 use async_io::Async;
 use async_io::Timer;
 
 use super::AsyncTimer;
-#[cfg(any(feature = "runtime-smol", feature = "runtime-async-std"))]
+#[cfg(feature = "runtime-smol")]
 use super::{AsyncUdpSocket, Runtime, UdpPollHelper};
 
 #[cfg(feature = "runtime-smol")]
@@ -45,36 +45,6 @@ mod smol {
     }
 }
 
-#[cfg(feature = "runtime-async-std")]
-// Due to MSRV, we must specify `self::` where there's crate/module ambiguity
-pub use self::async_std::AsyncStdRuntime;
-
-#[cfg(feature = "runtime-async-std")]
-mod async_std {
-    use super::*;
-
-    /// A Quinn runtime for async-std
-    #[derive(Debug)]
-    pub struct AsyncStdRuntime;
-
-    impl Runtime for AsyncStdRuntime {
-        fn new_timer(&self, t: Instant) -> Pin<Box<dyn AsyncTimer>> {
-            Box::pin(Timer::at(t))
-        }
-
-        fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) {
-            ::async_std::task::spawn(future);
-        }
-
-        fn wrap_udp_socket(
-            &self,
-            sock: std::net::UdpSocket,
-        ) -> io::Result<Arc<dyn AsyncUdpSocket>> {
-            Ok(Arc::new(UdpSocket::new(sock)?))
-        }
-    }
-}
-
 impl AsyncTimer for Timer {
     fn reset(mut self: Pin<&mut Self>, t: Instant) {
         self.set_at(t)
@@ -85,14 +55,14 @@ impl AsyncTimer for Timer {
     }
 }
 
-#[cfg(any(feature = "runtime-smol", feature = "runtime-async-std"))]
+#[cfg(feature = "runtime-smol")]
 #[derive(Debug)]
 struct UdpSocket {
     io: Async<std::net::UdpSocket>,
     inner: udp::UdpSocketState,
 }
 
-#[cfg(any(feature = "runtime-smol", feature = "runtime-async-std"))]
+#[cfg(feature = "runtime-smol")]
 impl UdpSocket {
     fn new(sock: std::net::UdpSocket) -> io::Result<Self> {
         Ok(Self {
@@ -102,7 +72,7 @@ impl UdpSocket {
     }
 }
 
-#[cfg(any(feature = "runtime-smol", feature = "runtime-async-std"))]
+#[cfg(feature = "runtime-smol")]
 impl AsyncUdpSocket for UdpSocket {
     fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn super::UdpPoller>> {
         Box::pin(UdpPollHelper::new(move || {


### PR DESCRIPTION
async-std has been deprecated upstream in favor of smol.