### PR TITLE
perf: move client and server on one binary

### DIFF
--- a/perf/src/bin/perf.rs
+++ b/perf/src/bin/perf.rs
@@ -1,0 +1,42 @@
+use clap::{Parser, Subcommand};
+use tracing::error;
+use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+
+use perf::{client, server};
+
+#[derive(Parser)]
+#[clap(long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Run as a perf server
+    Server(server::Opt),
+    /// Run as a perf client
+    Client(client::Opt),
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let opt = Cli::parse();
+
+    tracing_subscriber::registry()
+        .with(
+            EnvFilter::try_from_default_env()
+                .or_else(|_| EnvFilter::try_new("warn"))
+                .unwrap(),
+        )
+        .with(fmt::layer())
+        .init();
+
+    let r = match opt.command {
+        Commands::Server(opt) => server::run(opt).await,
+        Commands::Client(opt) => client::run(opt).await,
+    };
+    if let Err(e) = r {
+        error!("{:#}", e);
+    }
+}

--- a/perf/src/client.rs
+++ b/perf/src/client.rs
@@ -14,8 +14,8 @@ use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info};
 
-use perf::{
-    CommonOpt, init_tracing,
+use crate::{
+    CommonOpt, PERF_CIPHER_SUITES,
     noprotection::NoProtectionClientConfig,
     parse_byte_size,
     stats::{OpenStreamStats, Stats},
@@ -24,7 +24,7 @@ use perf::{
 /// Connects to a QUIC perf server and maintains a specified pattern of requests until interrupted
 #[derive(Parser)]
 #[clap(name = "client")]
-struct Opt {
+pub struct Opt {
     /// Host to connect to
     #[clap(default_value = "localhost:4433")]
     host: String,
@@ -67,18 +67,7 @@ struct Opt {
     common: CommonOpt,
 }
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() {
-    let opt = Opt::parse();
-
-    init_tracing();
-
-    if let Err(e) = run(opt).await {
-        error!("{:#}", e);
-    }
-}
-
-async fn run(opt: Opt) -> Result<()> {
+pub async fn run(opt: Opt) -> Result<()> {
     let mut host_parts = opt.host.split(':');
     let host_name = host_parts.next().unwrap();
     let host_port = host_parts
@@ -116,7 +105,7 @@ async fn run(opt: Opt) -> Result<()> {
 
     let default_provider = rustls::crypto::ring::default_provider();
     let provider = Arc::new(rustls::crypto::CryptoProvider {
-        cipher_suites: perf::PERF_CIPHER_SUITES.into(),
+        cipher_suites: PERF_CIPHER_SUITES.into(),
         ..default_provider
     });
 

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -14,12 +14,14 @@ use quinn::{
 use rustls::crypto::ring::cipher_suite;
 use socket2::{Domain, Protocol, Socket, Type};
 use tracing::warn;
-use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[cfg_attr(not(feature = "json-output"), allow(dead_code))]
 pub mod stats;
 
 pub mod noprotection;
+
+pub mod client;
+pub mod server;
 
 // Common options between client and server binary
 #[derive(Parser)]
@@ -210,17 +212,6 @@ impl CongestionAlgorithm {
             CongestionAlgorithm::NewReno => Arc::new(congestion::NewRenoConfig::default()),
         }
     }
-}
-
-pub fn init_tracing() {
-    tracing_subscriber::registry()
-        .with(
-            EnvFilter::try_from_default_env()
-                .or_else(|_| EnvFilter::try_new("warn"))
-                .unwrap(),
-        )
-        .with(fmt::layer())
-        .init();
 }
 
 pub static PERF_CIPHER_SUITES: &[rustls::SupportedCipherSuite] = &[

--- a/perf/src/server.rs
+++ b/perf/src/server.rs
@@ -7,11 +7,11 @@ use quinn::{TokioRuntime, crypto::rustls::QuicServerConfig};
 use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use tracing::{debug, error, info};
 
-use perf::{CommonOpt, PERF_CIPHER_SUITES, init_tracing, noprotection::NoProtectionServerConfig};
+use crate::{CommonOpt, PERF_CIPHER_SUITES, noprotection::NoProtectionServerConfig};
 
 #[derive(Parser)]
 #[clap(name = "server")]
-struct Opt {
+pub struct Opt {
     /// Address to listen on
     #[clap(long = "listen", default_value = "[::]:4433")]
     listen: SocketAddr,
@@ -26,18 +26,7 @@ struct Opt {
     common: CommonOpt,
 }
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() {
-    let opt = Opt::parse();
-
-    init_tracing();
-
-    if let Err(e) = run(opt).await {
-        error!("{:#}", e);
-    }
-}
-
-async fn run(opt: Opt) -> Result<()> {
+pub async fn run(opt: Opt) -> Result<()> {
     let (key, cert) = match (&opt.key, &opt.cert) {
         (Some(key), Some(cert)) => {
             let key = fs::read(key).context("reading key")?;


### PR DESCRIPTION
I've been using `perf_client` and `perf_server` lately, but the split-binary design feels cumbersome.

It'd be much more convenient—like `iperf3` or msquic's perf—to have a single binary that supports both client and server modes via command-line flags.

Converted the previous top-level options into Perf subcommands. All other behavior remains consistent with the prior implementation.

old version:
```bash
$ ./perf_server --no-protection
$ ./perf_client ip:4433 --no-protection
```

new version:
```bash
$ ./perf server --no-protection
$ ./perf client ip:4433 --no-protection
```