### PR TITLE
perf: rename perf binary to quinn-perf to prevent name clash with linux perf

### DIFF
--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
 
+[[bin]]
+name = "quinn-perf"
+path = "src/bin/perf.rs"
+
 [features]
 # NOTE: Please keep this in sync with the feature list in `.github/workflows/codecov.yml`, see
 # comment in that file for more information.


### PR DESCRIPTION
As title suggest, renamed perf binary to quinn-perf to prevent name clash with linux perf profiler