### PR TITLE
feat(datagrams): add sendable/readable futures and try_send/try_recv methods

### DIFF
--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -57,7 +57,7 @@ impl Datagrams<'_> {
         Ok(())
     }
 
-    /// By calling this function, next time a datagram is sent a DatagramsUnblocked event will be created
+    /// Next time a Datagram is sent, datagram_unblocked will be notified
     pub fn request_datagram_unblocked_notification(&mut self) {
         self.conn.datagrams.send_blocked = true;
     }

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -57,6 +57,11 @@ impl Datagrams<'_> {
         Ok(())
     }
 
+    /// By calling this function, next time a datagram is sent a DatagramsUnblocked event will be created
+    pub fn request_datagram_unblocked_notification(&mut self) {
+        self.conn.datagrams.send_blocked = true;
+    }
+
     /// Compute the maximum size of datagrams that may passed to `send_datagram`
     ///
     /// Returns `None` if datagrams are unsupported by the peer or disabled locally.
@@ -85,6 +90,11 @@ impl Datagrams<'_> {
     /// Receive an unreliable, unordered datagram
     pub fn recv(&mut self) -> Option<Bytes> {
         self.conn.datagrams.recv()
+    }
+
+    /// Recv Bytes currently stored in the read buffer
+    pub fn recv_buffered(&self) -> usize {
+        self.conn.datagrams.recv_buffered
     }
 
     /// Bytes available in the outgoing datagram buffer

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -57,8 +57,10 @@ impl Datagrams<'_> {
         Ok(())
     }
 
+    /// Sets the send_blocked flag to true
+    ///
     /// Next time a Datagram is sent, datagram_unblocked will be notified
-    pub fn request_datagram_unblocked_notification(&mut self) {
+    pub fn set_send_blocked(&mut self) {
         self.conn.datagrams.send_blocked = true;
     }
 

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -346,8 +346,8 @@ impl Connection {
     }
 
     /// Creates a future, resolving as soon as a readable datagram is buffered
-    pub fn readable_datagram(&self) -> ReadableDatagram<'_> {
-        ReadableDatagram {
+    pub fn datagram_readable(&self) -> DatagramReadable<'_> {
+        DatagramReadable {
             conn: &self.0,
             notify: self.0.shared.datagram_received.notified(),
         }
@@ -448,7 +448,7 @@ impl Connection {
     }
 
     /// Creates a future, resolving as soon as a Datagram with the given size in byte can be sent
-    pub fn sendable_datagram(&self, size: usize) -> DatagramSendable<'_> {
+    pub fn datagram_sendable(&self, size: usize) -> DatagramSendable<'_> {
         DatagramSendable {
             conn: &self.0,
             required_space: size,
@@ -884,14 +884,14 @@ impl Future for ReadDatagram<'_> {
 
 pin_project! {
     /// Future produced by [`Connection::datagram_readable`]
-    pub struct ReadableDatagram<'a> {
+    pub struct DatagramReadable<'a> {
         conn: &'a ConnectionRef,
         #[pin]
         notify: Notified<'a>,
     }
 }
 
-impl Future for ReadableDatagram<'_> {
+impl Future for DatagramReadable<'_> {
     type Output = Result<(), ConnectionError>;
     fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.project();

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -490,7 +490,7 @@ impl Connection {
     /// and `data` must both fit inside a single QUIC packet and be smaller than the maximum
     /// dictated by the peer.
     ///
-    /// If the send buffer doesn't have enough available space, this will return [TryIoError::WouldBlock]
+    /// If the send buffer doesn't have enough available space, this will return [TrySendDatagramError::WouldBlock]
     pub fn try_send_datagram(&self, data: Bytes) -> Result<(), TrySendDatagramError> {
         let conn = &mut *self.0.state.lock("try_send_datagram");
         if let Some(ref x) = conn.error {

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -76,7 +76,7 @@ pub use udp;
 
 pub use crate::connection::{
     AcceptBi, AcceptUni, Connecting, Connection, OpenBi, OpenUni, ReadDatagram, SendDatagram,
-    SendDatagramError, ZeroRttAccepted,
+    SendDatagramError, TryReceiveDatagramError, TrySendDatagramError, ZeroRttAccepted,
 };
 pub use crate::endpoint::{Accept, Endpoint, EndpointStats};
 pub use crate::incoming::{Incoming, IncomingFuture, RetryError};


### PR DESCRIPTION
Related Issues:
- #2351 
- #1423 (introduces notification when send buffer space reaches a threshold via `datagram_sendable`)

Additions:

- `Connection::try_send_datagram` and `Connection::try_read_datagram`, returning `WouldBlock` when the operation cannot complete immediately
- `Connection::datagram_readable`, resolving as soon as any datagram is readable
- `Connection::datagram_sendable`, resolving as soon as a specified number of bytes are writable
