### PR TITLE
Use newer rustls-pki-types PEM parser API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,7 +1758,6 @@ dependencies = [
  "quinn-proto",
  "rcgen",
  "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "socket2 0.6.0",
@@ -1931,7 +1930,6 @@ dependencies = [
  "rcgen",
  "rustc-hash 2.1.1",
  "rustls",
- "rustls-pemfile",
  "smol",
  "socket2 0.6.0",
  "thiserror 2.0.16",
@@ -2218,15 +2216,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ rcgen = "0.14"
 ring = "0.17"
 rustc-hash = "2"
 rustls = { version = "0.23.5", default-features = false, features = ["std"] }
-rustls-pemfile = "2"
 rustls-platform-verifier = "0.6"
 rustls-pki-types = "1.7"
 serde = { version = "1.0", features = ["derive"] }

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -34,7 +34,6 @@ quinn = { path = "../quinn" }
 quinn-proto = { path = "../quinn-proto" }
 rcgen = { workspace = true }
 rustls = { workspace = true }
-rustls-pemfile = { workspace = true }
 serde = { workspace = true, optional = true  }
 serde_json = { workspace = true, optional = true }
 socket2 = { workspace = true }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -78,7 +78,6 @@ bencher = { workspace = true }
 directories-next = { workspace = true }
 rand = { workspace = true }
 rcgen = { workspace = true }
-rustls-pemfile = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time", "macros"] }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
Could potentially be backported to `0.11.x`.