### PR TITLE
docs: add guarantees to the read and send_datagram function

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -346,6 +346,10 @@ impl Connection {
     }
 
     /// Receive an application datagram
+    ///
+    /// Guarantees:
+    /// - Cancel-safe future
+    /// - First poll resolves immediately if a datagram is available
     pub fn read_datagram(&self) -> ReadDatagram<'_> {
         ReadDatagram {
             conn: &self.0,
@@ -430,6 +434,10 @@ impl Connection {
     ///
     /// Previously queued datagrams which are still unsent may be discarded to make space for this
     /// datagram, in order of oldest to newest.
+    ///
+    /// Guarantees:
+    /// - Cancel-safe future
+    /// - First poll resolves immediately if given datagram can be sent
     pub fn send_datagram(&self, data: Bytes) -> Result<(), SendDatagramError> {
         let conn = &mut *self.0.state.lock("send_datagram");
         if let Some(ref x) = conn.error {


### PR DESCRIPTION
Related Issue: #2351 

Adds documentation for the required Gurantees to allow a noop poll to send/read_datagram function to act as a try_write/try_recv similar to e.g. [Tokio UDP Socket](https://docs.rs/tokio/latest/tokio/net/struct.UdpSocket.html#method.try_recv)
