### PR TITLE
feat!(udp): mark RecvMeta as non_exhaustive

### DIFF
--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -93,6 +93,7 @@ pub const BATCH_SIZE: usize = 1;
 ///
 /// [`stride`]: RecvMeta::stride
 #[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
 pub struct RecvMeta {
     /// The source address of the datagram(s) contained in the buffer
     pub addr: SocketAddr,


### PR DESCRIPTION
Mark `RecvMeta` as non exhaustive such that subsequent field additions are not breaking changes.

Fixes https://github.com/quinn-rs/quinn/issues/2378.