### PR TITLE
Add watchOS to BSD-like OS target list

### DIFF
--- a/quinn-udp/build.rs
+++ b/quinn-udp/build.rs
@@ -9,7 +9,8 @@ fn main() {
                 target_os = "macos",
                 target_os = "ios",
                 target_os = "tvos",
-                target_os = "visionos"
+                target_os = "visionos",
+                target_os = "watchos"
             )
         },
         bsd: {


### PR DESCRIPTION
Fix #2386 

Depends on https://github.com/briansmith/ring/pull/2702 Tested in the dependant PR.