### PR TITLE
Use `checked_mul` when calculating `congestion_period` to not panic on overflow

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1679,8 +1679,10 @@ impl Connection {
         // InPersistentCongestion: Determine if all packets in the time period before the newest
         // lost packet, including the edges, are marked lost. PTO computation must always
         // include max ACK delay, i.e. operate as if in Data space (see RFC9001 §7.6.1).
-        let congestion_period =
-            self.pto(SpaceId::Data) * self.config.persistent_congestion_threshold;
+        let congestion_period = self
+            .pto(SpaceId::Data)
+            .checked_mul(self.config.persistent_congestion_threshold)
+            .unwrap_or(Duration::MAX);
         let mut persistent_congestion_start: Option<Instant> = None;
         let mut prev_packet = None;
         let mut in_persistent_congestion = false;


### PR DESCRIPTION
When using a large enough value for `persistent_congestion_threshold`, the calculation for `congestion_period` panics.

In my case, I was using `u32::MAX` since I did not want the connection to ever be marked as persistently congested.

With this PR, the `congestion_period` is calculated using `checked_mul`, so that no panic on overflow is possible.