### PR TITLE
feat(ip_recverr): ADD IP_RECVERR and IPV6_RECVERR  support for linux 

### DIFF
--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -238,3 +238,18 @@ impl EcnCodepoint {
         })
     }
 }
+
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub struct IcmpError {
+    pub dst: SocketAddr,
+    pub kind: IcmpErrorKind,
+}
+
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub enum IcmpErrorKind {
+    NetworkUnreachable,
+    HostUnreachable,
+    PortUnreachable,
+    PacketTooBig,
+    Other { icmp_type: u8, icmp_code: u8 },
+}


### PR DESCRIPTION
On Linux, enables `IP_RECVERR` and `IPV6_RECVERR` socket options

This allows the socket to receive ICMP errors via the error **queue,** enabling faster detection of network unreachability instead of waiting for connection timeouts.

Features Implemented 

- Enable IP_RECVERR and IPV6_RECVERR socket options on Linux
- Add error queue polling in recv path
- Add IcmpError type for ICMP error reporting
- Add tests for ICMP error handling (Not Completed)

Closes #2052