### PR TITLE
fix(pacing): allow ±1ns tolerance in computes_pause_correctly test on i386

### DIFF
--- a/quinn-proto/src/connection/pacing.rs
+++ b/quinn-proto/src/connection/pacing.rs
@@ -273,14 +273,18 @@ mod tests {
 
         let pace_duration = Duration::from_nanos((TARGET_BURST_INTERVAL.as_nanos() * 4 / 5) as u64);
 
-        assert_eq!(
-            pacer
-                .delay(rtt, mtu as u64, mtu, window, old_instant)
-                .expect("Send must be delayed")
-                .duration_since(old_instant),
-            pace_duration
-        );
+        let actual_delay = pacer
+            .delay(rtt, mtu as u64, mtu, window, old_instant)
+            .expect("Send must be delayed")
+            .duration_since(old_instant);
 
+        let diff = actual_delay.abs_diff(pace_duration);
+
+        // Allow up to 2ns difference due to rounding
+        assert!(
+            diff < Duration::from_nanos(2),
+            "expected ≈ {pace_duration:?}, got {actual_delay:?} (diff {diff:?})"
+        );
         // Refill half of the tokens
         assert_eq!(
             pacer.delay(


### PR DESCRIPTION
### Summary
This PR fixes a test failure on 32-bit (i386) architectures in `connection::pacing::tests::computes_pause_correctly`.

### Context
On i386, the test occasionally fails due to a one-nanosecond rounding difference:


This appears to be caused by floating-point rounding during the conversion between `f64` and integer types in `Duration` arithmetic.

### Changes
- Updated the test to allow a ±1ns tolerance when comparing durations.
- This prevents spurious failures on 32-bit architectures while keeping test precision intact.

### Notes
- Verified locally that all tests pass on x86_64.
- Should not affect runtime behavior, only the test assertion.
- Related: Debian CI report where this issue was originally observed on i386.

---

**Closes:** N/A  
**Type:**  Test Fix  
