### PR TITLE
Add server-side 0-RTT detection via early_data_accepted()

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2689,6 +2689,10 @@ impl Connection {
                 ..
             } => {
                 self.process_payload(now, remote, number.unwrap(), packet)?;
+                // Track that 0-RTT data was received and accepted (server-side)
+                if self.side.is_server() {
+                    self.accepted_0rtt = true;
+                }
                 Ok(())
             }
             Header::VersionNegotiate { .. } => {

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -334,6 +334,12 @@ async fn zero_rtt() {
             s.write_all(MSG1).await.expect("write");
             // The peer might close the connection before ACKing
             let _ = s.finish();
+
+            // Test early_data_accepted() on server side
+            let early_data = connection.early_data_accepted();
+            info!("server early_data_accepted: {:?}", early_data);
+            // First connection should show Some(false) - no 0-RTT
+            // Second connection should show Some(true) - 0-RTT received
         }
     });
 
@@ -378,6 +384,15 @@ async fn zero_rtt() {
     let msg = stream.read_to_end(usize::MAX).await.expect("read_to_end");
     assert_eq!(msg, MSG0);
     assert!(zero_rtt.await);
+
+    // Test early_data_accepted() on client side after handshake completes
+    let early_data = connection.early_data_accepted();
+    info!("client early_data_accepted: {:?}", early_data);
+    assert_eq!(
+        early_data,
+        Some(true),
+        "Client should see that 0-RTT was accepted by server"
+    );
 
     drop((stream, connection));
 


### PR DESCRIPTION
Expose a public API to detect whether 0-RTT (early data) was used on both client and server sides. This addresses issue #2439 by allowing servers to identify  possible replay-vulnerable requests.

Changes:
- Add Connection::early_data_accepted() public API
- Track 0-RTT packet reception on server side in quinn-proto
- Add test coverage in existing zero_rtt test

For clients: Some(true) if server accepted 0-RTT, Some(false) if rejected For servers: Some(true) if client sent 0-RTT data, Some(false) otherwise Returns None while handshake is in progress

This is useful for servers to implement replay attack mitigation, such as rejecting non-idempotent operations (POST/PUT/DELETE) that arrived via 0-RTT with HTTP 425 "Too Early" status.

