### PR TITLE
Track handshake confirmation

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2637,6 +2637,8 @@ impl Connection {
                     // Server-only
                     self.spaces[SpaceId::Data].pending.handshake_done = true;
                     self.discard_space(now, SpaceId::Handshake);
+                    self.events.push_back(Event::HandshakeConfirmed);
+                    trace!("handshake confirmed");
                 }
 
                 self.events.push_back(Event::Connected);
@@ -3056,6 +3058,8 @@ impl Connection {
                     if self.spaces[SpaceId::Handshake].crypto.is_some() {
                         self.discard_space(now, SpaceId::Handshake);
                     }
+                    self.events.push_back(Event::HandshakeConfirmed);
+                    trace!("handshake confirmed");
                 }
             }
         }
@@ -4041,6 +4045,8 @@ pub enum Event {
     HandshakeDataReady,
     /// The connection was successfully established
     Connected,
+    /// The TLS handshake was confirmed
+    HandshakeConfirmed,
     /// The connection was lost
     ///
     /// Emitted if the peer closes the connection or an error is encountered.

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -233,7 +233,15 @@ impl Pair {
         );
         assert_matches!(
             self.server_conn_mut(server_ch).poll(),
+            Some(Event::HandshakeConfirmed)
+        );
+        assert_matches!(
+            self.server_conn_mut(server_ch).poll(),
             Some(Event::Connected)
+        );
+        assert_matches!(
+            self.client_conn_mut(client_ch).poll(),
+            Some(Event::HandshakeConfirmed)
         );
     }
 


### PR DESCRIPTION
Adds a new variant to `quinn_proto::Event` for when the TLS handshake is confirmed. For the server, this is irrelevant, as the TLS handshake is confirmed simultaneously with being completed. However, for the client the handshake is only confirmed one RTT after the handshake is completed. If mTLS is in use, being able to tell when the handshake is confirmed enables the client to wait for client authentication to complete. For this purpose, an async function is added on `quin::Connection` to await the handshake confirmation.