### PR TITLE
Add an option to retrieve TLS errors

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2605,6 +2605,7 @@ impl Connection {
                                 code: TransportErrorCode::crypto(0x6d),
                                 frame: None,
                                 reason: "transport parameters missing".into(),
+                                crypto: None,
                             })?;
 
                     if self.has_0rtt() {
@@ -2678,6 +2679,7 @@ impl Connection {
                                 code: TransportErrorCode::crypto(0x6d),
                                 frame: None,
                                 reason: "transport parameters missing".into(),
+                                crypto: None,
                             })?;
                     self.handle_peer_params(params)?;
                     self.issue_first_cids(now);

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -110,6 +110,7 @@ impl crypto::Session for TlsSession {
                     code: TransportErrorCode::crypto(alert.into()),
                     frame: None,
                     reason: e.to_string(),
+                    crypto: Some(Arc::new(e)),
                 }
             } else {
                 TransportError::PROTOCOL_VIOLATION(format!("TLS error: {e}"))

--- a/quinn-proto/src/transport_error.rs
+++ b/quinn-proto/src/transport_error.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use bytes::{Buf, BufMut};
 
@@ -8,7 +8,12 @@ use crate::{
 };
 
 /// Transport-level errors occur when a peer violates the protocol specification
-#[derive(Debug, Clone, Eq, PartialEq)]
+///
+/// # Note
+///
+/// The `PartialEq` implementation for this type performs comparison on the `code` field only
+#[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct Error {
     /// Type of error
     pub code: Code,
@@ -16,7 +21,29 @@ pub struct Error {
     pub frame: Option<frame::FrameType>,
     /// Human-readable explanation of the reason
     pub reason: String,
+    /// An underlying crypto (e.g. TLS) layer error
+    pub crypto: Option<Arc<dyn std::error::Error + Send + Sync>>,
 }
+
+impl Error {
+    /// Construct an error with a code and a reason
+    pub fn new(code: Code, reason: String) -> Self {
+        Self {
+            code,
+            frame: None,
+            reason,
+            crypto: None,
+        }
+    }
+}
+
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        self.code == other.code
+    }
+}
+
+impl Eq for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -39,6 +66,7 @@ impl From<Code> for Error {
             code: x,
             frame: None,
             reason: "".to_string(),
+            crypto: None,
         }
     }
 }
@@ -79,6 +107,7 @@ macro_rules! errors {
                     code: Code::$name,
                     frame: None,
                     reason: reason.into(),
+                    crypto: None,
                 }
             }
             )*

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -1074,11 +1074,10 @@ impl State {
                     self.close(error_code, reason, shared);
                 }
                 Poll::Ready(None) => {
-                    return Err(ConnectionError::TransportError(proto::TransportError {
-                        code: proto::TransportErrorCode::INTERNAL_ERROR,
-                        frame: None,
-                        reason: "endpoint driver future was dropped".to_string(),
-                    }));
+                    return Err(ConnectionError::TransportError(proto::TransportError::new(
+                        proto::TransportErrorCode::INTERNAL_ERROR,
+                        "endpoint driver future was dropped".to_string(),
+                    )));
                 }
                 Poll::Pending => {
                     return Ok(());


### PR DESCRIPTION
Hello,

I'm using `quinn` create together with TLS Encrypted Client Hello (ECH) extension.
However, I encountered a problem where the client uses an invalid server ECH config. There is a mechanism described in the ECH RFC that the server can respond with the correct config, and the client can reconnect using it instead.

And theoretically, the `rustls` crate offers a way to retrieve the server ECH config from the TLS error, as discussed in https://github.com/rustls/rustls/issues/2572.

Sadly, when using the `quinn` crate, there is no way to retrieve the underlying TLS error and extract the ECH config.

This PR aims to provide a way to get the underlying `rustls` error and effectively allow for ECH client retry.

