### PR TITLE
feat(quinn-udp): add opt-in Apple fast UDP datapath

### DIFF
--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -17,7 +17,7 @@ default = ["tracing", "tracing-log"]
 # Configure `tracing` to log events via `log` if no `tracing` subscriber exists.
 tracing-log = ["tracing/log"]
 log = ["dep:log"]
-# Use private Apple APIs to send multiple packets in a single syscall.
+# Support private Apple APIs to send multiple packets in a single syscall.
 fast-apple-datapath = []
 
 [dependencies]


### PR DESCRIPTION
Add runtime dispatch so callers explicitly opt in to the `sendmsg_x`/`recvmsg_x` fast datapath instead of using it unconditionally.