### PR TITLE
refactor(quinn-udp): make `decode_recv` generic over `MsgHdr`

### DIFF
--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -712,10 +712,9 @@ fn prepare_recv(
     hdr.msg_datalen = buf.len();
 }
 
-fn decode_recv(
+fn decode_recv<M: cmsg::MsgHdr<ControlMessage = libc::cmsghdr>>(
     name: &MaybeUninit<libc::sockaddr_storage>,
-    #[cfg(not(apple_fast))] hdr: &libc::msghdr,
-    #[cfg(apple_fast)] hdr: &msghdr_x,
+    hdr: &M,
     len: usize,
 ) -> io::Result<RecvMeta> {
     let name = unsafe { name.assume_init() };


### PR DESCRIPTION
Replace conditional compilation on the `hdr` parameter with a generic type bound `M: cmsg::MsgHdr<ControlMessage = libc::cmsghdr>`. This enables `decode_recv` to work with both `libc::msghdr` and `msghdr_x` message types.

Broken out of #2463 as suggested by @djc.