### PR TITLE
refactor(quinn-udp): split fast&slow send/recv paths

### DIFF
--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -161,6 +161,7 @@ impl Transmit<'_> {
     /// This case is actually quite common when splitting up a prepared GSO batch
     /// again after GSO has been disabled because the last datagram in a GSO
     /// batch is allowed to be smaller than the segment size.
+    #[cfg_attr(apple_fast, allow(dead_code))] // Used by prepare_msg, which is unused when apple_fast
     fn effective_segment_size(&self) -> Option<usize> {
         match self.segment_size? {
             size if size >= self.contents.len() => None,


### PR DESCRIPTION
Separate the fast path (`msghdr_x`-based) and slow path (`msghdr`-based) implementations to prepare for runtime dispatch between them.

Broken out of #2463 as suggested by @djc.