### PR TITLE
Re-export `InvalidCid` from `quinn-proto` in `quinn`

### DIFF
--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -63,9 +63,9 @@ pub use proto::{
     AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ClosedStream, ConfigError,
     ConnectError, ConnectionClose, ConnectionError, ConnectionId, ConnectionIdGenerator,
     ConnectionStats, Dir, EcnCodepoint, EndpointConfig, FrameStats, FrameType, IdleTimeout,
-    MtuDiscoveryConfig, NoneTokenLog, NoneTokenStore, PathStats, ServerConfig, Side, StdSystemTime,
-    StreamId, TimeSource, TokenLog, TokenMemoryCache, TokenReuseError, TokenStore, Transmit,
-    TransportConfig, TransportErrorCode, UdpStats, ValidationTokenConfig, VarInt,
+    InvalidCid, MtuDiscoveryConfig, NoneTokenLog, NoneTokenStore, PathStats, ServerConfig, Side,
+    StdSystemTime, StreamId, TimeSource, TokenLog, TokenMemoryCache, TokenReuseError, TokenStore,
+    Transmit, TransportConfig, TransportErrorCode, UdpStats, ValidationTokenConfig, VarInt,
     VarIntBoundsExceeded, Written, congestion, crypto,
 };
 #[cfg(feature = "qlog")]


### PR DESCRIPTION
The interface of `ConnectionIdGenerator` refers to `InvalidCid`, which is not re-exported in `quinn` right now. So implementers have to depend on `quinn-proto` directly.

Re-exporting `InvalidCid` alongside `ConnectionIdGenerator` makes it more convenient to provide custom CID generators.