### PR TITLE
quinn: Implement abstractions over hard tokio dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,6 +1901,7 @@ name = "quinn"
 version = "0.12.0"
 dependencies = [
  "anyhow",
+ "async-channel",
  "async-io",
  "bencher",
  "bytes",
@@ -1908,6 +1909,7 @@ dependencies = [
  "clap",
  "crc",
  "directories-next",
+ "event-listener",
  "futures-io",
  "pin-project-lite",
  "quinn-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["network-programming", "asynchronous"]
 [workspace.dependencies]
 anyhow = "1.0.22"
 arbitrary = { version = "1.0.1", features = ["derive"] }
+async-channel = "2"
 async-io = "2"
 assert_matches = "1.1"
 aws-lc-rs = { version = "1.9", default-features = false }
@@ -22,6 +23,7 @@ bytes = "1"
 clap = { version = "4", features = ["derive"] }
 crc = "3"
 directories-next = "2"
+event-listener = "5"
 fastbloom = "0.14"
 futures-io = "0.3.19"
 getrandom = { version = "0.3", default-features = false }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -36,7 +36,7 @@ rustls-ring = ["dep:rustls", "ring", "proto/rustls-ring", "proto/ring"]
 # Outside wasm*-unknown-unknown targets, this enables `Endpoint::client` and `Endpoint::server` conveniences.
 ring = ["proto/ring"]
 runtime-tokio = ["tokio/time", "tokio/rt", "tokio/net"]
-runtime-smol = ["dep:async-io", "dep:smol"]
+runtime-smol = ["dep:async-channel", "dep:async-io", "dep:event-listener", "dep:smol", "futures-io"]
 
 # Configure `tracing` to log events via `log` if no `tracing` subscriber exists.
 tracing-log = ["tracing/log", "proto/tracing-log", "udp/tracing-log"]
@@ -51,8 +51,10 @@ qlog = ["proto/qlog"]
 __rustls-post-quantum-test =  ["rustls/prefer-post-quantum", "rustls-aws-lc-rs", "proto/__rustls-post-quantum-test"]
 
 [dependencies]
+async-channel = { workspace = true, optional = true }
 async-io = { workspace = true, optional = true }
 bytes = { workspace = true }
+event-listener = { workspace = true, optional = true }
 # Enables futures::io::{AsyncRead, AsyncWrite} support for streams
 futures-io = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
@@ -62,7 +64,7 @@ rustls = { workspace = true, optional = true }
 smol = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing =  { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, optional = true }
 udp = { package = "quinn-udp", path = "../quinn-udp", version = "0.6", default-features = false, features = ["tracing"] }
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]

--- a/quinn/src/abstraction/io.rs
+++ b/quinn/src/abstraction/io.rs
@@ -1,0 +1,97 @@
+use std::fmt;
+use std::mem::MaybeUninit;
+
+/// A wrapper around a byte buffer that is incrementally filled and tracks
+/// initialization progress.
+pub struct ReadBuf<'a> {
+    buf: &'a mut [MaybeUninit<u8>],
+    filled: usize,
+    initialized: usize,
+}
+
+impl<'a> ReadBuf<'a> {
+    /// Create a new `ReadBuf` from a fully initialized buffer.
+    #[inline]
+    pub(crate) fn new(buf: &'a mut [u8]) -> Self {
+        let len = buf.len();
+        // Safety: &[u8] has the same layout as &[MaybeUninit<u8>], and
+        // [u8] is always initialized.
+        let buf = unsafe { &mut *(buf as *mut [u8] as *mut [MaybeUninit<u8>]) };
+        Self {
+            buf,
+            filled: 0,
+            initialized: len,
+        }
+    }
+
+    /// Returns the total capacity of the buffer.
+    #[inline]
+    pub(crate) fn capacity(&self) -> usize {
+        self.buf.len()
+    }
+
+    /// Returns a shared reference to the filled portion of the buffer.
+    #[inline]
+    pub(crate) fn filled(&self) -> &[u8] {
+        // Safety: filled bytes are always initialized
+        unsafe {
+            &*(self.buf.get_unchecked(..self.filled) as *const [MaybeUninit<u8>] as *const [u8])
+        }
+    }
+
+    /// Returns the number of bytes at the end of the slice that are unfilled.
+    #[inline]
+    pub(crate) fn remaining(&self) -> usize {
+        self.capacity() - self.filled
+    }
+    /// Append data to the buffer.
+    ///
+    /// Advances both the initialized and filled cursors.
+    #[inline]
+    pub(crate) fn put_slice(&mut self, data: &[u8]) {
+        assert!(self.remaining() >= data.len(), "not enough space in buffer");
+
+        // Copy data into the unfilled portion
+        let dest = &mut self.buf[self.filled..self.filled + data.len()];
+        // Safety: we're writing initialized data
+        for (d, s) in dest.iter_mut().zip(data) {
+            d.write(*s);
+        }
+
+        // Update cursors
+        let new_filled = self.filled + data.len();
+        self.initialized = self.initialized.max(new_filled);
+        self.filled = new_filled;
+    }
+}
+
+impl fmt::Debug for ReadBuf<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReadBuf")
+            .field("capacity", &self.capacity())
+            .field("filled", &self.filled)
+            .field("initialized", &self.initialized)
+            .finish()
+    }
+}
+
+/// Convert from tokio's ReadBuf to our ReadBuf.
+///
+/// This is a zero-cost conversion when using the tokio runtime.
+#[cfg(feature = "runtime-tokio")]
+impl<'a> From<&'a mut tokio::io::ReadBuf<'_>> for ReadBuf<'a> {
+    #[inline]
+    fn from(buf: &'a mut tokio::io::ReadBuf<'_>) -> Self {
+        // We need to be careful here - we'll treat the tokio ReadBuf as our own
+        // by wrapping its unfilled_mut portion
+        let filled_len = buf.filled().len();
+        let initialized_len = buf.initialized().len();
+        let unfilled = unsafe { buf.unfilled_mut() };
+
+        Self {
+            buf: unfilled,
+            filled: 0,
+            initialized: initialized_len.saturating_sub(filled_len),
+        }
+    }
+}

--- a/quinn/src/abstraction/mod.rs
+++ b/quinn/src/abstraction/mod.rs
@@ -1,0 +1,7 @@
+pub(super) mod io;
+pub(super) mod mpsc;
+pub(super) mod oneshot;
+pub(super) mod sync;
+
+#[cfg(not(any(feature = "runtime-tokio", feature = "runtime-smol")))]
+compile_error!("Must enable either `runtime-tokio` or `runtime-smol` feature");

--- a/quinn/src/abstraction/mpsc.rs
+++ b/quinn/src/abstraction/mpsc.rs
@@ -1,0 +1,177 @@
+#[cfg(feature = "runtime-tokio")]
+pub(crate) use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+
+#[cfg(all(feature = "runtime-smol", not(feature = "runtime-tokio")))]
+pub(crate) use smol_impl::*;
+
+#[cfg(all(feature = "runtime-smol", not(feature = "runtime-tokio")))]
+mod smol_impl {
+    use std::fmt;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    /// Creates an unbounded multi-producer, single-consumer channel.
+    #[inline]
+    pub(crate) fn unbounded_channel<T>() -> (UnboundedSender<T>, UnboundedReceiver<T>) {
+        let (tx, rx) = async_channel::unbounded();
+        (
+            UnboundedSender { inner: tx },
+            UnboundedReceiver {
+                inner: rx,
+                recv_future: None,
+            },
+        )
+    }
+
+    /// The sending half of an unbounded channel.
+    pub(crate) struct UnboundedSender<T> {
+        inner: async_channel::Sender<T>,
+    }
+
+    impl<T> UnboundedSender<T> {
+        /// Send a value into the channel.
+        #[inline]
+        pub(crate) fn send(&self, value: T) -> Result<(), SendError<T>> {
+            // For unbounded channels, try_send never fails due to capacity
+            self.inner.try_send(value).map_err(|e| match e {
+                async_channel::TrySendError::Full(_) => {
+                    unreachable!("unbounded channel cannot be full")
+                }
+                async_channel::TrySendError::Closed(v) => SendError(v),
+            })
+        }
+    }
+
+    impl<T> Clone for UnboundedSender<T> {
+        #[inline]
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+
+    impl<T> fmt::Debug for UnboundedSender<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("UnboundedSender").finish_non_exhaustive()
+        }
+    }
+
+    // Type alias for the boxed receive future
+    type RecvFuture<T> = Pin<Box<dyn Future<Output = Result<T, async_channel::RecvError>> + Send>>;
+
+    /// The receiving half of an unbounded channel.
+    pub(crate) struct UnboundedReceiver<T> {
+        inner: async_channel::Receiver<T>,
+        recv_future: Option<RecvFuture<T>>,
+    }
+
+    impl<T: Send + 'static> UnboundedReceiver<T> {
+        /// Receive a value from the channel.
+        #[inline]
+        #[allow(dead_code)]
+        pub(crate) async fn recv(&mut self) -> Option<T> {
+            // Clear any pending poll_recv future since we're using async recv
+            self.recv_future = None;
+            self.inner.recv().await.ok()
+        }
+
+        /// Poll for a value from the channel.
+        pub(crate) fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+            loop {
+                // First, always try to receive without blocking
+                // This handles the case where data arrived between polls
+                match self.inner.try_recv() {
+                    Ok(value) => {
+                        // Got a value, clear any pending future
+                        self.recv_future = None;
+                        return Poll::Ready(Some(value));
+                    }
+                    Err(async_channel::TryRecvError::Closed) => {
+                        self.recv_future = None;
+                        return Poll::Ready(None);
+                    }
+                    Err(async_channel::TryRecvError::Empty) => {
+                        // Channel is empty, need to wait
+                    }
+                }
+
+                // Create the receive future if we don't have one
+                if self.recv_future.is_none() {
+                    let rx = self.inner.clone();
+                    self.recv_future = Some(Box::pin(async move { rx.recv().await }));
+                }
+
+                // Poll the receive future
+                let future = self.recv_future.as_mut().unwrap();
+                match future.as_mut().poll(cx) {
+                    Poll::Ready(Ok(value)) => {
+                        self.recv_future = None;
+                        return Poll::Ready(Some(value));
+                    }
+                    Poll::Ready(Err(_)) => {
+                        // Channel closed
+                        self.recv_future = None;
+                        return Poll::Ready(None);
+                    }
+                    Poll::Pending => {
+                        return Poll::Pending;
+                    }
+                }
+            }
+        }
+
+        /// Try to receive a value from the channel without blocking.
+        #[inline]
+        #[allow(dead_code)]
+        pub(crate) fn try_recv(&mut self) -> Result<T, TryRecvError> {
+            self.inner.try_recv().map_err(|e| match e {
+                async_channel::TryRecvError::Empty => TryRecvError::Empty,
+                async_channel::TryRecvError::Closed => TryRecvError::Disconnected,
+            })
+        }
+    }
+
+    impl<T> fmt::Debug for UnboundedReceiver<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("UnboundedReceiver")
+                .field("has_pending_recv", &self.recv_future.is_some())
+                .finish_non_exhaustive()
+        }
+    }
+
+    /// Error returned from [`UnboundedSender::send`] when the receiver
+    /// has been dropped.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(crate) struct SendError<T>(pub T);
+
+    impl<T> fmt::Display for SendError<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "channel closed")
+        }
+    }
+
+    impl<T: fmt::Debug> std::error::Error for SendError<T> {}
+
+    /// Error returned from [`UnboundedReceiver::try_recv`].
+    #[allow(dead_code)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) enum TryRecvError {
+        /// The channel is empty but not closed.
+        Empty,
+        /// The channel is closed and empty.
+        Disconnected,
+    }
+
+    impl fmt::Display for TryRecvError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::Empty => write!(f, "channel empty"),
+                Self::Disconnected => write!(f, "channel disconnected"),
+            }
+        }
+    }
+
+    impl std::error::Error for TryRecvError {}
+}

--- a/quinn/src/abstraction/oneshot.rs
+++ b/quinn/src/abstraction/oneshot.rs
@@ -1,0 +1,222 @@
+#[cfg(feature = "runtime-tokio")]
+pub(crate) use tokio::sync::oneshot::{Receiver, Sender, channel};
+
+#[cfg(all(feature = "runtime-smol", not(feature = "runtime-tokio")))]
+pub(crate) use smol_impl::*;
+
+#[cfg(all(feature = "runtime-smol", not(feature = "runtime-tokio")))]
+mod smol_impl {
+    use event_listener::{Event, EventListener};
+    use std::fmt;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
+    use std::task::{Context, Poll};
+
+    /// Internal state of the oneshot channel.
+    struct Inner<T> {
+        /// The value, if it has been sent.
+        value: Option<T>,
+        /// Whether the channel is closed.
+        closed: bool,
+        /// Event for notifying the receiver when a value is sent.
+        recv_event: Event,
+        /// Event for notifying the sender when the receiver is closed.
+        close_event: Event,
+    }
+
+    /// Create a new oneshot channel.
+    ///
+    /// Returns a sender and receiver pair. The sender can send exactly one value,
+    /// and the receiver will receive it.
+    pub(crate) fn channel<T>() -> (Sender<T>, Receiver<T>) {
+        let inner = Arc::new(Mutex::new(Inner {
+            value: None,
+            closed: false,
+            recv_event: Event::new(),
+            close_event: Event::new(),
+        }));
+        (
+            Sender {
+                inner: inner.clone(),
+            },
+            Receiver {
+                inner,
+                listener: None,
+            },
+        )
+    }
+
+    /// The sending half of a oneshot channel.
+    ///
+    /// A `Sender` can be used to send a single value to the corresponding [`Receiver`].
+    pub(crate) struct Sender<T> {
+        inner: Arc<Mutex<Inner<T>>>,
+    }
+
+    impl<T> Sender<T> {
+        /// Send a value on the channel.
+        ///
+        /// This consumes the sender. Returns an error containing the value if the
+        /// receiver has been dropped.
+        pub(crate) fn send(self, value: T) -> Result<(), T> {
+            let mut inner = self.inner.lock().unwrap();
+            if inner.closed {
+                return Err(value);
+            }
+            inner.value = Some(value);
+            inner.recv_event.notify(usize::MAX);
+            Ok(())
+        }
+    }
+
+    impl<T> Drop for Sender<T> {
+        fn drop(&mut self) {
+            let inner = self.inner.lock().unwrap();
+            // Wake up the receiver to let it know the sender is gone
+            inner.recv_event.notify(usize::MAX);
+        }
+    }
+
+    impl<T> fmt::Debug for Sender<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("Sender").finish_non_exhaustive()
+        }
+    }
+
+    /// The receiving half of a oneshot channel.
+    ///
+    /// A `Receiver` can be awaited to receive the value sent by the corresponding [`Sender`].
+    pub(crate) struct Receiver<T> {
+        inner: Arc<Mutex<Inner<T>>>,
+        listener: Option<Pin<Box<EventListener>>>,
+    }
+
+    impl<T> Receiver<T> {
+        /// Try to receive the value without blocking.
+        ///
+        /// Returns `Ok(value)` if the value has been sent,
+        /// `Err(TryRecvError::Empty)` if no value has been sent yet,
+        /// or `Err(TryRecvError::Closed)` if the sender has been dropped.
+        #[allow(dead_code)]
+        pub(crate) fn try_recv(&mut self) -> Result<T, TryRecvError> {
+            let mut inner = self.inner.lock().unwrap();
+            if let Some(value) = inner.value.take() {
+                Ok(value)
+            } else if Arc::strong_count(&self.inner) == 1 {
+                // Only this Receiver holds a reference, sender must be dropped
+                Err(TryRecvError::Closed)
+            } else {
+                Err(TryRecvError::Empty)
+            }
+        }
+
+        /// Close the channel.
+        ///
+        /// This signals to the sender that the receiver is no longer interested.
+        fn close(&mut self) {
+            let mut inner = self.inner.lock().unwrap();
+            inner.closed = true;
+            inner.close_event.notify(usize::MAX);
+        }
+    }
+
+    impl<T> Future for Receiver<T> {
+        type Output = Result<T, RecvError>;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let this = unsafe { self.get_unchecked_mut() };
+
+            loop {
+                // First, always check for the value
+                {
+                    let mut inner = this.inner.lock().unwrap();
+                    if let Some(value) = inner.value.take() {
+                        return Poll::Ready(Ok(value));
+                    }
+                    // Check if sender is dropped (we're the only Arc holder)
+                    if Arc::strong_count(&this.inner) == 1 {
+                        return Poll::Ready(Err(RecvError));
+                    }
+                }
+
+                // Create listener if we don't have one
+                if this.listener.is_none() {
+                    let inner = this.inner.lock().unwrap();
+                    this.listener = Some(Box::pin(inner.recv_event.listen()));
+                }
+
+                // Check again after registering - the value might have arrived
+                // between our check and listener registration
+                {
+                    let mut inner = this.inner.lock().unwrap();
+                    if let Some(value) = inner.value.take() {
+                        return Poll::Ready(Ok(value));
+                    }
+                    if Arc::strong_count(&this.inner) == 1 {
+                        return Poll::Ready(Err(RecvError));
+                    }
+                }
+
+                // Poll the listener
+                let listener = this.listener.as_mut().unwrap();
+                match listener.as_mut().poll(cx) {
+                    Poll::Ready(()) => {
+                        // Event was triggered, clear listener and loop to check value
+                        this.listener = None;
+                        // Continue the loop to check for value
+                    }
+                    Poll::Pending => {
+                        return Poll::Pending;
+                    }
+                }
+            }
+        }
+    }
+
+    impl<T> Drop for Receiver<T> {
+        fn drop(&mut self) {
+            // Mark as closed and notify the sender
+            self.close();
+        }
+    }
+
+    impl<T> fmt::Debug for Receiver<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("Receiver").finish_non_exhaustive()
+        }
+    }
+
+    /// Error returned when receiving from a closed channel.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) struct RecvError;
+
+    impl fmt::Display for RecvError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "channel closed")
+        }
+    }
+
+    impl std::error::Error for RecvError {}
+
+    /// Error returned from [`Receiver::try_recv`].
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[allow(dead_code)]
+    pub(crate) enum TryRecvError {
+        /// The channel is empty but not closed.
+        Empty,
+        /// The channel is closed.
+        Closed,
+    }
+
+    impl fmt::Display for TryRecvError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::Empty => write!(f, "channel empty"),
+                Self::Closed => write!(f, "channel closed"),
+            }
+        }
+    }
+
+    impl std::error::Error for TryRecvError {}
+}

--- a/quinn/src/abstraction/sync.rs
+++ b/quinn/src/abstraction/sync.rs
@@ -1,0 +1,228 @@
+#[cfg(feature = "runtime-tokio")]
+pub(crate) use tokio::sync::{Notify, futures::Notified};
+
+#[cfg(all(feature = "runtime-smol", not(feature = "runtime-tokio")))]
+pub(crate) use smol_impl::{Notified, Notify};
+
+#[cfg(all(feature = "runtime-smol", not(feature = "runtime-tokio")))]
+mod smol_impl {
+    use event_listener::{Event, EventListener};
+    use std::fmt;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Context, Poll};
+
+    /// A notification primitive for waking tasks.
+    pub(crate) struct Notify {
+        /// The underlying event for broadcasting notifications.
+        event: Event,
+        /// Counter to track stored notifications for `notify_one` semantics.
+        /// When a `notify_one` is called without any waiters, this is incremented.
+        /// When a `Notified` future starts waiting, it checks this first.
+        stored_notifications: AtomicUsize,
+        /// Version counter incremented on each `notify_waiters()` call.
+        /// Used to detect notifications that happened between `notified()`
+        /// creation and the first poll.
+        waiters_version: AtomicUsize,
+    }
+
+    impl Notify {
+        /// Create a new `Notify` instance.
+        #[inline]
+        pub(crate) fn new() -> Self {
+            Self {
+                event: Event::new(),
+                stored_notifications: AtomicUsize::new(0),
+                waiters_version: AtomicUsize::new(0),
+            }
+        }
+
+        /// Wait for a notification.
+        #[inline]
+        pub(crate) fn notified(&self) -> Notified<'_> {
+            // Capture the current waiters_version to detect notify_waiters()
+            // calls that happen between now and when we first poll.
+            let version_at_creation = self.waiters_version.load(Ordering::SeqCst);
+
+            Notified {
+                notify: self,
+                listener: None,
+                state: NotifiedState::Init,
+                version_at_creation,
+            }
+        }
+
+        /// Notify all waiting tasks.
+        #[inline]
+        pub(crate) fn notify_waiters(&self) {
+            // Increment version BEFORE notifying, so that any Notified
+            // created before this point will see the new version on first poll.
+            self.waiters_version.fetch_add(1, Ordering::SeqCst);
+            self.event.notify(usize::MAX);
+        }
+
+        /// Notify a single waiting task.
+        ///
+        /// If there is a task waiting via [`notified`](Self::notified), it
+        /// will be woken. If no task is waiting, the notification is stored
+        /// and the next call to `notified` will complete immediately.
+        #[inline]
+        #[allow(dead_code)]
+        pub(crate) fn notify_one(&self) {
+            // First try to notify a waiter
+            if self.event.notify(1) == 0 {
+                // No waiters, store the notification
+                self.stored_notifications.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        /// Try to consume a stored notification.
+        fn try_consume_stored(&self) -> bool {
+            loop {
+                let current = self.stored_notifications.load(Ordering::SeqCst);
+                if current == 0 {
+                    return false;
+                }
+
+                if self
+                    .stored_notifications
+                    .compare_exchange(current, current - 1, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+                {
+                    return true;
+                }
+            }
+        }
+    }
+
+    impl Default for Notify {
+        #[inline]
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl fmt::Debug for Notify {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("Notify")
+                .field(
+                    "stored_notifications",
+                    &self.stored_notifications.load(Ordering::Relaxed),
+                )
+                .field(
+                    "waiters_version",
+                    &self.waiters_version.load(Ordering::Relaxed),
+                )
+                .finish_non_exhaustive()
+        }
+    }
+
+    /// State machine for the Notified future
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum NotifiedState {
+        /// Initial state, haven't checked for stored notifications yet
+        Init,
+        /// Listener has been created and is waiting
+        Waiting,
+        /// Notification has been received
+        Done,
+    }
+
+    /// A future that completes when the associated [`Notify`] is signaled.
+    #[must_use = "futures do nothing unless polled"]
+    pub(crate) struct Notified<'a> {
+        notify: &'a Notify,
+        listener: Option<Pin<Box<EventListener>>>,
+        state: NotifiedState,
+        version_at_creation: usize,
+    }
+
+    impl Future for Notified<'_> {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            // Safety: We're only modifying fields, not moving the pinned data
+            let this = unsafe { self.get_unchecked_mut() };
+
+            loop {
+                match this.state {
+                    NotifiedState::Init => {
+                        let current_version = this.notify.waiters_version.load(Ordering::SeqCst);
+                        if current_version != this.version_at_creation {
+                            this.state = NotifiedState::Done;
+                            return Poll::Ready(());
+                        }
+
+                        // Check for a stored notification
+                        if this.notify.try_consume_stored() {
+                            this.state = NotifiedState::Done;
+                            return Poll::Ready(());
+                        }
+
+                        // No notification yet, create and register the listener.
+                        this.listener = Some(Box::pin(this.notify.event.listen()));
+                        this.state = NotifiedState::Waiting;
+
+                        // Check version again after registering, in case notify_waiters()
+                        // was called between our check above and registering the listener.
+                        let current_version = this.notify.waiters_version.load(Ordering::SeqCst);
+                        if current_version != this.version_at_creation {
+                            this.state = NotifiedState::Done;
+                            return Poll::Ready(());
+                        }
+                    }
+
+                    NotifiedState::Waiting => {
+                        // Check again for stored notifications (might've been added)
+                        if this.notify.try_consume_stored() {
+                            this.state = NotifiedState::Done;
+                            return Poll::Ready(());
+                        }
+
+                        // Also check version in case notify_waiters() was called
+                        let current_version = this.notify.waiters_version.load(Ordering::SeqCst);
+                        if current_version != this.version_at_creation {
+                            this.state = NotifiedState::Done;
+                            return Poll::Ready(());
+                        }
+
+                        // Poll the listener
+                        let listener = this
+                            .listener
+                            .as_mut()
+                            .expect("listener must exist in Waiting state");
+
+                        match listener.as_mut().poll(cx) {
+                            Poll::Ready(()) => {
+                                this.state = NotifiedState::Done;
+                                return Poll::Ready(());
+                            }
+                            Poll::Pending => return Poll::Pending,
+                        }
+                    }
+
+                    NotifiedState::Done => {
+                        // Already notified, return immediately
+                        return Poll::Ready(());
+                    }
+                }
+            }
+        }
+    }
+
+    impl fmt::Debug for Notified<'_> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("Notified")
+                .field("state", &self.state)
+                .field("version_at_creation", &self.version_at_creation)
+                .finish_non_exhaustive()
+        }
+    }
+
+    // Safety: Event and EventListener are Send + Sync
+    unsafe impl Send for Notify {}
+    unsafe impl Sync for Notify {}
+    unsafe impl Send for Notified<'_> {}
+    unsafe impl Sync for Notified<'_> {}
+}

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -13,15 +13,16 @@ use bytes::Bytes;
 use pin_project_lite::pin_project;
 use rustc_hash::FxHashMap;
 use thiserror::Error;
-use tokio::sync::{Notify, futures::Notified, mpsc, oneshot};
 use tracing::{Instrument, Span, debug_span};
 
 use crate::{
-    ConnectionEvent, Duration, Instant, VarInt,
+    ConnectionEvent, Duration, Instant, VarInt, mpsc,
     mutex::Mutex,
+    oneshot,
     recv_stream::RecvStream,
     runtime::{AsyncTimer, Runtime, UdpSender},
     send_stream::SendStream,
+    sync::{Notified, Notify},
     udp_transmit,
 };
 use proto::{

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -35,13 +35,16 @@ use rustc_hash::FxHashMap;
     any(feature = "aws-lc-rs", feature = "ring"),
 ))]
 use socket2::{Domain, Protocol, Socket, Type};
-use tokio::sync::{Notify, futures::Notified, mpsc};
 use tracing::{Instrument, Span};
 use udp::{BATCH_SIZE, RecvMeta};
 
 use crate::{
     ConnectionEvent, EndpointConfig, IO_LOOP_BOUND, RECV_TIME_BOUND, VarInt,
-    connection::Connecting, incoming::Incoming, work_limiter::WorkLimiter,
+    connection::Connecting,
+    incoming::Incoming,
+    mpsc,
+    sync::{Notified, Notify},
+    work_limiter::WorkLimiter,
 };
 
 /// A QUIC endpoint.

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -41,6 +41,10 @@
 
 use std::pin::Pin;
 
+mod abstraction;
+pub use abstraction::io::ReadBuf;
+use abstraction::{io, mpsc, oneshot, sync};
+
 mod connection;
 mod endpoint;
 mod incoming;

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -331,6 +331,7 @@ impl futures_io::AsyncWrite for SendStream {
     }
 }
 
+#[cfg(feature = "runtime-tokio")]
 impl tokio::io::AsyncWrite for SendStream {
     fn poll_write(
         self: Pin<&mut Self>,

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -704,9 +704,9 @@ async fn rebind_recv() {
 
     const MSG: &[u8; 5] = b"hello";
 
-    let write_send = Arc::new(tokio::sync::Notify::new());
+    let write_send = Arc::new(crate::sync::Notify::new());
     let write_recv = write_send.clone();
-    let connected_send = Arc::new(tokio::sync::Notify::new());
+    let connected_send = Arc::new(crate::sync::Notify::new());
     let connected_recv = connected_send.clone();
     let server = tokio::spawn(async move {
         let connection = server.accept().await.unwrap().await.unwrap();
@@ -788,7 +788,7 @@ async fn two_datagram_readers() {
     let client = client.unwrap();
     let server = server.unwrap();
 
-    let done = tokio::sync::Notify::new();
+    let done = crate::sync::Notify::new();
     let (a, b, ()) = tokio::join!(
         async {
             let x = client.read_datagram().await.unwrap();


### PR DESCRIPTION
This PR implements abstractions over the hard `tokio` dependency allowing
users of `runtime-smol` to avoid having to introduce a dep on `tokio` in their
projects.

I was unable to extrapolate the tests to not use tokio since that's heavily integrated,
but I have had success using `runtime-smol` in an external project and it did not have
to pull in tokio.

This is related to https://github.com/quinn-rs/quinn/issues/2504

It's an initial suggestion and I'm open to feedback and review.

This change should also require one of either `runtime-tokio` or `runtime-smol`
to be enabled, and they should likely be exclusive.

Cc: @djc 