### PR TITLE
Remove `RecvStream`s from `blocked_readers` on `stop`

### DIFF
--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -280,6 +280,9 @@ impl RecvStream {
         conn.inner.recv_stream(self.stream).stop(error_code)?;
         conn.wake();
         self.all_data_read = true;
+        // Clean up shared state that might be left over from a cancalled read
+        // operation, so `drop` doesn't have to
+        conn.blocked_readers.remove(&self.stream);
         Ok(())
     }
 


### PR DESCRIPTION
Fixes the issue reported in https://github.com/quinn-rs/quinn/pull/2495#issuecomment-3904293203.