### PR TITLE
add metric for spurious congestion events

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1456,6 +1456,7 @@ impl Connection {
         };
 
         if self.detect_spurious_loss(&ack, space) {
+            self.stats.path.spurious_congestion_events += 1;
             self.path.congestion.on_spurious_congestion_event();
         }
 

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -140,6 +140,8 @@ pub struct PathStats {
     pub cwnd: u64,
     /// Congestion events on the connection
     pub congestion_events: u64,
+    /// Spurious congestion events on the connection
+    pub spurious_congestion_events: u64,
     /// The amount of packets lost on this path
     pub lost_packets: u64,
     /// The amount of bytes lost on this path


### PR DESCRIPTION
This is inspired by recent work seen on `neqo`: we would like to track spurious congestion events through telemetry to understand the congestion controller behavior at scale.