### PR TITLE
Suppress table output in quinn-perf when JSON output targets stdout (#2544)

### DIFF
--- a/perf/src/stats.rs
+++ b/perf/src/stats.rs
@@ -120,12 +120,11 @@ impl Stats {
 
     #[cfg(feature = "json-output")]
     pub fn print_json(&self, path: &Path) -> io::Result<()> {
-        match path {
-            path if path == Path::new("-") => json::print(self, std::io::stdout()),
-            _ => {
-                let file = File::create(path)?;
-                json::print(self, file)
-            }
+        if path == Path::new("-") {
+            json::print(self, std::io::stdout());
+        } else {
+            let file = File::create(path)?;
+            json::print(self, file)
         }
         Ok(())
     }


### PR DESCRIPTION
Suppress table output meant to provide human-friendly visualization when using the `--json` CLI option and its argument is `-`, that is, when the JSON output targets stdout.