### PR TITLE
fix(quinn-udp): add Apple fast path API stubs for windows and fallback

### DIFF
--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -115,6 +115,20 @@ impl UdpSocketState {
     pub fn may_fragment(&self) -> bool {
         true
     }
+
+    /// Stub: Apple's fast UDP datapath is not available on this platform.
+    ///
+    /// # Safety
+    ///
+    /// No-op on this platform. Present for API compatibility with the Unix implementation.
+    pub unsafe fn set_apple_fast_path(&self) {}
+
+    /// Returns whether Apple's fast UDP datapath is enabled for this socket.
+    ///
+    /// Always returns `false` on this platform.
+    pub fn is_apple_fast_path_enabled(&self) -> bool {
+        false
+    }
 }
 
 fn send(socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -373,6 +373,20 @@ impl UdpSocketState {
     pub fn may_fragment(&self) -> bool {
         false
     }
+
+    /// Stub: Apple's fast UDP datapath is not available on Windows.
+    ///
+    /// # Safety
+    ///
+    /// No-op on Windows. Present for API compatibility with the Unix implementation.
+    pub unsafe fn set_apple_fast_path(&self) {}
+
+    /// Returns whether Apple's fast UDP datapath is enabled for this socket.
+    ///
+    /// Always returns `false` on Windows.
+    pub fn is_apple_fast_path_enabled(&self) -> bool {
+        false
+    }
 }
 
 fn send(


### PR DESCRIPTION
Mirror the Apple fast datapath APIs to windows.rs and fallback.rs.

See discussion in https://github.com/quinn-rs/quinn/pull/2463#discussion_r2909250172.