### PR TITLE
proto: promote recovery metrics to PathStats

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1270,6 +1270,12 @@ impl Connection {
         stats.path.rtt = self.path.rtt.get();
         stats.path.cwnd = self.path.congestion.window();
         stats.path.current_mtu = self.path.mtud.current_mtu();
+        stats.path.bytes_in_flight = self.path.in_flight.bytes;
+        stats.path.packets_in_flight = self.path.in_flight.ack_eliciting;
+        stats.path.min_rtt = self.path.rtt.min();
+        stats.path.latest_rtt = self.path.rtt.latest();
+        stats.path.rtt_variance = self.path.rtt.var();
+        stats.path.pto_count = self.pto_count;
 
         stats
     }

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -322,6 +322,16 @@ impl RttEstimator {
         self.min
     }
 
+    /// Most recent RTT sample
+    pub fn latest(&self) -> Duration {
+        self.latest
+    }
+
+    /// Current RTT variance estimate, computed as described in RFC 6298
+    pub fn var(&self) -> Duration {
+        self.var
+    }
+
     // PTO computed as described in RFC9002#6.2.1
     pub(crate) fn pto_base(&self) -> Duration {
         self.get() + cmp::max(4 * self.var, TIMER_GRANULARITY)

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -157,6 +157,20 @@ pub struct PathStats {
     pub black_holes_detected: u64,
     /// Largest UDP payload size the path currently supports
     pub current_mtu: u16,
+    /// Number of bytes considered in-flight by congestion control
+    ///
+    /// Does not include IP or UDP overhead. Packets containing only ACK frames are excluded.
+    pub bytes_in_flight: u64,
+    /// Number of ack-eliciting packets currently in flight
+    pub packets_in_flight: u64,
+    /// Minimum RTT observed on this path, ignoring ack delay
+    pub min_rtt: Duration,
+    /// Most recently observed RTT sample
+    pub latest_rtt: Duration,
+    /// Estimated variance of RTT samples, computed as described in RFC 6298
+    pub rtt_variance: Duration,
+    /// Number of probe timeout (PTO) events fired
+    pub pto_count: u32,
 }
 
 /// Connection statistics


### PR DESCRIPTION
## Summary

Promote 6 fields from qlog-only `RecoveryMetrics` to `PathStats`, making them available through the zero-overhead `Connection::stats()` path:

- `bytes_in_flight: u64` — bytes in-flight per congestion control
- `packets_in_flight: u64` — ack-eliciting packets in flight
- `min_rtt: Duration` — minimum observed RTT (ignoring ack delay)
- `latest_rtt: Duration` — most recent RTT sample
- `rtt_variance: Duration` — smoothed RTT variance (RFC 6298)
- `pto_count: u32` — probe timeout event count

Also adds `latest()` and `var()` public getters on `RttEstimator` (`min()` already existed).

## Motivation

These values are already computed internally and surfaced through qlog's `MetricsUpdated` event. However, accessing them via qlog requires enabling the `qlog` feature and paying per-event `Arc<Mutex>` locking + JSON serialization overhead — unsuitable for high-frequency polling in relay/proxy workloads that need to make adaptive decisions (e.g., flow control window sizing based on BDP).

Promoting them to `PathStats` makes them available with zero additional overhead since `stats()` already snapshots `rtt`, `cwnd`, and `current_mtu` from the same internal state.

## Use cases

- **Adaptive flow control:** `min_rtt` (not smoothed RTT) is the correct input for bandwidth-delay product estimation. `bytes_in_flight` vs `cwnd` instantly distinguishes flow-control-limited from congestion-limited connections.
- **Path quality monitoring:** `latest_rtt` + `rtt_variance` enable jitter detection without qlog.
- **Tail latency diagnosis:** `pto_count` identifies connections experiencing repeated probe timeouts.

## Changes

- `quinn-proto/src/connection/stats.rs` — 6 new fields on `PathStats`
- `quinn-proto/src/connection/paths.rs` — 2 new pub getters on `RttEstimator`
- `quinn-proto/src/connection/mod.rs` — populate new fields in `stats()`

All fields use `#[non_exhaustive]` (inherited from `PathStats`), so this is backwards-compatible.

## Related

- #2156 (distinguishing congestion vs pacing blocks — `bytes_in_flight` helps here)
- #884 (original connection statistics PR)