### PR TITLE
Test write readiness after ENOBUFS

### DIFF
--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -33,7 +33,8 @@ windows-sys = { workspace = true }
 
 [dev-dependencies]
 criterion = { version = "0.8", default-features = false, features = ["async_tokio"] }
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "net"] }
+libc = "0.2.175"
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "net", "time", "macros"] }
 
 [build-dependencies]
 cfg_aliases = { workspace = true }

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -370,6 +370,111 @@ fn ip_to_v6_mapped(x: IpAddr) -> IpAddr {
     }
 }
 
+/// Reproducer for <https://github.com/quinn-rs/quinn/issues/2293>.
+///
+/// On macOS, `ENOBUFS` ("No buffer space available", os error 55) is returned by
+/// `sendmsg` when the kernel's network buffer pool (mbufs) is exhausted. Unlike
+/// `EAGAIN`/`EWOULDBLOCK` — which signals that the per-socket send buffer is full and
+/// for which the I/O driver reliably fires a WRITE event once buffer space returns —
+/// `ENOBUFS` is a system-wide condition the I/O driver has no direct visibility into.
+///
+/// Mapping `ENOBUFS` to `WouldBlock` is therefore incorrect: after `ENOBUFS`, the
+/// I/O driver may not re-signal writability, so a task waiting for a WRITE event can
+/// suspend indefinitely (confirmed by Firezone in production).
+///
+/// This test verifies the expected behaviour: after `ENOBUFS` is returned and the
+/// receiver has drained its buffer (freeing kernel memory), the tokio reactor IS
+/// woken up so that the sender can retry.
+///
+/// Run with: `cargo test --test tests enobufs_task_wakeup -- --nocapture`
+#[tokio::test]
+#[cfg(target_os = "macos")]
+async fn enobufs_task_wakeup() {
+    use std::time::Duration;
+
+    let sender_std = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let receiver_std = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let dst_addr = receiver_std.local_addr().unwrap();
+
+    // tokio::net::UdpSocket::from_std requires the socket to be non-blocking already.
+    sender_std.set_nonblocking(true).unwrap();
+    let sender = tokio::net::UdpSocket::from_std(sender_std).unwrap();
+
+    let send_state = UdpSocketState::new((&sender).into()).unwrap();
+
+    // Use a typical QUIC packet size to avoid EMSGSIZE while still building
+    // buffer pressure quickly.
+    let payload = vec![0u8; 1400];
+
+    // Flood the socket without draining the receiver to maximise buffer pressure.
+    // We stop as soon as ENOBUFS is observed.
+    let mut enobufs_seen = false;
+    for _ in 0..50_000 {
+        let transmit = Transmit {
+            destination: dst_addr,
+            ecn: None,
+            contents: &payload,
+            segment_size: None,
+            src_ip: None,
+        };
+        match send_state.try_send((&sender).into(), &transmit) {
+            Ok(()) => {}
+            Err(e) if e.raw_os_error() == Some(libc::ENOBUFS) => {
+                enobufs_seen = true;
+                break;
+            }
+            // WouldBlock means the per-socket send buffer is full; keep going so
+            // we can build up more pressure toward ENOBUFS.
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(e) => eprintln!("unexpected send error: {e:?}"),
+        }
+    }
+
+    assert!(
+        enobufs_seen,
+        "ENOBUFS was not triggered after 5000 sends; \
+         the test requires ENOBUFS to validate the wakeup behaviour"
+    );
+
+    eprintln!("ENOBUFS observed; draining receiver and waiting for task wakeup");
+
+    // Drain the receiver in a background task so the kernel can reclaim mbufs.
+    receiver_std.set_nonblocking(true).unwrap();
+    let drain_task = tokio::task::spawn_blocking(move || {
+        let mut buf = vec![0u8; 65507];
+        loop {
+            match receiver_std.recv(&mut buf) {
+                Ok(_) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                Err(_) => break,
+            }
+        }
+    });
+
+    // After ENOBUFS + receiver drain the tokio reactor must wake this task so it
+    // can retry. The async loop awaits write-readiness, then attempts to send.
+    // On success this proves the task was woken up with send space available.
+    // If the I/O driver never re-signals writability the outer timeout fires,
+    // demonstrating the "task suspends indefinitely" bug described in the issue.
+    let probe = Transmit {
+        destination: dst_addr,
+        ecn: None,
+        contents: b"probe",
+        segment_size: None,
+        src_ip: None,
+    };
+    tokio::time::timeout(Duration::from_secs(5), async {
+        sender.writable().await.unwrap();
+        send_state
+            .try_send((&sender).into(), &probe)
+            .expect("send after ENOBUFS + receiver drain should succeed");
+    })
+    .await
+    .expect("task was not woken up after ENOBUFS + receiver drain");
+
+    drain_task.await.unwrap();
+}
+
 /// Test Apple fast datapath enable/disable functionality.
 ///
 /// This test verifies that:

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -392,21 +392,20 @@ fn ip_to_v6_mapped(x: IpAddr) -> IpAddr {
 async fn enobufs_task_wakeup() {
     use std::time::Duration;
 
-    let sender_std = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let receiver_std = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let dst_addr = receiver_std.local_addr().unwrap();
+    // Send to TEST-NET-1 (RFC 5737): packets are routed into the network stack
+    // but never delivered, building kernel buffer pressure more effectively than
+    // loopback where packets are consumed immediately.
+    let dst_addr: std::net::SocketAddr = SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 1), 1234).into();
 
-    // tokio::net::UdpSocket::from_std requires the socket to be non-blocking already.
+    let sender_std = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)).unwrap();
     sender_std.set_nonblocking(true).unwrap();
     let sender = tokio::net::UdpSocket::from_std(sender_std).unwrap();
 
     let send_state = UdpSocketState::new((&sender).into()).unwrap();
 
-    // Use a typical QUIC packet size to avoid EMSGSIZE while still building
-    // buffer pressure quickly.
     let payload = vec![0u8; 1400];
 
-    // Flood the socket without draining the receiver to maximise buffer pressure.
+    // Flood the socket to exhaust kernel network buffers (mbufs).
     // We stop as soon as ENOBUFS is observed.
     let mut enobufs_seen = false;
     for _ in 0..50_000 {
@@ -432,30 +431,16 @@ async fn enobufs_task_wakeup() {
 
     assert!(
         enobufs_seen,
-        "ENOBUFS was not triggered after 5000 sends; \
+        "ENOBUFS was not triggered after 50000 sends; \
          the test requires ENOBUFS to validate the wakeup behaviour"
     );
 
-    eprintln!("ENOBUFS observed; draining receiver and waiting for task wakeup");
+    eprintln!("ENOBUFS observed; waiting for task wakeup");
 
-    // Drain the receiver in a background task so the kernel can reclaim mbufs.
-    receiver_std.set_nonblocking(true).unwrap();
-    let drain_task = tokio::task::spawn_blocking(move || {
-        let mut buf = vec![0u8; 65507];
-        loop {
-            match receiver_std.recv(&mut buf) {
-                Ok(_) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
-                Err(_) => break,
-            }
-        }
-    });
-
-    // After ENOBUFS + receiver drain the tokio reactor must wake this task so it
-    // can retry. The async loop awaits write-readiness, then attempts to send.
-    // On success this proves the task was woken up with send space available.
-    // If the I/O driver never re-signals writability the outer timeout fires,
-    // demonstrating the "task suspends indefinitely" bug described in the issue.
+    // After ENOBUFS the kernel will eventually free mbufs as it processes/drops
+    // the outbound packets (non-routable destination). The I/O driver must then
+    // wake this task so it can retry. If it never re-signals writability the
+    // timeout fires, demonstrating the "task suspends indefinitely" bug.
     let probe = Transmit {
         destination: dst_addr,
         ecn: None,
@@ -467,12 +452,10 @@ async fn enobufs_task_wakeup() {
         sender.writable().await.unwrap();
         send_state
             .try_send((&sender).into(), &probe)
-            .expect("send after ENOBUFS + receiver drain should succeed");
+            .expect("send after ENOBUFS should succeed once buffers are freed");
     })
     .await
-    .expect("task was not woken up after ENOBUFS + receiver drain");
-
-    drain_task.await.unwrap();
+    .expect("task was not woken up after ENOBUFS");
 }
 
 /// Test Apple fast datapath enable/disable functionality.

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -395,7 +395,8 @@ async fn enobufs_task_wakeup() {
     // Send to TEST-NET-1 (RFC 5737): packets are routed into the network stack
     // but never delivered, building kernel buffer pressure more effectively than
     // loopback where packets are consumed immediately.
-    let dst_addr: std::net::SocketAddr = SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 1), 1234).into();
+    let dst_addr: std::net::SocketAddr =
+        SocketAddrV4::new(Ipv4Addr::new(25, 43, 64, 0), 1234).into();
 
     let sender_std = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)).unwrap();
     sender_std.set_nonblocking(true).unwrap();

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -382,13 +382,14 @@ fn ip_to_v6_mapped(x: IpAddr) -> IpAddr {
 /// I/O driver may not re-signal writability, so a task waiting for a WRITE event can
 /// suspend indefinitely (confirmed by Firezone in production).
 ///
-/// This test verifies the expected behaviour: after `ENOBUFS` is returned and the
-/// receiver has drained its buffer (freeing kernel memory), the tokio reactor IS
-/// woken up so that the sender can retry.
+/// This test reproduces the bug by deliberately mapping `ENOBUFS` to `WouldBlock`
+/// inside the `async_io` closure. When `ENOBUFS` occurs, `async_io` then waits for
+/// a writability event that never comes, and the outer timeout fires — confirming
+/// that `ENOBUFS` must not be surfaced as `WouldBlock`.
 ///
-/// Run with: `cargo test --test tests enobufs_task_wakeup -- --nocapture`
+/// Run with: `cargo test --release --features fast-apple-datapath --test tests enobufs_task_wakeup -- --nocapture`
 #[tokio::test]
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", apple_fast))]
 async fn enobufs_task_wakeup() {
     use std::time::Duration;
 
@@ -403,60 +404,58 @@ async fn enobufs_task_wakeup() {
     let sender = tokio::net::UdpSocket::from_std(sender_std).unwrap();
 
     let send_state = UdpSocketState::new((&sender).into()).unwrap();
-
-    let payload = vec![0u8; 1400];
-
-    // Flood the socket to exhaust kernel network buffers (mbufs).
-    // We stop as soon as ENOBUFS is observed.
-    let mut enobufs_seen = false;
-    for _ in 0..50_000 {
-        let transmit = Transmit {
-            destination: dst_addr,
-            ecn: None,
-            contents: &payload,
-            segment_size: None,
-            src_ip: None,
-        };
-        match send_state.try_send((&sender).into(), &transmit) {
-            Ok(()) => {}
-            Err(e) if e.raw_os_error() == Some(libc::ENOBUFS) => {
-                enobufs_seen = true;
-                break;
-            }
-            // WouldBlock means the per-socket send buffer is full; keep going so
-            // we can build up more pressure toward ENOBUFS.
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
-            Err(e) => eprintln!("unexpected send error: {e:?}"),
-        }
+    unsafe {
+        send_state.set_apple_fast_path();
     }
+
+    const CONTENT_LEN: usize = 35000;
+    const PACKET_LEN: usize = 1400;
+
+    let transmit = Transmit {
+        destination: dst_addr,
+        ecn: None,
+        contents: &vec![0u8; CONTENT_LEN],
+        segment_size: Some(PACKET_LEN),
+        src_ip: None,
+    };
+
+    let mut enobufs_seen = false;
+    let mut sent = 0;
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            sender
+                .async_io(tokio::io::Interest::WRITABLE, || -> std::io::Result<()> {
+                    match send_state.try_send((&sender).into(), &transmit) {
+                        Ok(()) => {
+                            sent += CONTENT_LEN / PACKET_LEN;
+                            if sent % 1000 == 0 {
+                                eprintln!("sent {sent} packets");
+                            }
+
+                            Ok(())
+                        }
+                        Err(e) if e.raw_os_error() == Some(libc::ENOBUFS) => {
+                            enobufs_seen = true;
+
+                            Err(std::io::Error::from(std::io::ErrorKind::WouldBlock))
+                        }
+                        Err(e) => Err(e),
+                    }
+                })
+                .await
+                .unwrap();
+        }
+    })
+    .await;
 
     assert!(
         enobufs_seen,
-        "ENOBUFS was not triggered after 50000 sends; \
-         the test requires ENOBUFS to validate the wakeup behaviour"
+        "ENOBUFS was not triggered; the test cannot demonstrate the bug without it"
     );
-
-    eprintln!("ENOBUFS observed; waiting for task wakeup");
-
-    // After ENOBUFS the kernel will eventually free mbufs as it processes/drops
-    // the outbound packets (non-routable destination). The I/O driver must then
-    // wake this task so it can retry. If it never re-signals writability the
-    // timeout fires, demonstrating the "task suspends indefinitely" bug.
-    let probe = Transmit {
-        destination: dst_addr,
-        ecn: None,
-        contents: b"probe",
-        segment_size: None,
-        src_ip: None,
-    };
-    tokio::time::timeout(Duration::from_secs(5), async {
-        sender.writable().await.unwrap();
-        send_state
-            .try_send((&sender).into(), &probe)
-            .expect("send after ENOBUFS should succeed once buffers are freed");
-    })
-    .await
-    .expect("task was not woken up after ENOBUFS");
+    assert!(
+        result.is_err(),
+        "expected timeout: mapping ENOBUFS to WouldBlock should leave the task suspended"
+    );
 }
 
 /// Test Apple fast datapath enable/disable functionality.


### PR DESCRIPTION
Trying to reproduce missing wake-up on `ENOBUFS` discussed in https://github.com/quinn-rs/quinn/issues/2293.