### PR TITLE
Don't use initial server connection ID longer than necessary.

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2981,9 +2981,9 @@ impl Connection {
                         }
                     };
 
-                    if self.side.is_server() && self.rem_cids.active_seq() == 0 {
-                        // We're a server still using the initial remote CID for the client, so
-                        // let's switch immediately to enable clientside stateless resets.
+                    if self.rem_cids.active_seq() == 0 {
+                        // We're a server still using the initial remote CID for the client or
+                        // server, so let's switch immediately to enable clientside stateless resets.
                         self.update_rem_cid();
                     }
                 }


### PR DESCRIPTION
I was analyzing what connection ids are transmitted when running `bench` and saw that the initial server connection ID (one assigned after the client sends us first packet with random cid) is used during the whole connection, which makes it easier for a passive observer to identify a specific connection.


Tested with default bench params (just `cargo run` in bench dir)

The connection proceeds as follows:
1. Client sends first initial packet with `src_cid: <client_cid>` and dst_cid: <some_random_value>
2. Server continues handshake but replaces `<some_random_value>` with `<server_cid>`, server sends packet with long header and `src_cid: <server_cid>` and `dst_id: <client_cid>` (observer can see both ids and link them together)
3. Handshake continues ..
4. Server sends new identifiers to client with `<new_server_id>`
5. Client sends new_identifiers to server with `<new_client_id>`
6. Client sends short header packets with `dst_id: <server_cid>` and Server sends short header packets with `dst_id: <client_cid>`
7. Server starts sending packets with `dst_id: <new_client_id>` and `<client_cid>` is retired.
---
8. <server_cid> is never retired during this connection. Passive observer knows that `<server_cid>` is linked to `<client_cid>` and `<some_random_value>` so they know when client sends data for this connection to server (probably not forever cause later ids may change).

The fix is pretty simple one line change to update remote CID not only in server code.