### PR TITLE
quinn: fix ref count logic for ConnectionRef and EndpointRef

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -932,7 +932,7 @@ impl Clone for ConnectionRef {
 
 impl Drop for ConnectionRef {
     fn drop(&mut self) {
-        if self.shared.ref_count.fetch_sub(1, Ordering::Relaxed) > 0 {
+        if self.shared.ref_count.fetch_sub(1, Ordering::Relaxed) > 1 {
             return;
         }
 

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -784,7 +784,7 @@ impl Clone for EndpointRef {
 
 impl Drop for EndpointRef {
     fn drop(&mut self) {
-        if self.shared.ref_count.fetch_sub(1, Ordering::Relaxed) > 0 {
+        if self.shared.ref_count.fetch_sub(1, Ordering::Relaxed) > 1 {
             return;
         }
 


### PR DESCRIPTION
PR #2495 broke the ref count logic when moving from non atomic usize to atomic usize.

We found it in one of our test where we did the following usage pattern on an Endpoint create / use / drop / create another one / use / drop.

When the first Endpoint is dropped, its driver continued to run for some seconds and accepted(network) and refused(proto) some connections.

After the fix, the driver is stopped as soon as the last ref is dropped. (Validated by us)

The ConnectionRef drop also has the same logic, we have no test to validate it.