### PR TITLE
quinn: expose accepted_0rtt() on Connection

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -291,6 +291,19 @@ impl Future for ConnectionDriver {
 pub struct Connection(ConnectionRef);
 
 impl Connection {
+    /// Returns whether the TLS handshake accepted 0-RTT early data on this
+    /// connection.
+    ///
+    /// Server consumers accepting 0-RTT need this signal to gate replay-
+    /// sensitive logic (non-idempotent HTTP methods, etc.) on streams that
+    /// actually arrived as 0-RTT. Prior to this accessor `accepted_0rtt()`
+    /// was public only on the internal `quinn_proto::Connection`, forcing
+    /// server code to fall back to time-window heuristics.
+    pub fn accepted_0rtt(&self) -> bool {
+        let conn = self.0.state.lock("accepted_0rtt");
+        conn.inner.accepted_0rtt()
+    }
+
     /// Initiate a new outgoing unidirectional stream.
     ///
     /// Streams are cheap and instantaneous to open unless blocked by flow control. As a


### PR DESCRIPTION
## Summary

The high-level `quinn::Connection` wrapper omits `accepted_0rtt()` even though `quinn_proto::Connection` already exposes it publicly. Server-side consumers that accept 0-RTT early data need this signal to safely gate replay-sensitive operations (e.g. non-idempotent HTTP methods on an HTTP/3 MITM listener) without falling back to time-window heuristics.

This adds a one-line delegation. No behavioral change to other code paths.

## Motivation

Building an HTTP/3 MITM interception proxy ([Hugin](https://github.com/HuginSecurity/Hugin)), I needed to decide per-request whether to reject non-idempotent methods (POST/PUT/PATCH/DELETE) that arrived as 0-RTT early data — replayable and therefore unsafe for anything with side effects. The only public signal available was a time-since-handshake heuristic (\"if the stream arrived within N ms of handshake start, assume it's 0-RTT\"), which is imprecise under network jitter and adversarial timing.

The exact signal already exists in `quinn_proto::Connection::accepted_0rtt()`. Exposing it on the high-level `Connection` closes the gap with no new API surface on the proto side.

## Test plan

- [x] Local build + test of a downstream project using the accessor
- [ ] Any upstream tests reviewers would like me to add (happy to extend)

## Notes

Targeted at `main` off tag `quinn-0.11.9`. The change is a single public method; semver-compatible as a minor-version addition.