### PR TITLE
Use binary search in ArrayRangeSet

### DIFF
--- a/quinn-proto/src/range_set/array_range_set.rs
+++ b/quinn-proto/src/range_set/array_range_set.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use std::cmp::Ordering;
 use std::ops::Range;
 
 use tinyvec::TinyVec;
@@ -58,15 +60,18 @@ impl ArrayRangeSet {
 
     #[cfg(test)]
     pub(super) fn contains(&self, x: u64) -> bool {
-        for range in self.0.iter() {
-            if range.start > x {
-                // We only get here if there was no prior range that contained x
-                return false;
-            } else if range.contains(&x) {
-                return true;
-            }
-        }
-        false
+        self.0
+            .binary_search_by(|range| {
+                if range.end <= x {
+                    Ordering::Less
+                } else if x < range.start {
+                    Ordering::Greater
+                } else {
+                    // range.start <= x < range.end
+                    Ordering::Equal
+                }
+            })
+            .is_ok()
     }
 
     pub(crate) fn insert_one(&mut self, x: u64) -> bool {
@@ -81,57 +86,58 @@ impl ArrayRangeSet {
             return false;
         }
 
-        let mut idx = 0;
-        while idx != self.0.len() {
-            let range = &mut self.0[idx];
+        // Find the first range that might interact with `x`.
+        // Unlike removal, we use a strict comparison so that ranges
+        // adjacent to `x` are included in the right-hand partition and can be merged.
+        let idx = self.0.partition_point(|r| r.end < x.start);
 
-            if range.start > x.end {
-                // The range is fully before this range and therefore not extensible.
-                // Add a new range to the left
-                self.0.insert(idx, x);
-                return true;
-            } else if range.start > x.start {
-                // The new range starts before this range but overlaps.
-                // Extend the current range to the left
-                // Note that we don't have to merge a potential left range, since
-                // this case would have been captured by merging the right range
-                // in the previous loop iteration
-                result = true;
-                range.start = x.start;
-            }
-
-            // At this point we have handled all parts of the new range which
-            // are in front of the current range. Now we handle everything from
-            // the start of the current range
-
-            if x.end <= range.end {
-                // Fully contained
-                return result;
-            } else if x.start <= range.end {
-                // Extend the current range to the end of the new range.
-                // Since it's not contained it must be bigger
-                range.end = x.end;
-
-                // Merge all follow-up ranges which overlap
-                while idx != self.0.len() - 1 {
-                    let curr = self.0[idx].clone();
-                    let next = self.0[idx + 1].clone();
-                    if curr.end >= next.start {
-                        self.0[idx].end = next.end.max(curr.end);
-                        self.0.remove(idx + 1);
-                    } else {
-                        break;
-                    }
-                }
-
-                return true;
-            }
-
-            idx += 1;
+        if idx == self.0.len() {
+            self.0.push(x);
+            return true;
         }
 
-        // Insert a range at the end
-        self.0.push(x);
+        let range = &mut self.0[idx];
+
+        if x.end < range.start {
+            // The range is fully before this range and therefore not extensible.
+            // Add a new range to the left
+            self.0.insert(idx, x);
+            return true;
+        } else if range.start > x.start {
+            // The new range starts before this range but overlaps.
+            // Extend the current range to the left
+            // Note that we don't have to merge a potential left range, since
+            // this case would have been captured by merging the right range
+            // in the previous loop iteration
+            result = true;
+            range.start = x.start;
+        }
+
+        // At this point we have handled all parts of the new range which
+        // are in front of the current range. Now we handle everything from
+        // the start of the current range
+
+        if x.end <= range.end {
+            // Fully contained
+            return result;
+        }
+
+        // Extend the current range to the end of the new range.
+        // Since it's not contained it must be bigger
+        range.end = x.end;
+
+        // Merge all follow-up ranges which overlap
+        while idx != self.0.len() - 1 {
+            let curr = self.0[idx].clone();
+            let next = self.0[idx + 1].clone();
+            if curr.end >= next.start {
+                self.0[idx].end = next.end.max(curr.end);
+                self.0.remove(idx + 1);
+            } else {
+                break;
+            }
+        }
+
         true
     }
 
@@ -143,17 +149,17 @@ impl ArrayRangeSet {
             return false;
         }
 
-        let mut idx = 0;
-        while idx != self.0.len() && x.start != x.end {
+        // Find the first range that might overlap with `x`.
+        // Unlike insertion, we use an inclusive comparison since removal does not
+        // affect the adjacent range on the left.
+        let mut idx = self.0.partition_point(|r| r.end <= x.start);
+
+        while idx != self.0.len() {
             let range = self.0[idx].clone();
 
             if x.end <= range.start {
-                // The range is fully before this range
-                return result;
-            } else if x.start >= range.end {
-                // The range is fully after this range
-                idx += 1;
-                continue;
+                // The range is not in the set
+                break;
             }
 
             // The range overlaps with this range
@@ -161,6 +167,7 @@ impl ArrayRangeSet {
 
             let left = range.start..x.start;
             let right = x.end..range.end;
+
             if left.is_empty() && right.is_empty() {
                 self.0.remove(idx);
             } else if left.is_empty() {

--- a/quinn-proto/src/range_set/tests.rs
+++ b/quinn-proto/src/range_set/tests.rs
@@ -11,7 +11,9 @@ macro_rules! common_set_tests {
             fn merge_and_split() {
                 let mut set = $set_type::new();
                 assert!(set.insert(0..2));
+                assert!(set.contains(0));
                 assert!(set.insert(2..4));
+                assert!(set.contains(3));
                 assert!(!set.insert(1..3));
                 assert_eq!(set.len(), 1);
                 assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 2, 3]);


### PR DESCRIPTION
This PR modifies the `ArrayRangeSet` implementation to use binary search instead of linear scan for insertions and removals, as suggested on [Discord](https://discord.com/channels/976380008299917365/1063547094863978677/1438455284195659786).

I also wrote two basic `criterion` benchmarks:
- completely random insertions and removals between 0 and `size`
- almost-linear insertions between 0 and `size` with occasional holes

But did not include them in this PR since I'm not sure they're super meaningful and require a bunch of noisy diffs in `quinn-proto` to expose the types for the benchmarks.

They show limited gains (but no regression) for smaller sets, but significant improvements for larger sets, especially for the linear scenario which I believe is closer to the expected usage in `quinn`.

Size | Mode | BTree | Array (linear scan) | Array (binary search)
-- | -- | -- | -- | --
100 | Random | 14.431 µs | 4.7897 µs | 4.5871 µs
100 | Linear | 13.288 µs | 4.9711 µs | 4.2885 µs
500 | Random | 95.934 µs | 46.976 µs | 25.327 µs
500 | Linear | 84.387 µs | 56.173 µs | 22.717 µs
5000 | Random | 1.2510 ms | 3.0309 ms | 378.20 µs
5000 | Linear | 1.0457 ms | 3.8295 ms | 256.83 µs
10000 | Random | 2.6267 ms | 11.886 ms | 1.0308 ms
10000 | Linear | 2.1992 ms | 13.944 ms | 533.71 µs
