### PR TITLE
Improve 0-RTT usability

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -16,7 +16,11 @@ use bytes::Bytes;
 use pin_project_lite::pin_project;
 use rustc_hash::FxHashMap;
 use thiserror::Error;
-use tokio::sync::{Notify, futures::Notified, mpsc, oneshot};
+use tokio::sync::{
+    Notify,
+    futures::{Notified, OwnedNotified},
+    mpsc, oneshot,
+};
 use tracing::{Instrument, Span, debug_span};
 
 use crate::{
@@ -36,7 +40,7 @@ use proto::{
 #[derive(Debug)]
 pub struct Connecting {
     conn: Option<ConnectionRef>,
-    connected: oneshot::Receiver<bool>,
+    connected: Pin<Box<OwnedNotified>>,
     handshake_data_ready: Option<oneshot::Receiver<()>>,
 }
 
@@ -50,7 +54,6 @@ impl Connecting {
         runtime: Arc<dyn Runtime>,
     ) -> Self {
         let (on_handshake_data_send, on_handshake_data_recv) = oneshot::channel();
-        let (on_connected_send, on_connected_recv) = oneshot::channel();
 
         let conn = ConnectionRef(Arc::new(ConnectionInner {
             state: Mutex::new(State::new(
@@ -59,12 +62,12 @@ impl Connecting {
                 endpoint_events,
                 conn_events,
                 on_handshake_data_send,
-                on_connected_send,
                 sender,
                 runtime.clone(),
             )),
             shared: Shared::default(),
         }));
+        let connected = Box::pin(conn.shared.connected.clone().notified_owned());
 
         let driver = ConnectionDriver(conn.clone());
         runtime.spawn(Box::pin(
@@ -78,7 +81,7 @@ impl Connecting {
 
         Self {
             conn: Some(conn),
-            connected: on_connected_recv,
+            connected,
             handshake_data_ready: Some(on_handshake_data_recv),
         }
     }
@@ -88,7 +91,7 @@ impl Connecting {
     /// Returns `Ok` immediately if the local endpoint is able to attempt sending 0/0.5-RTT data.
     /// If so, the returned [`Connection`] can be used to send application data without waiting for
     /// the rest of the handshake to complete, at the cost of weakened cryptographic security
-    /// guarantees. The returned [`ZeroRttAccepted`] future resolves when the handshake does
+    /// guarantees. The [`Connection::authenticated`] future resolves when the handshake does
     /// complete, at which point subsequently opened streams and written data will have full
     /// cryptographic protection.
     ///
@@ -98,11 +101,13 @@ impl Connecting {
     /// 0-RTT data will proceed if the [`crypto::ClientConfig`][crate::crypto::ClientConfig]
     /// attempts to resume a previous TLS session. However, **the remote endpoint may not actually
     /// _accept_ the 0-RTT data**--yet still accept the connection attempt in general. This
-    /// possibility is conveyed through the [`ZeroRttAccepted`] future--when the handshake
-    /// completes, it resolves to true if the 0-RTT data was accepted and false if it was rejected.
-    /// If it was rejected, the existence of streams opened and other application data sent prior
-    /// to the handshake completing will not be conveyed to the remote application, and local
-    /// operations on them will return `ZeroRttRejected` errors.
+    /// possibility is conveyed through `ZeroRttRejected` errors on stream I/O methods, which may
+    /// arise when the handshake completes. If 0-RTT was rejected, the existence of streams opened
+    /// and other application data sent by a client prior to the handshake completing will not be
+    /// conveyed to the remote application. Clients which need to e.g. re-transmit rejected stream
+    /// data must take care to detect `ZeroRttRejected` errors even on finished streams opened
+    /// during 0-RTT, e.g. by awaiting an application-layer response on bidirectional streams, or
+    /// awaiting [`SendStream::stopped`] on unidirectional streams.
     ///
     /// A server may reject 0-RTT data at its discretion, but accepting 0-RTT data requires the
     /// relevant resumption state to be stored in the server, which servers may limit or lose for
@@ -113,8 +118,7 @@ impl Connecting {
     ///
     /// ## Incoming
     ///
-    /// For incoming connections, conversion to 0.5-RTT will always fully succeed. `into_0rtt` will
-    /// always return `Ok` and the [`ZeroRttAccepted`] will always resolve to true.
+    /// For incoming connections, conversion to 0.5-RTT will always succeed.
     ///
     /// If manually providing a [`crypto::ServerConfig`][crate::crypto::ServerConfig], check your
     /// implementation's docs for 0-RTT pitfalls.
@@ -127,7 +131,7 @@ impl Connecting {
     /// On incoming connections, this enables transmission of 0.5-RTT data, which may be sent
     /// before TLS client authentication has occurred, and should therefore not be used to send
     /// data for which client authentication is being used.
-    pub fn into_0rtt(mut self) -> Result<(Connection, ZeroRttAccepted), Self> {
+    pub fn into_0rtt(mut self) -> Result<Connection, Self> {
         // This lock borrows `self` and would normally be dropped at the end of this scope, so we'll
         // have to release it explicitly before returning `self` by value.
         let conn = (self.conn.as_mut().unwrap()).state.lock("into_0rtt");
@@ -137,7 +141,7 @@ impl Connecting {
 
         if is_ok {
             let conn = self.conn.take().unwrap();
-            Ok((Connection(conn), ZeroRttAccepted(self.connected)))
+            Ok(Connection(conn))
         } else {
             Err(self)
         }
@@ -213,19 +217,6 @@ impl Future for Connecting {
                     .expect("connected signaled without connection success or error"))
             }
         })
-    }
-}
-
-/// Future that completes when a connection is fully established
-///
-/// For clients, the resulting value indicates if 0-RTT was accepted. For servers, the resulting
-/// value is meaningless.
-pub struct ZeroRttAccepted(oneshot::Receiver<bool>);
-
-impl Future for ZeroRttAccepted {
-    type Output = bool;
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Pin::new(&mut self.0).poll(cx).map(|x| x.unwrap_or(false))
     }
 }
 
@@ -999,7 +990,7 @@ pub(crate) struct Shared {
     datagram_received: Notify,
     datagrams_unblocked: Notify,
     closed: Notify,
-    connected: Notify,
+    connected: Arc<Notify>,
     /// Number of live handles that can used to initiate or handle I/O; excludes the driver
     ref_count: AtomicUsize,
 }
@@ -1009,7 +1000,6 @@ pub(crate) struct State {
     driver: Option<Waker>,
     handle: ConnectionHandle,
     on_handshake_data: Option<oneshot::Sender<()>>,
-    on_connected: Option<oneshot::Sender<bool>>,
     connected: bool,
     handshake_confirmed: bool,
     timer: Option<Pin<Box<dyn AsyncTimer>>>,
@@ -1036,7 +1026,6 @@ impl State {
         endpoint_events: mpsc::UnboundedSender<(ConnectionHandle, EndpointEvent)>,
         conn_events: mpsc::UnboundedReceiver<ConnectionEvent>,
         on_handshake_data: oneshot::Sender<()>,
-        on_connected: oneshot::Sender<bool>,
         sender: Pin<Box<dyn UdpSender>>,
         runtime: Arc<dyn Runtime>,
     ) -> Self {
@@ -1045,7 +1034,6 @@ impl State {
             driver: None,
             handle,
             on_handshake_data: Some(on_handshake_data),
-            on_connected: Some(on_connected),
             connected: false,
             handshake_confirmed: false,
             timer: None,
@@ -1171,10 +1159,6 @@ impl State {
                 Connected => {
                     self.connected = true;
                     shared.connected.notify_waiters();
-                    if let Some(x) = self.on_connected.take() {
-                        // We don't care if the on-connected future was dropped
-                        let _ = x.send(self.inner.accepted_0rtt());
-                    }
                     if self.inner.side().is_client() && !self.inner.accepted_0rtt() {
                         // Wake up rejected 0-RTT streams so they can fail immediately with
                         // `ZeroRttRejected` errors.
@@ -1288,9 +1272,6 @@ impl State {
         shared.stream_incoming[Dir::Bi as usize].notify_waiters();
         shared.datagram_received.notify_waiters();
         shared.datagrams_unblocked.notify_waiters();
-        if let Some(x) = self.on_connected.take() {
-            let _ = x.send(false);
-        }
         shared.handshake_confirmed.notify_waiters();
         wake_all_notify(&mut self.stopped);
         shared.closed.notify_waiters();

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -589,6 +589,33 @@ impl Connection {
             .clone_box()
     }
 
+    /// Succeeds when an incoming connection is proven not to be a replay attack.
+    ///
+    /// Only interesting for `Connection`s obtained from [`Connecting::into_0rtt`]. On 1-RTT
+    /// connections, always completes immediately. Contrast
+    /// [`handshake_confirmed`](Self::handshake_confirmed), which waits longer on clients e.g. to
+    /// confirm client authentication.
+    ///
+    /// For incoming connections, reads from [`RecvStream`]s are guaranteed not to arise from replay
+    /// attacks after this succeeds, even for streams accepted or read during 0-RTT. For outgoing
+    /// connections, streams opened after this succeeds will never be discarded by the server due to
+    /// 0-RTT rejection.
+    pub async fn authenticated(&self) -> Result<(), ConnectionError> {
+        let notified = {
+            let conn = self.0.state.lock("connected");
+            if let Some(e) = &conn.error {
+                return Err(e.clone());
+            }
+            if conn.connected {
+                return Ok(());
+            }
+            self.0.shared.connected.notified()
+        };
+        notified.await;
+        let conn = self.0.state.lock("connected");
+        conn.error.clone().map_or(Ok(()), Err)
+    }
+
     /// Parameters negotiated during the handshake
     ///
     /// Guaranteed to return `Some` on fully established connections or after
@@ -972,6 +999,7 @@ pub(crate) struct Shared {
     datagram_received: Notify,
     datagrams_unblocked: Notify,
     closed: Notify,
+    connected: Notify,
     /// Number of live handles that can used to initiate or handle I/O; excludes the driver
     ref_count: AtomicUsize,
 }
@@ -1142,6 +1170,7 @@ impl State {
                 }
                 Connected => {
                     self.connected = true;
+                    shared.connected.notify_waiters();
                     if let Some(x) = self.on_connected.take() {
                         // We don't care if the on-connected future was dropped
                         let _ = x.send(self.inner.accepted_0rtt());
@@ -1265,6 +1294,7 @@ impl State {
         shared.handshake_confirmed.notify_waiters();
         wake_all_notify(&mut self.stopped);
         shared.closed.notify_waiters();
+        shared.connected.notify_waiters();
     }
 
     fn close(&mut self, error_code: VarInt, reason: Bytes, shared: &Shared) {

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -74,7 +74,7 @@ pub use udp;
 
 pub use crate::connection::{
     AcceptBi, AcceptUni, Connecting, Connection, OpenBi, OpenUni, ReadDatagram, SendDatagram,
-    SendDatagramError, ZeroRttAccepted,
+    SendDatagramError,
 };
 pub use crate::endpoint::{Accept, Endpoint, EndpointStats};
 pub use crate::incoming::{Incoming, IncomingFuture, RetryError};

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -286,10 +286,16 @@ impl RecvStream {
         Ok(())
     }
 
-    /// Check if this stream has been opened during 0-RTT.
+    /// Check if this stream predates completion of the handshake on an incoming connection.
     ///
-    /// In which case any non-idempotent request should be considered dangerous at the application
-    /// level. Because read data is subject to replay attacks.
+    /// True only if the stream was accepted before the handshake completed, which is only possible
+    /// if you successfully called [`Connecting::into_0rtt`](crate::Connecting::into_0rtt) and the
+    /// client chose to send 0-RTT data.
+    ///
+    /// Under those conditions, depending on cryptographic layer configuration, 0-RTT application
+    /// data may be a replay attack. To guard against this, applications should not execute
+    /// non-idempotent operations until
+    /// [`Connection::authenticated`](crate::Connection::authenticated) succeeds.
     pub fn is_0rtt(&self) -> bool {
         self.is_0rtt
     }

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -243,6 +243,9 @@ impl SendStream {
     /// For a variety of reasons, the peer may not send acknowledgements immediately upon receiving
     /// data. As such, relying on `stopped` to know when the peer has read a stream to completion
     /// may introduce more latency than using an application-level response of some sort.
+    ///
+    /// Clients may wish to await this after finishing a unidirectional 0-RTT stream to reliably
+    /// determine whether the stream was rejected.
     pub fn stopped(
         &self,
     ) -> impl Future<Output = Result<Option<VarInt>, StoppedError>> + Send + Sync + 'static {

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -325,7 +325,7 @@ async fn zero_rtt() {
     tokio::spawn(async move {
         for _ in 0..2 {
             let incoming = endpoint2.accept().await.unwrap().accept().unwrap();
-            let (connection, established) = incoming.into_0rtt().unwrap_or_else(|_| unreachable!());
+            let connection = incoming.into_0rtt().unwrap_or_else(|_| unreachable!());
             let c = connection.clone();
             tokio::spawn(async move {
                 while let Ok(mut x) = c.accept_uni().await {
@@ -337,7 +337,7 @@ async fn zero_rtt() {
             let mut s = connection.open_uni().await.expect("open_uni");
             s.write_all(MSG0).await.expect("write");
             s.finish().unwrap();
-            established.await;
+            connection.authenticated().await.expect("connected");
             info!("sending 1-RTT");
             let mut s = connection.open_uni().await.expect("open_uni");
             s.write_all(MSG1).await.expect("write");
@@ -369,7 +369,7 @@ async fn zero_rtt() {
 
     info!("initial connection complete");
 
-    let (connection, zero_rtt) = endpoint
+    let connection = endpoint
         .connect(endpoint.local_addr().unwrap(), "localhost")
         .unwrap()
         .into_0rtt()
@@ -388,7 +388,7 @@ async fn zero_rtt() {
     let mut stream = connection.accept_uni().await.expect("incoming streams");
     let msg = stream.read_to_end(usize::MAX).await.expect("read_to_end");
     assert_eq!(msg, MSG0);
-    assert!(zero_rtt.await);
+    connection.authenticated().await.expect("connected");
 
     drop((stream, connection));
 

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -322,13 +322,15 @@ async fn zero_rtt() {
     const MSG0: &[u8] = b"zero";
     const MSG1: &[u8] = b"one";
     let endpoint2 = endpoint.clone();
-    tokio::spawn(async move {
-        for _ in 0..2 {
+    let accept_connection = move |expect_0rtt| {
+        let endpoint2 = endpoint2.clone();
+        async move {
             let incoming = endpoint2.accept().await.unwrap().accept().unwrap();
             let connection = incoming.into_0rtt().unwrap_or_else(|_| unreachable!());
             let c = connection.clone();
             tokio::spawn(async move {
                 while let Ok(mut x) = c.accept_uni().await {
+                    assert_eq!(x.is_0rtt(), expect_0rtt);
                     let msg = x.read_to_end(usize::MAX).await.unwrap();
                     assert_eq!(msg, MSG0);
                 }
@@ -344,14 +346,15 @@ async fn zero_rtt() {
             // The peer might close the connection before ACKing
             let _ = s.finish();
         }
-    });
+    };
+
+    tokio::spawn(accept_connection(false));
 
     let connection = endpoint
         .connect(endpoint.local_addr().unwrap(), "localhost")
         .unwrap()
         .into_0rtt()
-        .err()
-        .expect("0-RTT succeeded without keys")
+        .expect_err("0-RTT succeeded without keys")
         .await
         .expect("connect");
 
@@ -374,23 +377,26 @@ async fn zero_rtt() {
         .unwrap()
         .into_0rtt()
         .unwrap_or_else(|_| panic!("missing 0-RTT keys"));
-    // Send something ASAP to use 0-RTT
-    let c = connection.clone();
-    tokio::spawn(async move {
-        let mut s = c.open_uni().await.expect("0-RTT open uni");
-        info!("sending 0-RTT");
-        s.write_all(MSG0).await.expect("0-RTT write");
-        s.finish().unwrap();
-        // Ensure 0-RTT was accepted
-        s.stopped().await.expect("0-RTT stopped");
-    });
 
+    // Send something before the handshake can make progress, thereby forcing 0-RTT
+    let mut stream_0rtt = connection.open_uni().await.expect("0-RTT open uni");
+    info!("sending 0-RTT");
+    stream_0rtt.write_all(MSG0).await.expect("0-RTT write");
+    stream_0rtt.finish().unwrap();
+
+    tokio::spawn(accept_connection(true));
+
+    // Receive 0.5-RTT
     let mut stream = connection.accept_uni().await.expect("incoming streams");
     let msg = stream.read_to_end(usize::MAX).await.expect("read_to_end");
     assert_eq!(msg, MSG0);
     connection.authenticated().await.expect("connected");
 
-    drop((stream, connection));
+    // Ensure 0-RTT was accepted
+    stream_0rtt.stopped().await.expect("0-RTT stopped");
+
+    // Allow the connection to close
+    drop((stream_0rtt, stream, connection));
 
     endpoint.wait_idle().await;
 }

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -381,6 +381,8 @@ async fn zero_rtt() {
         info!("sending 0-RTT");
         s.write_all(MSG0).await.expect("0-RTT write");
         s.finish().unwrap();
+        // Ensure 0-RTT was accepted
+        s.stopped().await.expect("0-RTT stopped");
     });
 
     let mut stream = connection.accept_uni().await.expect("incoming streams");


### PR DESCRIPTION
Some breaking API tweaks inspired by #2613.

IMO this is a more discoverable and simpler API. As detailed in commit messages, a stream-independent `ZeroRttAccepted` signal was difficult to use correctly beyond trivial cases.