### PR TITLE
Reject DATAGRAMs larger than the send buffer

### DIFF
--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -38,7 +38,10 @@ impl Datagrams<'_> {
         }
         if drop {
             self.conn.datagrams.make_space_for(send_buffer_size);
-        } else if self.conn.datagrams.outgoing_total + data.len() > send_buffer_size
+        } else if !self
+            .conn
+            .datagrams
+            .has_send_buffer_space(data.len(), send_buffer_size)
         {
             self.conn.datagrams.send_blocked = true;
             return Err(SendDatagramError::Blocked(data));
@@ -139,6 +142,10 @@ impl DatagramState {
             trace!(len = prev.data.len(), "dropping outgoing datagram");
             self.outgoing_total -= prev.data.len();
         }
+    }
+
+    fn has_send_buffer_space(&self, datagram_len: usize, send_buffer_size: usize) -> bool {
+        self.outgoing_total + datagram_len <= send_buffer_size
     }
 
     /// Discard outgoing datagrams with a payload larger than `max_payload` bytes

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -33,7 +33,7 @@ impl Datagrams<'_> {
             .max_size()
             .ok_or(SendDatagramError::UnsupportedByPeer)?;
         let send_buffer_size = self.conn.config.datagram_send_buffer_size;
-        if data.len() > max {
+        if data.len() > Ord::min(max, send_buffer_size) {
             return Err(SendDatagramError::TooLarge);
         }
         if drop {

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -32,11 +32,12 @@ impl Datagrams<'_> {
         let max = self
             .max_size()
             .ok_or(SendDatagramError::UnsupportedByPeer)?;
+        let send_buffer_size = self.conn.config.datagram_send_buffer_size;
         if data.len() > max {
             return Err(SendDatagramError::TooLarge);
         }
         if drop {
-            while self.conn.datagrams.outgoing_total > self.conn.config.datagram_send_buffer_size {
+            while self.conn.datagrams.outgoing_total > send_buffer_size {
                 let prev = self
                     .conn
                     .datagrams
@@ -46,8 +47,7 @@ impl Datagrams<'_> {
                 trace!(len = prev.data.len(), "dropping outgoing datagram");
                 self.conn.datagrams.outgoing_total -= prev.data.len();
             }
-        } else if self.conn.datagrams.outgoing_total + data.len()
-            > self.conn.config.datagram_send_buffer_size
+        } else if self.conn.datagrams.outgoing_total + data.len() > send_buffer_size
         {
             self.conn.datagrams.send_blocked = true;
             return Err(SendDatagramError::Blocked(data));

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -37,16 +37,7 @@ impl Datagrams<'_> {
             return Err(SendDatagramError::TooLarge);
         }
         if drop {
-            while self.conn.datagrams.outgoing_total > send_buffer_size {
-                let prev = self
-                    .conn
-                    .datagrams
-                    .outgoing
-                    .pop_front()
-                    .expect("datagrams.outgoing_total desynchronized");
-                trace!(len = prev.data.len(), "dropping outgoing datagram");
-                self.conn.datagrams.outgoing_total -= prev.data.len();
-            }
+            self.conn.datagrams.make_space_for(send_buffer_size);
         } else if self.conn.datagrams.outgoing_total + data.len() > send_buffer_size
         {
             self.conn.datagrams.send_blocked = true;
@@ -138,6 +129,16 @@ impl DatagramState {
         self.recv_buffered += datagram.data.len();
         self.incoming.push_back(datagram);
         Ok(was_empty)
+    }
+
+    fn make_space_for(&mut self, send_buffer_size: usize) {
+        while self.outgoing_total > send_buffer_size {
+            let Some(prev) = self.outgoing.pop_front() else {
+                break;
+            };
+            trace!(len = prev.data.len(), "dropping outgoing datagram");
+            self.outgoing_total -= prev.data.len();
+        }
     }
 
     /// Discard outgoing datagrams with a payload larger than `max_payload` bytes

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -37,7 +37,9 @@ impl Datagrams<'_> {
             return Err(SendDatagramError::TooLarge);
         }
         if drop {
-            self.conn.datagrams.make_space_for(send_buffer_size);
+            self.conn
+                .datagrams
+                .make_space_for(data.len(), send_buffer_size);
         } else if !self
             .conn
             .datagrams
@@ -134,8 +136,8 @@ impl DatagramState {
         Ok(was_empty)
     }
 
-    fn make_space_for(&mut self, send_buffer_size: usize) {
-        while self.outgoing_total > send_buffer_size {
+    fn make_space_for(&mut self, datagram_len: usize, send_buffer_size: usize) {
+        while !self.has_send_buffer_space(datagram_len, send_buffer_size) {
             let Some(prev) = self.outgoing.pop_front() else {
                 break;
             };
@@ -145,7 +147,11 @@ impl DatagramState {
     }
 
     fn has_send_buffer_space(&self, datagram_len: usize, send_buffer_size: usize) -> bool {
-        self.outgoing_total + datagram_len <= send_buffer_size
+        let Some(total) = self.outgoing_total.checked_add(datagram_len) else {
+            return false;
+        };
+
+        total <= send_buffer_size
     }
 
     /// Discard outgoing datagrams with a payload larger than `max_payload` bytes
@@ -199,6 +205,43 @@ impl DatagramState {
         let x = self.incoming.pop_front()?.data;
         self.recv_buffered -= x.len();
         Some(x)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn make_space_for_accounts_for_new_datagram() {
+        let mut state = DatagramState::default();
+        state.outgoing.push_back(Datagram {
+            data: Bytes::from_static(&[0; 7]),
+        });
+        state.outgoing.push_back(Datagram {
+            data: Bytes::from_static(&[0; 2]),
+        });
+        state.outgoing_total = 9;
+
+        state.make_space_for(4, 10);
+
+        assert_eq!(state.outgoing.len(), 1);
+        assert_eq!(state.outgoing[0].data.len(), 2);
+        assert_eq!(state.outgoing_total, 2);
+    }
+
+    #[test]
+    fn make_space_for_handles_overflowing_capacity_check() {
+        let mut state = DatagramState::default();
+        state.outgoing.push_back(Datagram {
+            data: Bytes::from_static(&[0]),
+        });
+        state.outgoing_total = usize::MAX - 1;
+
+        state.make_space_for(2, usize::MAX);
+
+        assert!(state.outgoing.is_empty());
+        assert_eq!(state.outgoing_total, usize::MAX - 2);
     }
 }
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -2030,6 +2030,28 @@ fn datagram_recv_buffer_overflow() {
 }
 
 #[test]
+fn datagram_larger_than_send_buffer_is_too_large() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let mut client_config = client_config();
+    let mut transport_config = TransportConfig::default();
+    transport_config.datagram_send_buffer_size(1);
+    client_config.transport_config(transport_config.into());
+    let (client_ch, _) = pair.connect_with(client_config);
+
+    assert_matches!(
+        pair.client_datagrams(client_ch)
+            .send(Bytes::from_static(&[0; 2]), true),
+        Err(SendDatagramError::TooLarge)
+    );
+    assert_matches!(
+        pair.client_datagrams(client_ch)
+            .send(Bytes::from_static(&[0; 2]), false),
+        Err(SendDatagramError::TooLarge)
+    );
+}
+
+#[test]
 fn datagram_unsupported() {
     let _guard = subscribe();
     let server = ServerConfig {


### PR DESCRIPTION
Follow-up to #2625.

A DATAGRAM larger than `datagram_send_buffer_size` cannot fit in the outgoing send buffer by itself. This returns `TooLarge` before trying either send mode, so the behavior is the same for `drop = true` and `drop = false`.

Tested with:

```text
cargo fmt --check
cargo test -p quinn-proto --lib
cargo test -p quinn-proto datagram
```