### PR TITLE
qlog: emit RTT values in milliseconds

### DIFF
--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -275,10 +275,16 @@ impl RecoveryMetrics {
 
         Some(RecoveryMetricsUpdated {
             ex_data: ExData::default(),
-            min_rtt: updated.min_rtt.map(|rtt| rtt.as_secs_f32()),
-            smoothed_rtt: updated.smoothed_rtt.map(|rtt| rtt.as_secs_f32()),
-            latest_rtt: updated.latest_rtt.map(|rtt| rtt.as_secs_f32()),
-            rtt_variance: updated.rtt_variance.map(|rtt| rtt.as_secs_f32()),
+            min_rtt: updated.min_rtt.map(|rtt| rtt.as_micros() as f32 / 1000.0),
+            smoothed_rtt: updated
+                .smoothed_rtt
+                .map(|rtt| rtt.as_micros() as f32 / 1000.0),
+            latest_rtt: updated
+                .latest_rtt
+                .map(|rtt| rtt.as_micros() as f32 / 1000.0),
+            rtt_variance: updated
+                .rtt_variance
+                .map(|rtt| rtt.as_micros() as f32 / 1000.0),
             pto_count: updated
                 .pto_count
                 .map(|count| count.try_into().unwrap_or(u16::MAX)),


### PR DESCRIPTION
currently, fn to_qlog_event emit RTT values within the qlog data structure as secs, while draft-ietf-quic-qlog-main-schema-13.txt says:
"   All timestamps and time-related values (e.g., offsets) in qlog are
   logged as float64 in the millisecond resolution."

The current qlog event timestamp is correctly emitted in ms.

