### PR TITLE
feat: Add OpenSSL support and update crypto provider configuration

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,15 +19,21 @@ jobs:
         # they have complex build requirements:
         #     https://github.com/aws/aws-lc/blob/3263ce2a553e4e917217fb487f8c6f488fcb1866/BUILDING.md#build-prerequisites
         #
+        # On Windows, OpenSSL is installed but the Rust `openssl` crate needs OPENSSL_DIR to
+        # locate it since pkg-config is not available.
+        #
         # This list of features was determined using:
         #     cargo metadata --format-version 1 --no-deps \
         #       | jq -r ' .packages[].features | keys[]' \
         #       | sort -u \
         #       | grep -vFx -e 'default' -e 'aws-lc-rs-fips' -e 'rustls-aws-lc-rs-fips' \
         #       | paste -sd ',' -
+        env:
+          # Help the `openssl` crate find OpenSSL on Windows (pre-installed via Chocolatey)
+          OPENSSL_DIR: ${{ runner.os == 'Windows' && 'C:\Program Files\OpenSSL-Win64' || '' }}
         run: |
           cargo llvm-cov \
-            --features="arbitrary,aws-lc-rs,bloom,log,fast-apple-datapath,futures-io,json-output,lock_tracking,tracing-log,platform-verifier,qlog,ring,runtime-smol,runtime-tokio,rustls,rustls-aws-lc-rs,rustls-log,rustls-ring,serde,serde_json,smol,tracing" \
+            --features="arbitrary,aws-lc-rs,bloom,log,fast-apple-datapath,futures-io,json-output,lock_tracking,tracing-log,openssl,platform-verifier,qlog,ring,runtime-smol,runtime-tokio,rustls,rustls-aws-lc-rs,rustls-log,rustls-openssl,rustls-ring,serde,serde_json,smol,tracing" \
             --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,10 +1714,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "page_size"
@@ -1816,6 +1869,12 @@ dependencies = [
  "fastrand",
  "futures-io",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polling"
@@ -1967,6 +2026,7 @@ dependencies = [
  "getrandom 0.3.4",
  "hex-literal",
  "lru-slab",
+ "openssl",
  "qlog",
  "rand",
  "rand_pcg",
@@ -1974,6 +2034,7 @@ dependencies = [
  "ring",
  "rustc-hash",
  "rustls",
+ "rustls-openssl",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
@@ -2192,6 +2253,20 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-openssl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f161084062dd5a443adfb0de9bbfab62699333e2d8424ca91da5f22ec88d1"
+dependencies = [
+ "foreign-types",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "rustls",
+ "zeroize",
 ]
 
 [[package]]
@@ -2854,6 +2929,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ async-io = "2"
 assert_matches = "1.1"
 aws-lc-rs = { version = "1.9", default-features = false }
 bencher = "0.1.5"
+openssl = { version = "0.10" }
+rustls-openssl = { version = "0.3" }
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
 crc = "3"
@@ -33,7 +35,7 @@ pin-project-lite = "0.2"
 qlog = "0.17"
 rand = "0.9"
 rcgen = "0.14"
-ring = "0.17"
+ring = { version = "0.17" }
 rustc-hash = "2"
 rustls = { version = "0.23.5", default-features = false, features = ["std"] }
 rustls-platform-verifier = "0.7"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true }
 hdrhistogram = { workspace = true }
-quinn = { path = "../quinn", features = ["ring"] }
+quinn = { path = "../quinn" }
 rcgen = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }

--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -63,7 +63,7 @@ pub async fn connect_client(
     let mut roots = RootCertStore::empty();
     roots.add(server_cert)?;
 
-    let default_provider = rustls::crypto::ring::default_provider();
+    let default_provider = (*quinn::crypto::rustls::configured_provider()).clone();
     let provider = rustls::crypto::CryptoProvider {
         cipher_suites: vec![opt.cipher.as_rustls()],
         ..default_provider
@@ -231,12 +231,23 @@ pub enum CipherSuite {
 
 impl CipherSuite {
     pub fn as_rustls(self) -> rustls::SupportedCipherSuite {
-        use rustls::crypto::ring::cipher_suite;
-        match self {
-            Self::Aes128 => cipher_suite::TLS13_AES_128_GCM_SHA256,
-            Self::Aes256 => cipher_suite::TLS13_AES_256_GCM_SHA384,
-            Self::Chacha20 => cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
-        }
+        use rustls::CipherSuite;
+        let id = match self {
+            Self::Aes128 => CipherSuite::TLS13_AES_128_GCM_SHA256,
+            Self::Aes256 => CipherSuite::TLS13_AES_256_GCM_SHA384,
+            Self::Chacha20 => CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
+        };
+        quinn::crypto::rustls::configured_provider()
+            .cipher_suites
+            .iter()
+            .find(|cs| cs.suite() == id)
+            .copied()
+            .unwrap_or_else(|| {
+                panic!(
+                    "cipher suite {:?} not supported by the active crypto provider",
+                    id
+                )
+            })
     }
 }
 

--- a/docs/book/src/bin/certificate.rs
+++ b/docs/book/src/bin/certificate.rs
@@ -39,7 +39,7 @@ struct SkipServerVerification(Arc<CryptoProvider>);
 
 impl SkipServerVerification {
     fn new() -> Arc<Self> {
-        Arc::new(Self(Arc::new(rustls::crypto::ring::default_provider())))
+        Arc::new(Self(quinn::crypto::rustls::configured_provider()))
     }
 }
 

--- a/perf/src/client.rs
+++ b/perf/src/client.rs
@@ -16,9 +16,9 @@ use tokio::sync::Semaphore;
 use tracing::{debug, error, info};
 
 use crate::{
-    CommonOpt, PERF_CIPHER_SUITES,
+    CommonOpt,
     noprotection::NoProtectionClientConfig,
-    parse_byte_size,
+    parse_byte_size, perf_cipher_suites,
     stats::{OpenStreamStats, Stats},
 };
 
@@ -104,9 +104,9 @@ pub async fn run(opt: Opt) -> Result<()> {
 
     let endpoint = quinn::Endpoint::new(endpoint_cfg, None, socket, Arc::new(TokioRuntime))?;
 
-    let default_provider = rustls::crypto::ring::default_provider();
+    let default_provider = (*quinn::crypto::rustls::configured_provider()).clone();
     let provider = Arc::new(rustls::crypto::CryptoProvider {
-        cipher_suites: PERF_CIPHER_SUITES.into(),
+        cipher_suites: perf_cipher_suites(),
         ..default_provider
     });
 

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -11,7 +11,6 @@ use quinn::{
     congestion::{self, ControllerFactory},
     udp::UdpSocketState,
 };
-use rustls::crypto::ring::cipher_suite;
 use socket2::{Domain, Protocol, Socket, Type};
 use tracing::warn;
 
@@ -214,8 +213,21 @@ impl CongestionAlgorithm {
     }
 }
 
-pub static PERF_CIPHER_SUITES: &[rustls::SupportedCipherSuite] = &[
-    cipher_suite::TLS13_AES_128_GCM_SHA256,
-    cipher_suite::TLS13_AES_256_GCM_SHA384,
-    cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
-];
+/// Returns the cipher suites used by the perf tool, filtered from the active crypto provider.
+///
+/// Replaces the former `PERF_CIPHER_SUITES` static so the list is not tied to a specific
+/// backend's compile-time constants.
+pub fn perf_cipher_suites() -> Vec<rustls::SupportedCipherSuite> {
+    use rustls::CipherSuite;
+    let desired = [
+        CipherSuite::TLS13_AES_128_GCM_SHA256,
+        CipherSuite::TLS13_AES_256_GCM_SHA384,
+        CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
+    ];
+    quinn::crypto::rustls::configured_provider()
+        .cipher_suites
+        .iter()
+        .filter(|cs| desired.contains(&cs.suite()))
+        .copied()
+        .collect()
+}

--- a/perf/src/server.rs
+++ b/perf/src/server.rs
@@ -7,7 +7,7 @@ use quinn::{TokioRuntime, crypto::rustls::QuicServerConfig};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, pem::PemObject};
 use tracing::{debug, error, info};
 
-use crate::{CommonOpt, PERF_CIPHER_SUITES, noprotection::NoProtectionServerConfig};
+use crate::{CommonOpt, noprotection::NoProtectionServerConfig, perf_cipher_suites};
 
 #[derive(Parser)]
 #[clap(name = "server")]
@@ -44,9 +44,9 @@ pub async fn run(opt: Opt) -> Result<()> {
         }
     };
 
-    let default_provider = rustls::crypto::ring::default_provider();
+    let default_provider = (*quinn::crypto::rustls::configured_provider()).clone();
     let provider = rustls::crypto::CryptoProvider {
-        cipher_suites: PERF_CIPHER_SUITES.into(),
+        cipher_suites: perf_cipher_suites(),
         ..default_provider
     };
 

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -26,6 +26,9 @@ rustls-aws-lc-rs-fips = ["rustls-aws-lc-rs", "aws-lc-rs-fips"]
 # Enable rustls with the `ring` crypto provider
 rustls-ring = ["dep:rustls", "rustls?/ring", "ring"]
 ring = ["dep:ring"]
+# Enable rustls with the `openssl` crypto provider (system OpenSSL)
+openssl = ["dep:openssl"]
+rustls-openssl = ["dep:rustls", "dep:rustls-openssl", "openssl"]
 # Enable rustls ring provider and direct ring usage
 # Provides `ClientConfig::with_platform_verifier()` convenience method
 platform-verifier = ["dep:rustls-platform-verifier"]
@@ -50,8 +53,10 @@ lru-slab = { workspace = true }
 qlog = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 rand = { workspace = true }
+openssl = { workspace = true, optional = true }
 ring = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
+rustls-openssl = { workspace = true, optional = true }
 rustls-platform-verifier = { workspace = true, optional = true }
 slab = { workspace = true }
 thiserror = { workspace = true }

--- a/quinn-proto/src/config/mod.rs
+++ b/quinn-proto/src/config/mod.rs
@@ -5,9 +5,17 @@ use std::{
     sync::Arc,
 };
 
-#[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+#[cfg(any(
+    feature = "rustls-aws-lc-rs",
+    feature = "rustls-ring",
+    feature = "rustls-openssl"
+))]
 use rustls::client::WebPkiServerVerifier;
-#[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+#[cfg(any(
+    feature = "rustls-aws-lc-rs",
+    feature = "rustls-ring",
+    feature = "rustls-openssl"
+))]
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use thiserror::Error;
 
@@ -15,7 +23,11 @@ use thiserror::Error;
 use crate::BloomTokenLog;
 #[cfg(not(feature = "bloom"))]
 use crate::NoneTokenLog;
-#[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+#[cfg(any(
+    feature = "rustls-aws-lc-rs",
+    feature = "rustls-ring",
+    feature = "rustls-openssl"
+))]
 use crate::crypto::rustls::{QuicServerConfig, configured_provider};
 use crate::{
     DEFAULT_SUPPORTED_VERSIONS, Duration, MAX_CID_SIZE, RandomConnectionIdGenerator, SystemTime,
@@ -174,19 +186,27 @@ impl fmt::Debug for EndpointConfig {
     }
 }
 
-#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+#[cfg(any(feature = "aws-lc-rs", feature = "ring", feature = "openssl"))]
 impl Default for EndpointConfig {
     fn default() -> Self {
-        #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
-        use aws_lc_rs::hmac;
         use rand::RngCore;
-        #[cfg(feature = "ring")]
-        use ring::hmac;
-
         let mut reset_key = [0; 64];
         rand::rng().fill_bytes(&mut reset_key);
 
-        Self::new(Arc::new(hmac::Key::new(hmac::HMAC_SHA256, &reset_key)))
+        #[cfg(feature = "ring")]
+        let key: Arc<dyn HmacKey> = {
+            use ring::hmac;
+            Arc::new(hmac::Key::new(hmac::HMAC_SHA256, &reset_key))
+        };
+        #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
+        let key: Arc<dyn HmacKey> = {
+            use aws_lc_rs::hmac;
+            Arc::new(hmac::Key::new(hmac::HMAC_SHA256, &reset_key))
+        };
+        #[cfg(all(feature = "openssl", not(feature = "ring"), not(feature = "aws-lc-rs")))]
+        let key: Arc<dyn HmacKey> = Arc::new(crate::crypto::openssl_like::HmacKey::new(&reset_key));
+
+        Self::new(key)
     }
 }
 
@@ -373,7 +393,11 @@ impl ServerConfig {
     }
 }
 
-#[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+#[cfg(any(
+    feature = "rustls-aws-lc-rs",
+    feature = "rustls-ring",
+    feature = "rustls-openssl"
+))]
 impl ServerConfig {
     /// Create a server config with the given certificate chain to be presented to clients
     ///
@@ -388,24 +412,35 @@ impl ServerConfig {
     }
 }
 
-#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+#[cfg(any(feature = "aws-lc-rs", feature = "ring", feature = "openssl"))]
 impl ServerConfig {
     /// Create a server config with the given [`crypto::ServerConfig`]
     ///
     /// Uses a randomized handshake token key.
     pub fn with_crypto(crypto: Arc<dyn crypto::ServerConfig>) -> Self {
-        #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
-        use aws_lc_rs::hkdf;
         use rand::RngCore;
-        #[cfg(feature = "ring")]
-        use ring::hkdf;
-
         let rng = &mut rand::rng();
         let mut master_key = [0u8; 64];
         rng.fill_bytes(&mut master_key);
-        let master_key = hkdf::Salt::new(hkdf::HKDF_SHA256, &[]).extract(&master_key);
 
-        Self::new(crypto, Arc::new(master_key))
+        #[cfg(feature = "ring")]
+        let token_key: Arc<dyn HandshakeTokenKey> = {
+            use ring::hkdf;
+            let prk = hkdf::Salt::new(hkdf::HKDF_SHA256, &[]).extract(&master_key);
+            Arc::new(prk)
+        };
+        #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
+        let token_key: Arc<dyn HandshakeTokenKey> = {
+            use aws_lc_rs::hkdf;
+            let prk = hkdf::Salt::new(hkdf::HKDF_SHA256, &[]).extract(&master_key);
+            Arc::new(prk)
+        };
+        #[cfg(all(feature = "openssl", not(feature = "ring"), not(feature = "aws-lc-rs")))]
+        let token_key: Arc<dyn HandshakeTokenKey> = Arc::new(
+            crate::crypto::openssl_like::HkdfPrk::extract(&[], &master_key),
+        );
+
+        Self::new(crypto, token_key)
     }
 }
 
@@ -618,7 +653,11 @@ impl ClientConfig {
     }
 }
 
-#[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+#[cfg(any(
+    feature = "rustls-aws-lc-rs",
+    feature = "rustls-ring",
+    feature = "rustls-openssl"
+))]
 impl ClientConfig {
     /// Create a client configuration that trusts the platform's native roots
     #[cfg(feature = "platform-verifier")]

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 /// Cryptography interface based on OpenSSL (system library)
-#[cfg(feature = "openssl")]
+#[cfg(all(feature = "openssl", not(feature = "ring"), not(feature = "aws-lc-rs")))]
 pub(crate) mod openssl_like;
 /// Cryptography interface based on *ring*
 #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -17,11 +17,18 @@ use crate::{
     transport_parameters::TransportParameters,
 };
 
+/// Cryptography interface based on OpenSSL (system library)
+#[cfg(feature = "openssl")]
+pub(crate) mod openssl_like;
 /// Cryptography interface based on *ring*
 #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
 pub(crate) mod ring_like;
 /// TLS interface based on rustls
-#[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+#[cfg(any(
+    feature = "rustls-aws-lc-rs",
+    feature = "rustls-ring",
+    feature = "rustls-openssl"
+))]
 pub mod rustls;
 
 /// A cryptographic session (commonly TLS)

--- a/quinn-proto/src/crypto/openssl_like.rs
+++ b/quinn-proto/src/crypto/openssl_like.rs
@@ -1,0 +1,153 @@
+//! Implementations of Quinn's low-level crypto traits backed by the system OpenSSL library.
+//!
+//! This module provides [`HmacKey`], [`HkdfPrk`], and [`AeadKey`] using the `openssl` crate,
+//! which links against the platform's installed libcrypto.  It mirrors the structure of
+//! `ring_like.rs` so that `config/mod.rs` can select the right backend with `#[cfg]` blocks.
+
+use openssl::{hash::MessageDigest, pkey::PKey, sign::Signer, symm};
+
+use crate::crypto::{self, CryptoError};
+
+// ---------------------------------------------------------------------------
+// HMAC-SHA256
+// ---------------------------------------------------------------------------
+
+/// An HMAC-SHA256 key backed by OpenSSL.
+pub(crate) struct HmacKey(Vec<u8>);
+
+impl HmacKey {
+    /// Create a new HMAC-SHA256 key from raw bytes.
+    pub(crate) fn new(key: &[u8]) -> Self {
+        Self(key.to_vec())
+    }
+}
+
+impl crypto::HmacKey for HmacKey {
+    fn sign(&self, data: &[u8], out: &mut [u8]) {
+        let pkey = PKey::hmac(&self.0).expect("openssl: PKey::hmac failed");
+        let mut signer =
+            Signer::new(MessageDigest::sha256(), &pkey).expect("openssl: Signer::new failed");
+        signer.update(data).expect("openssl: Signer::update failed");
+        let sig = signer.sign_to_vec().expect("openssl: sign_to_vec failed");
+        out.copy_from_slice(&sig);
+    }
+
+    fn signature_len(&self) -> usize {
+        32 // SHA-256 output is always 32 bytes
+    }
+
+    fn verify(&self, data: &[u8], signature: &[u8]) -> Result<(), CryptoError> {
+        let mut actual = [0u8; 32];
+        self.sign(data, &mut actual);
+        // Use OpenSSL's constant-time comparison to avoid timing attacks
+        if openssl::memcmp::eq(&actual, signature) {
+            Ok(())
+        } else {
+            Err(CryptoError)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HKDF PRK (HandshakeTokenKey)
+// ---------------------------------------------------------------------------
+
+/// An HKDF pseudo-random key backed by OpenSSL, usable as a [`crypto::HandshakeTokenKey`].
+///
+/// Created via HKDF-Extract(SHA-256, salt, IKM).  The `aead_from_hkdf` method performs
+/// HKDF-Expand to derive a 32-byte AES-256-GCM key (RFC 5869, single-block variant).
+pub(crate) struct HkdfPrk(Vec<u8>); // stores the raw 32-byte PRK
+
+impl HkdfPrk {
+    /// HKDF-Extract(salt, ikm) using SHA-256.
+    ///
+    /// Per RFC 5869 §2.2: if `salt` is empty a zero-filled HashLen (32) byte string is used.
+    pub(crate) fn extract(salt: &[u8], ikm: &[u8]) -> Self {
+        // RFC 5869: if not provided, salt = zeroes of HashLen
+        let zero_salt = [0u8; 32];
+        let actual_salt: &[u8] = if salt.is_empty() { &zero_salt } else { salt };
+
+        let pkey = PKey::hmac(actual_salt).expect("openssl: PKey::hmac failed");
+        let mut signer =
+            Signer::new(MessageDigest::sha256(), &pkey).expect("openssl: Signer::new failed");
+        signer.update(ikm).expect("openssl: Signer::update failed");
+        let prk = signer.sign_to_vec().expect("openssl: sign_to_vec failed");
+        Self(prk)
+    }
+}
+
+impl crypto::HandshakeTokenKey for HkdfPrk {
+    fn aead_from_hkdf(&self, random_bytes: &[u8]) -> Box<dyn crypto::AeadKey> {
+        // HKDF-Expand(PRK, info=random_bytes, L=32) — single 32-byte block:
+        //   T(1) = HMAC-SHA256(PRK, info || 0x01)
+        let pkey = PKey::hmac(&self.0).expect("openssl: PKey::hmac failed");
+        let mut signer =
+            Signer::new(MessageDigest::sha256(), &pkey).expect("openssl: Signer::new failed");
+        signer
+            .update(random_bytes)
+            .expect("openssl: Signer::update failed");
+        signer
+            .update(&[0x01])
+            .expect("openssl: Signer::update counter failed");
+        let okm = signer.sign_to_vec().expect("openssl: sign_to_vec failed");
+
+        let mut key_bytes = [0u8; 32];
+        key_bytes.copy_from_slice(&okm);
+        Box::new(AeadKey(key_bytes))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AES-256-GCM AEAD key (AeadKey)
+// ---------------------------------------------------------------------------
+
+/// An AES-256-GCM key backed by OpenSSL, usable as a [`crypto::AeadKey`].
+///
+/// Follows the same zero-nonce / 16-byte tag convention as the ring/aws-lc-rs implementation.
+pub(crate) struct AeadKey([u8; 32]);
+
+impl crypto::AeadKey for AeadKey {
+    fn seal(&self, data: &mut Vec<u8>, additional_data: &[u8]) -> Result<(), CryptoError> {
+        let nonce = [0u8; 12];
+        let mut tag = [0u8; 16];
+        let ciphertext = symm::encrypt_aead(
+            symm::Cipher::aes_256_gcm(),
+            &self.0,
+            Some(&nonce),
+            additional_data,
+            data,
+            &mut tag,
+        )
+        .map_err(|_| CryptoError)?;
+        *data = ciphertext;
+        data.extend_from_slice(&tag);
+        Ok(())
+    }
+
+    fn open<'a>(
+        &self,
+        data: &'a mut [u8],
+        additional_data: &[u8],
+    ) -> Result<&'a mut [u8], CryptoError> {
+        if data.len() < 16 {
+            return Err(CryptoError);
+        }
+        let tag_pos = data.len() - 16;
+        let nonce = [0u8; 12];
+
+        // decrypt_aead allocates a new buffer; we copy back into `data` afterwards
+        let plaintext = symm::decrypt_aead(
+            symm::Cipher::aes_256_gcm(),
+            &self.0,
+            Some(&nonce),
+            additional_data,
+            &data[..tag_pos],
+            &data[tag_pos..],
+        )
+        .map_err(|_| CryptoError)?;
+
+        let plain_len = plaintext.len();
+        data[..plain_len].copy_from_slice(&plaintext);
+        Ok(&mut data[..plain_len])
+    }
+}

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -191,11 +191,8 @@ impl crypto::Session for TlsSession {
             _ => unreachable!(),
         };
 
-        let nonce = aead::Nonce::assume_unique_for_key(nonce);
-        let key = aead::LessSafeKey::new(aead::UnboundKey::new(&aead::AES_128_GCM, &key).unwrap());
-
         let (aad, tag) = pseudo_packet.split_at_mut(tag_start);
-        key.open_in_place(nonce, aead::Aad::from(aad), tag).is_ok()
+        retry_aes128gcm_open(&key, &nonce, aad, tag)
     }
 
     fn export_keying_material(
@@ -209,6 +206,70 @@ impl crypto::Session for TlsSession {
             .map_err(|_| ExportKeyingMaterialError)?;
         Ok(())
     }
+}
+
+/// Verify an AES-128-GCM authenticated ciphertext for QUIC retry integrity.
+///
+/// `data` must be laid out as `ciphertext || 16-byte tag`.
+fn retry_aes128gcm_open(key: &[u8; 16], nonce: &[u8; 12], aad: &[u8], data: &mut [u8]) -> bool {
+    #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
+    {
+        let n = aead::Nonce::assume_unique_for_key(*nonce);
+        let k = aead::LessSafeKey::new(aead::UnboundKey::new(&aead::AES_128_GCM, key).unwrap());
+        return k.open_in_place(n, aead::Aad::from(aad), data).is_ok();
+    }
+    #[cfg(all(
+        feature = "rustls-openssl",
+        not(feature = "ring"),
+        not(feature = "aws-lc-rs")
+    ))]
+    {
+        use openssl::symm::{Cipher, decrypt_aead};
+        if data.len() < 16 {
+            return false;
+        }
+        let tag_pos = data.len() - 16;
+        return decrypt_aead(
+            Cipher::aes_128_gcm(),
+            key,
+            Some(nonce),
+            aad,
+            &data[..tag_pos],
+            &data[tag_pos..],
+        )
+        .is_ok();
+    }
+    #[allow(unreachable_code)]
+    false
+}
+
+/// Produce an AES-128-GCM authentication tag over `aad` for QUIC retry integrity.
+fn retry_aes128gcm_seal_tag(key: &[u8; 16], nonce: &[u8; 12], aad: &[u8]) -> [u8; 16] {
+    #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
+    {
+        let n = aead::Nonce::assume_unique_for_key(*nonce);
+        let k = aead::LessSafeKey::new(aead::UnboundKey::new(&aead::AES_128_GCM, key).unwrap());
+        let tag = k
+            .seal_in_place_separate_tag(n, aead::Aad::from(aad), &mut [])
+            .unwrap();
+        let mut result = [0u8; 16];
+        result.copy_from_slice(tag.as_ref());
+        return result;
+    }
+    #[cfg(all(
+        feature = "rustls-openssl",
+        not(feature = "ring"),
+        not(feature = "aws-lc-rs")
+    ))]
+    {
+        use openssl::symm::{Cipher, encrypt_aead};
+        let mut tag = [0u8; 16];
+        encrypt_aead(Cipher::aes_128_gcm(), key, Some(nonce), aad, &[], &mut tag)
+            .expect("openssl AES-128-GCM seal failed");
+        return tag;
+    }
+    #[allow(unreachable_code)]
+    [0u8; 16]
 }
 
 const RETRY_INTEGRITY_KEY_DRAFT: [u8; 16] = [
@@ -552,15 +613,7 @@ impl crypto::ServerConfig for QuicServerConfig {
         pseudo_packet.extend_from_slice(&orig_dst_cid);
         pseudo_packet.extend_from_slice(packet);
 
-        let nonce = aead::Nonce::assume_unique_for_key(nonce);
-        let key = aead::LessSafeKey::new(aead::UnboundKey::new(&aead::AES_128_GCM, &key).unwrap());
-
-        let tag = key
-            .seal_in_place_separate_tag(nonce, aead::Aad::from(pseudo_packet), &mut [])
-            .unwrap();
-        let mut result = [0; 16];
-        result.copy_from_slice(tag.as_ref());
-        result
+        retry_aes128gcm_seal_tag(&key, &nonce, &pseudo_packet)
     }
 }
 
@@ -579,11 +632,24 @@ pub(crate) fn initial_suite_from_provider(
         .flatten()
 }
 
-pub(crate) fn configured_provider() -> Arc<rustls::crypto::CryptoProvider> {
-    #[cfg(all(feature = "rustls-aws-lc-rs", not(feature = "rustls-ring")))]
-    let provider = rustls::crypto::aws_lc_rs::default_provider();
+/// Returns the active rustls [`CryptoProvider`][rustls::crypto::CryptoProvider] selected at
+/// compile time by the enabled backend feature (`rustls-ring`, `rustls-aws-lc-rs`, or
+/// `rustls-openssl`).
+///
+/// This is useful for building rustls configurations that stay in sync with the provider quinn
+/// was compiled against, e.g. when filtering cipher suites or constructing a custom
+/// [`rustls::ClientConfig`].
+pub fn configured_provider() -> Arc<rustls::crypto::CryptoProvider> {
     #[cfg(feature = "rustls-ring")]
     let provider = rustls::crypto::ring::default_provider();
+    #[cfg(all(feature = "rustls-aws-lc-rs", not(feature = "rustls-ring")))]
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    #[cfg(all(
+        feature = "rustls-openssl",
+        not(feature = "rustls-ring"),
+        not(feature = "rustls-aws-lc-rs")
+    ))]
+    let provider = rustls_openssl::default_provider();
     Arc::new(provider)
 }
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -20,6 +20,17 @@
 #![allow(clippy::too_many_arguments)]
 #![warn(clippy::use_self)]
 
+// #[cfg(all(
+//     not(feature = "rustls-ring"),
+//     not(feature = "rustls-aws-lc-rs"),
+//     not(feature = "rustls-aws-lc-rs-fips"),
+//     not(feature = "rustls-openssl"),
+// ))]
+// compile_error!(
+//     "quinn-proto requires at least one TLS backend feature: \
+//      rustls-ring, rustls-aws-lc-rs, rustls-aws-lc-rs-fips, or rustls-openssl."
+// );
+
 use std::{
     fmt,
     net::{IpAddr, SocketAddr},
@@ -30,7 +41,14 @@ mod cid_queue;
 pub mod coding;
 mod constant_time;
 mod range_set;
-#[cfg(all(test, any(feature = "rustls-aws-lc-rs", feature = "rustls-ring")))]
+#[cfg(all(
+    test,
+    any(
+        feature = "rustls-aws-lc-rs",
+        feature = "rustls-ring",
+        feature = "rustls-openssl"
+    )
+))]
 mod tests;
 pub mod transport_parameters;
 mod varint;

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -36,6 +36,9 @@ rustls-ring = ["dep:rustls", "ring", "proto/rustls-ring", "proto/ring"]
 # Outside wasm*-unknown-unknown targets, this enables `Endpoint::client` and `Endpoint::server` conveniences.
 ring = ["proto/ring"]
 runtime-tokio = ["tokio/time", "tokio/rt", "tokio/net"]
+# Enable rustls with the `openssl` crypto provider (system OpenSSL)
+openssl = ["proto/openssl"]
+rustls-openssl = ["dep:rustls", "openssl", "proto/rustls-openssl", "proto/openssl"]
 runtime-smol = ["dep:async-io", "dep:smol"]
 
 # Configure `tracing` to log events via `log` if no `tracing` subscriber exists.

--- a/quinn/examples/common/mod.rs
+++ b/quinn/examples/common/mod.rs
@@ -1,4 +1,8 @@
-#![cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+#![cfg(any(
+    feature = "rustls-aws-lc-rs",
+    feature = "rustls-ring",
+    feature = "rustls-openssl"
+))]
 //! Commonly used code in most examples.
 
 use quinn::{ClientConfig, Endpoint, ServerConfig};

--- a/quinn/examples/insecure_connection.rs
+++ b/quinn/examples/insecure_connection.rs
@@ -68,7 +68,7 @@ struct SkipServerVerification(Arc<rustls::crypto::CryptoProvider>);
 
 impl SkipServerVerification {
     fn new() -> Arc<Self> {
-        Arc::new(Self(Arc::new(rustls::crypto::ring::default_provider())))
+        Arc::new(Self(quinn::crypto::rustls::configured_provider()))
     }
 }
 

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -68,7 +68,11 @@ pub use proto::{
 };
 #[cfg(feature = "qlog")]
 pub use proto::{QlogConfig, QlogStream};
-#[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+#[cfg(any(
+    feature = "rustls-aws-lc-rs",
+    feature = "rustls-ring",
+    feature = "rustls-openssl"
+))]
 pub use rustls;
 pub use udp;
 


### PR DESCRIPTION
Add system OpenSSL (and rustls-openssl) as a pluggable crypto backend

- Introduced OpenSSL as a new cryptography backend.
- Refactored crypto provider logic to support OpenSSL alongside existing backends.
- Modified various modules to utilize the new OpenSSL-based implementations.

