### PR TITLE
feat: implement kernel receive timestamps on Linux/Android

### DIFF
--- a/quinn-udp/src/cmsg/mod.rs
+++ b/quinn-udp/src/cmsg/mod.rs
@@ -153,4 +153,4 @@ pub(crate) trait CMsgHdr {
 }
 
 #[cfg(unix)]
-pub(crate) const LEN: usize = 88;
+pub(crate) const LEN: usize = 96;

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -27,16 +27,14 @@
 #![warn(unreachable_pub)]
 #![warn(clippy::use_self)]
 
+use core::time::Duration;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 #[cfg(unix)]
 use std::os::unix::io::AsFd;
 #[cfg(windows)]
 use std::os::windows::io::AsSocket;
 #[cfg(not(wasm_browser))]
-use std::{
-    sync::Mutex,
-    time::{Duration, Instant},
-};
+use std::{sync::Mutex, time::Instant};
 
 #[cfg(apple_fast)]
 mod apple_fast;
@@ -124,6 +122,10 @@ pub struct RecvMeta {
     pub dst_ip: Option<IpAddr>,
     /// The interface index of the interface on which the datagram was received
     pub interface_index: Option<u32>,
+    /// Kernel receive timestamp as Unix epoch
+    ///
+    /// Populated on platforms: Linux, Android.
+    pub timestamp: Option<Duration>,
 }
 
 impl Default for RecvMeta {
@@ -136,6 +138,7 @@ impl Default for RecvMeta {
             ecn: None,
             dst_ip: None,
             interface_index: None,
+            timestamp: None,
         }
     }
 }

--- a/quinn-udp/src/linux.rs
+++ b/quinn-udp/src/linux.rs
@@ -123,7 +123,7 @@ impl LinuxError {
     }
 
     /// Control message buffer size for socket error queue (MSG_ERRQUEUE)
-    const ERR_CMSG_LEN: usize = 128;
+    const ERR_CMSG_LEN: usize = 256;
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -9,7 +9,7 @@ use std::{
         Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use socket2::SockRef;
@@ -135,6 +135,12 @@ impl UdpSocketState {
                 // list the kernel might potentially produce. See
                 // https://github.com/quinn-rs/quinn/pull/1354.
                 gro_segments = 64
+            }
+
+            if let Err(_err) =
+                set_socket_option(&*io, libc::SOL_SOCKET, libc::SO_TIMESTAMPNS, OPTION_ON)
+            {
+                crate::log::debug!("Ignoring error setting SO_TIMESTAMPNS on socket: {_err:?}");
             }
 
             if is_ipv4 || !io.only_v6()? {
@@ -725,6 +731,7 @@ pub(crate) fn decode_recv<M: cmsg::MsgHdr<ControlMessage = libc::cmsghdr>>(
         dst_ip: None,
         interface_index: None,
         stride: len,
+        timestamp: None,
     };
 
     let cmsg_iter = unsafe { cmsg::Iter::new(hdr) };
@@ -739,6 +746,7 @@ pub(crate) fn decode_recv<M: cmsg::MsgHdr<ControlMessage = libc::cmsghdr>>(
         ecn: EcnCodepoint::from_bits(ctrl.ecn_bits),
         dst_ip: ctrl.dst_ip,
         interface_index: ctrl.interface_index,
+        timestamp: ctrl.timestamp,
     })
 }
 
@@ -748,6 +756,7 @@ struct ControlMetadata {
     dst_ip: Option<IpAddr>,
     interface_index: Option<u32>,
     stride: usize,
+    timestamp: Option<Duration>,
 }
 
 impl ControlMetadata {
@@ -806,6 +815,13 @@ impl ControlMetadata {
             (libc::SOL_UDP, libc::UDP_GRO) => unsafe {
                 self.stride = cmsg::decode::<libc::c_int, libc::cmsghdr>(cmsg) as usize;
             },
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            (libc::SOL_SOCKET, libc::SCM_TIMESTAMPNS) => {
+                let ts = unsafe { cmsg::decode::<libc::timespec, libc::cmsghdr>(cmsg) };
+                let secs = u64::try_from(ts.tv_sec).unwrap_or(0);
+                let nsecs = u32::try_from(ts.tv_nsec).unwrap_or(0);
+                self.timestamp = Some(Duration::new(secs, nsecs));
+            }
             _ => {}
         }
     }

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -326,6 +326,7 @@ impl UdpSocketState {
             ecn: EcnCodepoint::from_bits(ecn_bits as u8),
             dst_ip,
             interface_index,
+            timestamp: None,
         };
         Ok(1)
     }

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -4,6 +4,7 @@ use std::{
     io::IoSliceMut,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, UdpSocket},
     slice,
+    time::Duration,
 };
 
 use quinn_udp::{EcnCodepoint, RecvMeta, Transmit, UdpSocketState};
@@ -359,6 +360,26 @@ fn test_send_recv(send: &Socket, recv: &Socket, transmit: Transmit<'_>) {
         } else {
             assert_eq!(meta.ecn, transmit.ecn);
         }
+
+        // On Linux and Android, we expect the kernel to provide a receive timestamp
+        // since we explicitly enabled `SO_TIMESTAMPNS`.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            assert!(
+                meta.timestamp.is_some(),
+                "Kernel timestamp should be present on Linux/Android"
+            );
+            assert!(
+                meta.timestamp.unwrap() > Duration::ZERO,
+                "Kernel timestamp should be non-zero"
+            );
+        }
+
+        // On other platforms, the timestamp should remain `None`.
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        {
+            assert!(meta.timestamp.is_none());
+        }
     }
     assert_eq!(datagrams, expected_datagrams);
 }
@@ -498,7 +519,7 @@ fn recv_transport_error() {
                 break;
             }
             _ => {
-                std::thread::sleep(std::time::Duration::from_millis(10));
+                std::thread::sleep(Duration::from_millis(10));
             }
         }
     }
@@ -558,7 +579,7 @@ fn recv_transport_error_ipv6() {
             received = Some(err);
             break;
         }
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        std::thread::sleep(Duration::from_millis(10));
     }
 
     let err = received.expect("ICMPv6 Port Unreachable not received");


### PR DESCRIPTION
Closes #2574.

Add Linux/Android support for kernel receive timestamps via `SO_TIMESTAMPNS`.

- Enable `SO_TIMESTAMPNS` on socket setup
- Parse `SCM_TIMESTAMPNS` ancillary messages
- Expose timestamp via `RecvMeta::timestamp` (`Option<u64>`, nanoseconds since Unix epoch)
- Increase `CMSG_LEN` from 88 to 96 bytes on Linux/Android

Tested on Linux x86_64. All tests pass locally.