### PR TITLE
Expose TLS handshake bytes from `Incoming`

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -1198,6 +1198,75 @@ impl Incoming {
     pub fn orig_dst_cid(&self) -> ConnectionId {
         self.token.orig_dst_cid
     }
+
+    /// The TLS handshake bytes carried by the Initial packet, suitable for
+    /// inspecting the ClientHello before deciding whether to
+    /// [`accept`](Endpoint::accept) or [`ignore`](Endpoint::ignore) this
+    /// connection attempt.
+    ///
+    /// This decrypts the Initial packet's payload using the (publicly
+    /// derivable) Initial keys, walks the QUIC frames, and concatenates the
+    /// data carried by `CRYPTO` frames in offset order. Per RFC 9001 §4.1.3,
+    /// QUIC carries TLS handshake messages directly inside `CRYPTO` frames
+    /// with no intervening TLS record layer, so the returned bytes begin with
+    /// the TLS handshake message header (`0x01` = ClientHello, then a 3-byte
+    /// length, then the body).
+    ///
+    /// Returns an error if the packet fails AEAD authentication, if its
+    /// frames cannot be parsed, or if the `CRYPTO` frames are non-contiguous
+    /// from offset 0. Non-`CRYPTO` frames (e.g. `PADDING`, `PING`) are
+    /// ignored.
+    pub fn handshake_bytes(&self) -> Result<Vec<u8>, HandshakeBytesError> {
+        let packet_number = self.packet.header.number.expand(0);
+        let mut payload = self.packet.payload.clone();
+        self.crypto
+            .packet
+            .remote
+            .decrypt(packet_number, &self.packet.header_data, &mut payload)
+            .map_err(|_| HandshakeBytesError::Decrypt)?;
+
+        let mut chunks: Vec<(u64, Bytes)> = Vec::new();
+        let iter =
+            frame::Iter::new(payload.freeze()).map_err(|_| HandshakeBytesError::MalformedFrames)?;
+        for frame in iter {
+            // PADDING, PING, ACK, CONNECTION_CLOSE are legal in Initials —
+            // skip them. Anything else would be a protocol violation, but we
+            // leave that judgement to the post-accept handshake path.
+            if let frame::Frame::Crypto(c) =
+                frame.map_err(|_| HandshakeBytesError::MalformedFrames)?
+            {
+                chunks.push((c.offset, c.data));
+            }
+        }
+
+        chunks.sort_by_key(|(off, _)| *off);
+        let mut out = Vec::new();
+        let mut expected = 0u64;
+        for (off, data) in chunks {
+            if off != expected {
+                return Err(HandshakeBytesError::NonContiguous);
+            }
+            expected += data.len() as u64;
+            out.extend_from_slice(&data);
+        }
+
+        Ok(out)
+    }
+}
+
+/// Error returned by [`Incoming::handshake_bytes`].
+#[derive(Debug, Error)]
+pub enum HandshakeBytesError {
+    /// The Initial packet failed AEAD authentication.
+    #[error("initial packet failed authentication")]
+    Decrypt,
+    /// The Initial packet's frames could not be parsed.
+    #[error("malformed frames in initial packet")]
+    MalformedFrames,
+    /// `CRYPTO` frames in the Initial packet did not form a contiguous run
+    /// starting at offset 0.
+    #[error("CRYPTO frames in initial packet are not contiguous from offset 0")]
+    NonContiguous,
 }
 
 impl fmt::Debug for Incoming {

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -71,7 +71,8 @@ pub use crate::frame::{ApplicationClose, ConnectionClose, Datagram, FrameType};
 
 mod endpoint;
 pub use crate::endpoint::{
-    AcceptError, ConnectError, ConnectionHandle, DatagramEvent, Endpoint, Incoming, RetryError,
+    AcceptError, ConnectError, ConnectionHandle, DatagramEvent, Endpoint, HandshakeBytesError,
+    Incoming, RetryError,
 };
 
 mod packet;

--- a/quinn/src/incoming.rs
+++ b/quinn/src/incoming.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use proto::{ConnectionError, ConnectionId, ServerConfig};
+use proto::{ConnectionError, ConnectionId, HandshakeBytesError, ServerConfig};
 use thiserror::Error;
 
 use crate::{
@@ -97,6 +97,17 @@ impl Incoming {
     /// The original destination CID when initiating the connection
     pub fn orig_dst_cid(&self) -> ConnectionId {
         self.0.as_ref().unwrap().inner.orig_dst_cid()
+    }
+
+    /// The TLS handshake bytes carried by the Initial packet.
+    ///
+    /// See [`proto::Incoming::handshake_bytes`] for the full description.
+    /// The returned bytes begin with the TLS handshake message header (`0x01`
+    /// for `ClientHello`) and can be passed to a TLS parser to inspect
+    /// extensions such as SNI or ALPN before deciding whether to
+    /// [`accept`](Self::accept) or [`ignore`](Self::ignore) the connection.
+    pub fn handshake_bytes(&self) -> Result<Vec<u8>, HandshakeBytesError> {
+        self.0.as_ref().unwrap().inner.handshake_bytes()
     }
 }
 


### PR DESCRIPTION
## Summary

Adds `Incoming::handshake_bytes()` (and a forwarding method on the high-level `quinn::Incoming` wrapper), which decrypts the Initial packet using the publicly-derivable Initial keys, walks the QUIC frames, and returns the concatenated `CRYPTO` frame contents in offset order.

Per RFC 9001 §4.1.3, TLS handshake messages travel inside `CRYPTO` frames with no intervening TLS record layer, so the returned bytes start directly with the TLS handshake message header (`0x01` for `ClientHello`, then a 3-byte length, then the body). Callers can feed this to a TLS parser to inspect extensions such as SNI or ALPN before deciding whether to `accept()`, `retry()`, `refuse()`, or `ignore()` the connection.

## Motivation

`Incoming` (from #2076) gave users the ability to make accept/refuse/retry/**ignore** decisions before any QUIC response goes on the wire — a very nice primitive for hardening. The decision can today be informed by remote address, address-validation status, original DCID, and local IP. What's missing is any ability to look at the ClientHello itself.

Concrete use case I bumped into: port-knocking style authentication on a UDP service. The goal is for the port to appear closed to scanners that don't carry a pre-shared token (an HMAC, say, embedded in a custom ALPN entry). Without ClientHello inspection, the closest one can do today is gate at the rustls layer via a custom `ResolvesServerCert` — but by that point a TLS alert has already left the box, so the service is observable. With `handshake_bytes()` + `Incoming::ignore()`, the port becomes truly silent for invalid clients (WireGuard-grade posture), while still being a normal QUIC service for valid ones. I've verified this end-to-end with packet capture: zero response packets to clients failing the check.

Other plausible uses: SNI-keyed rate limiting before TLS handshake, ClientHello-fingerprint denylists, GREASE/ECH-aware admission, eBPF-style port-knocking with cleaner state handling than out-of-band knock daemons.

## API shape

```rust
impl Incoming {
    pub fn handshake_bytes(&self) -> Result<Vec<u8>, HandshakeBytesError>;
}

pub enum HandshakeBytesError {
    Decrypt,            // AEAD authentication failed
    MalformedFrames,    // frame parsing failed
    NonContiguous,      // CRYPTO frames don't run from offset 0
}
```

Re-exported through `quinn-proto::Incoming` and `quinn::Incoming`.

## Design choices / alternatives considered

- **Why return bytes instead of a parsed `ClientHello`?** Keeps `quinn-proto` firmly in QUIC framing and out of the TLS layer. Callers already have rustls (or webpki-types, or whatever) available for the TLS-side parsing. Avoids growing `quinn-proto`'s API surface with a TLS data model.
- **Why a method on `Incoming` rather than exposing internal frame parsing?** `Iter`/`Frame`/`Crypto` are currently `pub(crate)`; making them public is a much larger commitment. A single inspection method is the smallest user-facing surface for the same capability.
- **Why `Vec<u8>` and not `Bytes` / `&[u8]`?** The CRYPTO frames need to be concatenated in offset order, so the result is inherently owned. Happy to switch to `Bytes` if that's preferred.
- **Non-`CRYPTO` frames** (`PADDING`, `PING`, `ACK`, `CONNECTION_CLOSE`) are silently skipped — they're legal in Initials per RFC 9000 §17.2.2.
- **Non-contiguous CRYPTO frames** return an explicit error rather than being silently reassembled with gaps. Real ClientHellos in Initials are typically a single frame at offset 0; a gap suggests either a fragmented handshake (rare for ClientHello) or something malformed.
- **Cost.** The method clones the (encrypted) payload buffer and does one AEAD decrypt + a frame walk. Cheap enough that callers can invoke it unconditionally; not so cheap that it should be called many times — the doc could note "cache the result if you need it more than once," happy to add that.

## What's not in this PR

- **No tests.** Most happy to add one — an integration test that captures an Initial via the existing simulated-IO test harness and asserts the returned bytes start with `0x01` and parse as a ClientHello would be straightforward. Held off pending design feedback on the API shape.
- **No changes to `accept()`/`ignore()`/etc.** The method is purely an additional read-only inspection point.

## Compatibility

Additive only. No existing methods change behaviour or signatures.

---

Happy to convert this to an issue / discussion if you'd prefer to align on the API shape before reviewing code. Also happy to iterate on naming (`handshake_bytes` vs `client_hello_bytes` vs `initial_crypto` etc.), error type granularity, or return type.