### PR TITLE
feat(udp): add support for `IP_RECVERR` and `IPV6_RECVERR` (Linux/Android)

### DIFF
--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -170,6 +170,51 @@ impl Transmit<'_> {
     }
 }
 
+/// Asynchronous transport-layer errors reported by the operating system
+///
+/// On Linux and Android these are delivered via the socket error queue
+/// (`MSG_ERRQUEUE`) and originate from ICMP messages.
+///
+/// These errors are out-of-band and do not correspond to a received packet.
+#[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
+pub struct TransportError {
+    /// Address associated with the error
+    ///
+    /// This is the remote peer or an intermediate network device that triggered the error.
+    /// Returns `None` if the kernel cannot determine the source (e.g. `AF_UNSPEC`).
+    pub addr: Option<SocketAddr>,
+    /// Transport-layer error details
+    pub payload: TransportErrorPayload,
+    /// The raw error code from the underlying operating system
+    pub raw_errno: i32,
+}
+
+impl TransportError {
+    /// Returns the recommended MTU for packet-too-big errors
+    pub fn mtu(&self) -> Option<u32> {
+        match self.payload {
+            TransportErrorPayload::TooBig { mtu } => Some(mtu),
+            _ => None,
+        }
+    }
+}
+
+/// Transport-layer error details reported by the kernel
+#[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
+pub enum TransportErrorPayload {
+    /// Destination host or port is unreachable
+    Unreachable,
+    /// Packet exceeds path MTU
+    TooBig {
+        /// Recommended Maximum Transmission Unit
+        mtu: u32,
+    },
+    /// Other transport-layer or kernel-reported error
+    Other,
+}
+
 /// Log at most 1 IO error per minute
 #[cfg(not(wasm_browser))]
 const IO_ERROR_LOG_INTERVAL: Duration = std::time::Duration::from_secs(60);

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -15,8 +15,12 @@ use std::{
 use socket2::SockRef;
 
 use super::{
-    EcnCodepoint, IO_ERROR_LOG_INTERVAL, RecvMeta, Transmit, UdpSockRef, cmsg, log_sendmsg_error,
+    EcnCodepoint, IO_ERROR_LOG_INTERVAL, RecvMeta, Transmit, TransportError, UdpSockRef, cmsg,
+    log_sendmsg_error,
 };
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use super::TransportErrorPayload;
 
 // Adapted from https://github.com/apple-oss-distributions/xnu/blob/8d741a5de7ff4191bf97d57b9f54c2f6d4a15585/bsd/sys/socket_private.h
 #[cfg(apple_fast)]
@@ -149,6 +153,21 @@ impl UdpSocketState {
                 // https://github.com/quinn-rs/quinn/pull/1354.
                 gro_segments = 64
             }
+
+            if is_ipv4 || !io.only_v6()? {
+                if let Err(_err) =
+                    set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_RECVERR, OPTION_ON)
+                {
+                    crate::log::debug!("ignoring error setting IP_RECVERR on socket: {_err:?}");
+                }
+            }
+            if !is_ipv4 {
+                if let Err(_err) =
+                    set_socket_option(&*io, libc::IPPROTO_IPV6, libc::IPV6_RECVERR, OPTION_ON)
+                {
+                    crate::log::debug!("ignoring error setting IPV6_RECVERR on socket: {_err:?}");
+                }
+            }
         }
         #[cfg(any(target_os = "freebsd", apple))]
         {
@@ -277,6 +296,29 @@ impl UdpSocketState {
         recv_single(socket.0, bufs, meta)
     }
 
+    /// Receives a pending, asynchronous transport-layer error from this socket.
+    ///
+    /// On Linux and Android this pops one entry from the socket error queue
+    /// (`MSG_ERRQUEUE`). Returns `None` if the queue is empty or if the
+    /// underlying platform is unsupported.
+    ///
+    /// Returns an error if the underlying system call fails unexpectedly.
+    pub fn recv_transport_error(
+        &self,
+        socket: UdpSockRef<'_>,
+    ) -> io::Result<Option<TransportError>> {
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            Ok(LinuxError::recv(socket.0)?.map(TransportError::from))
+        }
+
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        {
+            let _ = socket;
+            Ok(None)
+        }
+    }
+
     /// The maximum amount of segments which can be transmitted if a platform
     /// supports Generic Send Offload (GSO).
     ///
@@ -376,6 +418,155 @@ impl UdpSocketState {
             self.disable_apple_fast_path();
         }
         f
+    }
+}
+
+/// Decoded entry from the Linux socket error queue (`MSG_ERRQUEUE`).
+#[cfg(any(target_os = "linux", target_os = "android"))]
+struct LinuxError {
+    ee: libc::sock_extended_err,
+    offender: Option<SocketAddr>,
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl LinuxError {
+    /// Control message buffer size for socket error queue (MSG_ERRQUEUE)
+    const ERR_CMSG_LEN: usize = 128;
+
+    /// Reads one entry from the Linux socket error queue (MSG_ERRQUEUE)
+    fn recv(io: SockRef<'_>) -> io::Result<Option<Self>> {
+        let mut name = MaybeUninit::<libc::sockaddr_storage>::uninit();
+        let mut ctrl = cmsg::Aligned(MaybeUninit::<[u8; Self::ERR_CMSG_LEN]>::uninit());
+
+        // Linux requires at least one iovec even for MSG_ERRQUEUE.
+        let mut iov_data = [0u8; 1];
+        let mut iov = libc::iovec {
+            iov_base: iov_data.as_mut_ptr() as *mut _,
+            iov_len: iov_data.len(),
+        };
+
+        let mut hdr = unsafe { mem::zeroed::<libc::msghdr>() };
+
+        hdr.msg_name = name.as_mut_ptr() as _;
+        hdr.msg_namelen = mem::size_of::<libc::sockaddr_storage>() as _;
+        hdr.msg_iov = &mut iov;
+        hdr.msg_iovlen = 1;
+        hdr.msg_control = ctrl.0.as_mut_ptr() as _;
+        hdr.msg_controllen = Self::ERR_CMSG_LEN as _;
+
+        if let Err(err) = retry_if_interrupted(|| unsafe {
+            libc::recvmsg(
+                io.as_raw_fd(),
+                &mut hdr,
+                libc::MSG_ERRQUEUE | libc::MSG_DONTWAIT,
+            )
+        }) {
+            if err.kind() == io::ErrorKind::WouldBlock {
+                return Ok(None);
+            }
+            return Err(err);
+        };
+
+        if hdr.msg_flags & libc::MSG_CTRUNC != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "control message truncated",
+            ));
+        }
+
+        let cmsg_iter = unsafe { cmsg::Iter::new(&hdr) };
+
+        for cmsg in cmsg_iter {
+            if let Some(raw) = Self::decode(cmsg) {
+                return Ok(Some(raw));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Attempts to decode a Linux `sock_extended_err` from a MSG_ERRQUEUE control message.
+    fn decode(cmsg: &libc::cmsghdr) -> Option<Self> {
+        if cmsg.cmsg_level != libc::IPPROTO_IP && cmsg.cmsg_level != libc::IPPROTO_IPV6 {
+            return None;
+        }
+
+        if cmsg.cmsg_type != libc::IP_RECVERR && cmsg.cmsg_type != libc::IPV6_RECVERR {
+            return None;
+        }
+
+        let required =
+            unsafe { libc::CMSG_LEN(mem::size_of::<libc::sock_extended_err>() as _) as usize };
+
+        if cmsg.cmsg_len < required {
+            return None;
+        }
+
+        let ee_ptr = unsafe { libc::CMSG_DATA(cmsg) as *const libc::sock_extended_err };
+        let (ee, offender_ptr, mut storage) = unsafe {
+            (
+                std::ptr::read_unaligned(ee_ptr),
+                libc::SO_EE_OFFENDER(ee_ptr),
+                std::mem::zeroed::<libc::sockaddr_storage>(),
+            )
+        };
+
+        let family = unsafe { (*offender_ptr).sa_family as i32 };
+        let len = match family {
+            libc::AF_INET => std::mem::size_of::<libc::sockaddr_in>(),
+            libc::AF_INET6 => std::mem::size_of::<libc::sockaddr_in6>(),
+            libc::AF_UNSPEC => {
+                return Some(Self { ee, offender: None });
+            }
+            _ => return None,
+        };
+
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                offender_ptr as *const u8,
+                &mut storage as *mut _ as *mut u8,
+                len,
+            );
+        }
+
+        let offender = Some(decode_socket_addr(&storage).ok()?);
+
+        Some(Self { ee, offender })
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl From<LinuxError> for TransportError {
+    fn from(raw: LinuxError) -> Self {
+        crate::log::trace!(
+            "decoding Linux socket error: ee_origin={} ee_type={} ee_code={} ee_errno={} ee_info={}",
+            raw.ee.ee_origin,
+            raw.ee.ee_type,
+            raw.ee.ee_code,
+            raw.ee.ee_errno,
+            raw.ee.ee_info,
+        );
+        let payload = match (raw.ee.ee_origin, raw.ee.ee_type, raw.ee.ee_code) {
+            // IPv4: Fragmentation Needed (Type 3, Code 4)
+            (libc::SO_EE_ORIGIN_ICMP, 3, 4) => TransportErrorPayload::TooBig {
+                mtu: raw.ee.ee_info,
+            },
+            // IPv6: Packet Too Big (Type 2, Code 0)
+            (libc::SO_EE_ORIGIN_ICMP6, 2, 0) => TransportErrorPayload::TooBig {
+                mtu: raw.ee.ee_info,
+            },
+            // Unreachable cases
+            (libc::SO_EE_ORIGIN_ICMP, 3, _) | (libc::SO_EE_ORIGIN_ICMP6, 1, _) => {
+                TransportErrorPayload::Unreachable
+            }
+            _ => TransportErrorPayload::Other,
+        };
+
+        Self {
+            addr: raw.offender,
+            payload,
+            raw_errno: raw.ee.ee_errno as i32,
+        }
     }
 }
 
@@ -1251,5 +1442,71 @@ fn retry_if_interrupted(mut f: impl FnMut() -> isize) -> io::Result<isize> {
         if e.kind() != io::ErrorKind::Interrupted {
             return Err(e);
         }
+    }
+}
+
+#[cfg(all(test, any(target_os = "linux", target_os = "android")))]
+mod tests {
+    use super::*;
+
+    // Tests LinuxError::decode with a mocked MSG_ERRQUEUE control message.
+    //
+    // Validates CMSG parsing, SO_EE_OFFENDER handling, and sockaddr decoding.
+    #[test]
+    fn decode_mock_ip_recverr() {
+        let mock_ee = libc::sock_extended_err {
+            ee_errno: libc::EMSGSIZE as u32,
+            ee_origin: libc::SO_EE_ORIGIN_ICMP,
+            ee_type: 3,
+            ee_code: 4,
+            ee_pad: 0,
+            ee_info: 1420,
+            ee_data: 0,
+        };
+
+        let mock_addr = libc::sockaddr_in {
+            sin_family: libc::AF_INET as libc::sa_family_t,
+            sin_port: 443u16.to_be(),
+            sin_addr: libc::in_addr {
+                s_addr: u32::from_ne_bytes([127, 0, 0, 1]),
+            },
+            sin_zero: [0; 8],
+        };
+
+        let payload_len =
+            mem::size_of::<libc::sock_extended_err>() + mem::size_of::<libc::sockaddr_in>();
+        let cmsg_len = unsafe { libc::CMSG_LEN(payload_len as _) as usize };
+        let mut buffer = vec![0u8; cmsg_len];
+
+        let decoded = unsafe {
+            let cmsg = buffer.as_mut_ptr() as *mut libc::cmsghdr;
+
+            (*cmsg).cmsg_len = cmsg_len as _;
+            (*cmsg).cmsg_level = libc::IPPROTO_IP;
+            (*cmsg).cmsg_type = libc::IP_RECVERR;
+
+            let data = libc::CMSG_DATA(cmsg);
+            ptr::write(data as *mut libc::sock_extended_err, mock_ee);
+
+            let offender_ptr = data.add(mem::size_of::<libc::sock_extended_err>());
+            ptr::write(offender_ptr as *mut libc::sockaddr_in, mock_addr);
+
+            LinuxError::decode(&*cmsg)
+        }
+        .expect("decode failed");
+
+        assert_eq!(decoded.ee.ee_errno, libc::EMSGSIZE as u32);
+        assert_eq!(decoded.ee.ee_info, 1420);
+
+        let offender = decoded.offender.unwrap();
+
+        assert_eq!(offender.port(), 443);
+        assert_eq!(offender.ip(), Ipv4Addr::new(127, 0, 0, 1));
+
+        let transport = TransportError::from(decoded);
+        assert!(matches!(
+            transport.payload,
+            TransportErrorPayload::TooBig { mtu: 1420 }
+        ));
     }
 }

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -461,3 +461,116 @@ fn apple_fast_datapath() {
     }
     assert_eq!(total_received, segments, "should receive all segments");
 }
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn recv_transport_error() {
+    let sock = Socket::from(UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap());
+
+    let state = UdpSocketState::new((&sock).into()).unwrap();
+
+    // Pick an unused port by binding then dropping.
+    let unused_port = {
+        let tmp = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        tmp.local_addr().unwrap().port()
+    };
+
+    let dst = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, unused_port));
+
+    state
+        .try_send(
+            (&sock).into(),
+            &Transmit {
+                destination: dst,
+                ecn: None,
+                contents: b"hello",
+                segment_size: None,
+                src_ip: None,
+            },
+        )
+        .unwrap();
+
+    let mut received = None;
+    for _ in 0..100 {
+        match state.recv_transport_error((&sock).into()) {
+            Ok(Some(err)) => {
+                received = Some(err);
+                break;
+            }
+            _ => {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+        }
+    }
+
+    let err = received.expect("ICMP Port Unreachable was not received");
+
+    assert!(
+        matches!(err.payload, quinn_udp::TransportErrorPayload::Unreachable),
+        "expected ICMP destination unreachable transport error"
+    );
+    assert_eq!(
+        err.raw_errno,
+        libc::ECONNREFUSED,
+        "unexpected errno decoded from MSG_ERRQUEUE"
+    );
+    // Linux may report port 0 in SO_EE_OFFENDER for ICMP errors.
+    if let Some(addr) = err.addr {
+        assert_eq!(
+            addr.ip(),
+            dst.ip(),
+            "decoded offender IP does not match destination"
+        );
+    }
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn recv_transport_error_ipv6() {
+    let sock = Socket::from(UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap());
+
+    let state = UdpSocketState::new((&sock).into()).unwrap();
+
+    let unused_port = {
+        let tmp = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap();
+        tmp.local_addr().unwrap().port()
+    };
+
+    let dst = SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, unused_port, 0, 0));
+
+    state
+        .try_send(
+            (&sock).into(),
+            &Transmit {
+                destination: dst,
+                ecn: None,
+                contents: b"hello",
+                segment_size: None,
+                src_ip: None,
+            },
+        )
+        .unwrap();
+
+    let mut received = None;
+
+    for _ in 0..100 {
+        if let Ok(Some(err)) = state.recv_transport_error((&sock).into()) {
+            received = Some(err);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    let err = received.expect("ICMPv6 Port Unreachable not received");
+
+    assert!(matches!(
+        err.payload,
+        quinn_udp::TransportErrorPayload::Unreachable
+    ));
+
+    assert_eq!(err.raw_errno, libc::ECONNREFUSED);
+
+    if let Some(addr) = err.addr {
+        assert_eq!(addr.ip(), dst.ip());
+    }
+}


### PR DESCRIPTION
### Description

Closes #2052

This PR adds support for `IP_RECVERR` and `IPV6_RECVERR` on Linux and Android, enabling reception of asynchronous transport-layer errors via the socket error queue (`MSG_ERRQUEUE`).

It follows the “opt-in” approach (`recv_transport_error`) suggested in the original review of #2421. This keeps error handling out of the normal receive path and avoids any overhead for users who don’t need it.

### Changes

- Enable `IP_RECVERR` / `IPV6_RECVERR` on supported sockets
- Add `recv_transport_error` API for polling kernel error queue entries
- Decode Linux `sock_extended_err` messages into a `TransportError`
- On unsupported platforms, the API returns `Ok(None)`

### Notes

This builds on the work from #2421. Co-authorship has been preserved with the original contributor.

Co-authored-by: @RaghavendraRQ