### PR TITLE
proto: reject stream flow-control frames above limits

### DIFF
--- a/fuzz/fuzz_targets/streams.rs
+++ b/fuzz/fuzz_targets/streams.rs
@@ -53,7 +53,7 @@ fuzz_target!(|input: (StreamParams, Vec<Operation>)| {
                 let _ = SendStream::new(id, &mut state, &mut pending, &conn_state).finish();
             }
             Operation::ReceivedStopSending(sid, err_code) => {
-                Streams::new(&mut state, &conn_state)
+                let _ = Streams::new(&mut state, &conn_state)
                     .state()
                     .received_stop_sending(sid, err_code);
             }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2901,19 +2901,7 @@ impl Connection {
                     );
                 }
                 Frame::StopSending(frame::StopSending { id, error_code }) => {
-                    if id.initiator() != self.side.side() {
-                        if id.dir() == Dir::Uni {
-                            debug!("got STOP_SENDING on recv-only {}", id);
-                            return Err(TransportError::STREAM_STATE_ERROR(
-                                "STOP_SENDING on recv-only stream",
-                            ));
-                        }
-                    } else if self.streams.is_local_unopened(id) {
-                        return Err(TransportError::STREAM_STATE_ERROR(
-                            "STOP_SENDING on unopened stream",
-                        ));
-                    }
-                    self.streams.received_stop_sending(id, error_code);
+                    self.streams.received_stop_sending(id, error_code)?;
                 }
                 Frame::RetireConnectionId { sequence } => {
                     let allow_more_cids = self

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -356,14 +356,20 @@ impl StreamsState {
 
     /// Process incoming `STOP_SENDING` frame
     #[allow(unreachable_pub)] // fuzzing only
-    pub fn received_stop_sending(&mut self, id: StreamId, error_code: VarInt) {
+    pub fn received_stop_sending(
+        &mut self,
+        id: StreamId,
+        error_code: VarInt,
+    ) -> Result<(), TransportError> {
+        self.validate_send_id(id, "STOP_SENDING")?;
+
         let max_send_data = self.max_send_data(id);
         let Some(stream) = self
             .send
             .get_mut(&id)
             .map(get_or_insert_send(max_send_data))
         else {
-            return;
+            return Ok(());
         };
 
         if stream.try_stop(error_code) {
@@ -371,6 +377,8 @@ impl StreamsState {
                 .push_back(StreamEvent::Stopped { id, error_code });
             self.on_stream_frame(false, id);
         }
+
+        Ok(())
     }
 
     pub(crate) fn reset_acked(&mut self, id: StreamId) {
@@ -743,12 +751,8 @@ impl StreamsState {
         id: StreamId,
         offset: u64,
     ) -> Result<(), TransportError> {
-        if id.initiator() != self.side && id.dir() == Dir::Uni {
-            debug!("got MAX_STREAM_DATA on recv-only {}", id);
-            return Err(TransportError::STREAM_STATE_ERROR(
-                "MAX_STREAM_DATA on recv-only stream",
-            ));
-        }
+        self.validate_send_id(id, "MAX_STREAM_DATA")
+            .inspect_err(|_| debug!("received illegal MAX_STREAM_DATA frame"))?;
 
         let write_limit = self.write_limit();
         let max_send_data = self.max_send_data(id);
@@ -768,11 +772,6 @@ impl StreamsState {
                     self.connection_blocked.push(id);
                 }
             }
-        } else if id.initiator() == self.side && self.is_local_unopened(id) {
-            debug!("got MAX_STREAM_DATA on unopened {}", id);
-            return Err(TransportError::STREAM_STATE_ERROR(
-                "MAX_STREAM_DATA on unopened stream",
-            ));
         }
 
         self.on_stream_frame(false, id);
@@ -831,7 +830,7 @@ impl StreamsState {
     }
 
     /// Check for errors entailed by the peer's use of `id` as a send stream
-    fn validate_receive_id(&mut self, id: StreamId) -> Result<(), TransportError> {
+    fn validate_receive_id(&self, id: StreamId) -> Result<(), TransportError> {
         if self.side == id.initiator() {
             match id.dir() {
                 Dir::Uni => {
@@ -851,6 +850,28 @@ impl StreamsState {
             if id.index() >= limit {
                 return Err(TransportError::STREAM_LIMIT_ERROR(""));
             }
+        }
+        Ok(())
+    }
+
+    /// Check for errors entailed by the peer's use of `id` as a receive stream.
+    pub(crate) fn validate_send_id(
+        &self,
+        id: StreamId,
+        frame: &'static str,
+    ) -> Result<(), TransportError> {
+        if self.side == id.initiator() {
+            if self.is_local_unopened(id) {
+                return Err(TransportError::STREAM_STATE_ERROR(format!(
+                    "{frame} on unopened stream"
+                )));
+            }
+        } else if id.dir() == Dir::Uni {
+            return Err(TransportError::STREAM_STATE_ERROR(format!(
+                "{frame} on recv-only stream"
+            )));
+        } else if id.index() >= self.max_remote[id.dir() as usize] {
+            return Err(TransportError::STREAM_LIMIT_ERROR(""));
         }
         Ok(())
     }
@@ -1315,7 +1336,7 @@ mod tests {
         };
 
         let error_code = 0u32.into();
-        stream.state.received_stop_sending(id, error_code);
+        stream.state.received_stop_sending(id, error_code).unwrap();
         assert!(
             stream
                 .state
@@ -1330,8 +1351,32 @@ mod tests {
         assert_eq!(stream.write(&[]), Err(WriteError::ClosedStream));
 
         // A duplicate frame is a no-op
-        stream.state.received_stop_sending(id, error_code);
+        stream.state.received_stop_sending(id, error_code).unwrap();
         assert!(stream.state.events.is_empty());
+    }
+
+    #[test]
+    fn stop_sending_above_remote_stream_limit() {
+        let mut client = make(Side::Client);
+        assert_eq!(
+            client
+                .received_stop_sending(StreamId::new(Side::Server, Dir::Bi, 128), 0u32.into())
+                .unwrap_err()
+                .code,
+            TransportErrorCode::STREAM_LIMIT_ERROR
+        );
+    }
+
+    #[test]
+    fn max_stream_data_above_remote_stream_limit() {
+        let mut client = make(Side::Client);
+        assert_eq!(
+            client
+                .received_max_stream_data(StreamId::new(Side::Server, Dir::Bi, 128), 0)
+                .unwrap_err()
+                .code,
+            TransportErrorCode::STREAM_LIMIT_ERROR
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2650.

## Summary
- validate send-side stream IDs before handling `STOP_SENDING` and `MAX_STREAM_DATA`
- return `STREAM_LIMIT_ERROR` for remote-initiated bidirectional stream IDs above the advertised limit
- add regression coverage for both frame types

## Validation
- `cargo test --locked -p quinn-proto stream_limit` passed: 5 passed, 0 failed
- `cargo test --locked -p quinn-proto` passed: 273 unit tests and 3 doctests passed
- `cargo fmt --all -- --check` passed
- `cargo clippy --locked -p quinn-proto --all-targets -- -D warnings` passed
- `cargo test --locked --manifest-path fuzz/Cargo.toml` passed
- `RUSTFLAGS='--cfg fuzzing' cargo build --locked --manifest-path fuzz/Cargo.toml --bin streams` passed
- `git diff --check` passed
- `gitleaks protect --staged --redact --no-banner` passed: no leaks found

Note: #2601 also touches remote stream allocation state; this PR is against current `main` and may need a rebase if #2601 lands first.
