### PR TITLE
fix: set loss detection timer on path validation failure

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1199,6 +1199,7 @@ impl Connection {
                     debug!("path validation failed");
                     if let Some((_, prev)) = self.prev_path.take() {
                         self.path = prev;
+                        self.set_loss_detection_timer(now);
                     }
                     self.path.challenge = None;
                     self.path.challenge_pending = false;


### PR DESCRIPTION
Reset the loss detection timer on path validation failure.

Fixes https://github.com/quinn-rs/quinn/issues/2658

In our tests, the previous path no longer has in-flight ack-eliciting packets when restored, so the invariant that the loss timeout handler should not be called when not needed no longer holds.

I have not been able to write a unit test that reaches the debug assertion but the failure rate on our IPv6 migration scenario that initially triggered this investigation went from ~35% to 0% with this patch.