### PR TITLE
Add type-erased TLS metadata to rustls handshake data

### DIFF
--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -63,10 +63,20 @@ impl crypto::Session for TlsSession {
         }
         Some(Box::new(HandshakeData {
             protocol: self.inner.alpn_protocol().map(|x| x.into()),
-            server_name: match self.inner {
+            server_name: match &self.inner {
                 Connection::Client(_) => None,
-                Connection::Server(ref session) => session.server_name().map(|x| x.into()),
+                Connection::Server(session) => session.server_name().map(|x| x.into()),
             },
+            protocol_version: match &self.inner {
+                Connection::Client(session) => session.protocol_version(),
+                Connection::Server(session) => session.protocol_version(),
+            }
+            .map(|x| -> Box<dyn Any> { Box::new(x) }),
+            cipher_suite: match &self.inner {
+                Connection::Client(session) => session.negotiated_cipher_suite(),
+                Connection::Server(session) => session.negotiated_cipher_suite(),
+            }
+            .map(|suite| -> Box<dyn Any> { Box::new(suite.suite()) }),
             #[cfg(feature = "__rustls-post-quantum-test")]
             negotiated_key_exchange_group: self
                 .inner
@@ -265,6 +275,10 @@ pub struct HandshakeData {
     ///
     /// Always `None` for outgoing connections
     pub server_name: Option<String>,
+    /// The protocol version negotiated with the peer, if any
+    pub protocol_version: Option<Box<dyn Any>>,
+    /// The cipher suite negotiated with the peer, if any
+    pub cipher_suite: Option<Box<dyn Any>>,
     /// The key exchange group negotiated with the peer
     #[cfg(feature = "__rustls-post-quantum-test")]
     pub negotiated_key_exchange_group: NamedGroup,

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -266,6 +266,7 @@ impl HeaderKey for Box<dyn HeaderProtectionKey> {
 }
 
 /// Authentication data for (rustls) TLS session
+#[non_exhaustive]
 pub struct HandshakeData {
     /// The negotiated application protocol, if ALPN is in use
     ///

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -842,6 +842,18 @@ fn alpn_success() {
         .downcast::<crypto::rustls::HandshakeData>()
         .unwrap();
     assert_eq!(hd.protocol.unwrap(), &b"bar"[..]);
+    assert_eq!(
+        hd.protocol_version
+            .unwrap()
+            .downcast_ref::<rustls::ProtocolVersion>(),
+        Some(&rustls::ProtocolVersion::TLSv1_3)
+    );
+    assert!(
+        hd.cipher_suite
+            .unwrap()
+            .downcast_ref::<rustls::CipherSuite>()
+            .is_some()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes  #2662.

This adds the negotiated TLS protocol version and cipher suite to rustls `HandshakeData` as type-erased values (`Box<dyn Any>`).

I also extended the existing `alpn_success` test to cover the new metadata.