### PR TITLE
fix(apple): buffer unsent tail of partial `sendmsg_x` calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,6 +2054,7 @@ dependencies = [
  "criterion",
  "libc",
  "log",
+ "parking_lot",
  "socket2",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ hdrhistogram = { version = "7.2", default-features = false }
 hex-literal = "1"
 lru-slab = "0.1.2"
 log = "0.4"
+parking_lot = "0.12.5"
 pin-project-lite = "0.2"
 qlog = "0.18"
 rand = "0.10.1"

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -18,12 +18,13 @@ default = ["tracing", "tracing-log"]
 tracing-log = ["tracing/log"]
 log = ["dep:log"]
 # Support private Apple APIs to send multiple packets in a single syscall.
-fast-apple-datapath = []
+fast-apple-datapath = ["parking_lot"]
 
 [dependencies]
 libc = "0.2.175"
 log = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
+parking_lot = { workspace = true, optional = true }
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 socket2 = { workspace = true }

--- a/quinn-udp/src/apple_fast.rs
+++ b/quinn-udp/src/apple_fast.rs
@@ -1,14 +1,14 @@
 use std::{
     io::{self, IoSliceMut},
     mem::{self, MaybeUninit},
-    net::IpAddr,
+    net::{IpAddr, SocketAddr},
     os::fd::AsRawFd,
 };
 
 use socket2::SockRef;
 
 use crate::{
-    RecvMeta, Transmit, UdpSocketState,
+    EcnCodepoint, RecvMeta, Transmit, UdpSocketState,
     cmsg::{self, MsgHdr},
     imp::{BATCH_SIZE, IpTosTy, decode_recv, recv_single, retry_if_interrupted, send_single},
 };
@@ -25,48 +25,141 @@ pub(crate) fn send(
     }
 }
 
-/// Send using the fast `sendmsg_x` API
+/// Send using the fast `sendmsg_x` API.
 fn send_via_sendmsg_x(
     state: &UdpSocketState,
     io: SockRef<'_>,
     transmit: &Transmit<'_>,
 ) -> io::Result<()> {
+    let Some(sendmsg_x) = state.resolve_apple_fast_fn(sendmsg_x_fn) else {
+        return send_single(state, io, transmit);
+    };
+
+    let mut pending = state.partial_transmit();
+
+    if let Some(p) = pending.as_mut() {
+        while !p.buf.is_empty() {
+            match send_chunks(
+                &io,
+                sendmsg_x,
+                p.destination,
+                p.ecn,
+                p.src_ip,
+                state.sendmsg_einval(),
+                p.segment_size,
+                &p.buf,
+            ) {
+                Ok(sent) => {
+                    debug_assert!(sent > 0, "sendmsg_x returned Ok(0); would spin");
+                    let n = (sent * p.segment_size).min(p.buf.len());
+                    p.buf.drain(..n);
+                }
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => return Err(e),
+                Err(_e) => {
+                    crate::log::debug!("dropping queued datagram after sendmsg_x error: {_e}");
+                    let n = p.segment_size.min(p.buf.len());
+                    p.buf.drain(..n);
+                }
+            }
+        }
+    }
+
+    *pending = None;
+
+    let segment_size = transmit.segment_size.unwrap_or(transmit.contents.len());
+    let total = transmit.contents.len().div_ceil(segment_size);
+    let mut sent_datagrams = 0;
+
+    while sent_datagrams < total {
+        let remaining = &transmit.contents[sent_datagrams * segment_size..];
+        match send_chunks(
+            &io,
+            sendmsg_x,
+            transmit.destination,
+            transmit.ecn,
+            transmit.src_ip,
+            state.sendmsg_einval(),
+            segment_size,
+            remaining,
+        ) {
+            // We sent some datagrams, continue.
+            Ok(sent) => {
+                sent_datagrams += sent;
+            }
+            // We could not send any datagrams, suspend.
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock && sent_datagrams == 0 => {
+                return Err(e);
+            }
+            // We sent some datagrams (in a prior iteration) and now we are blocked.
+            // Buffer the remainder and return `Ok(())`.
+            // The caller will call us with the next datagram and we will suspend as
+            // part of the draining of the buffered packet.
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                let remainder = &transmit.contents[sent_datagrams * segment_size..];
+                crate::log::debug!(
+                    "sendmsg_x sent {sent_datagrams}/{total} datagrams; queuing remaining {} bytes for retry",
+                    remainder.len()
+                );
+
+                *pending = Some(PartialTransmit {
+                    destination: transmit.destination,
+                    ecn: transmit.ecn,
+                    src_ip: transmit.src_ip,
+                    segment_size,
+                    buf: remainder.to_vec(),
+                });
+                return Ok(());
+            }
+            // Surface any other error without buffering / retry.
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(())
+}
+
+/// Splits `contents` into `segment_size`-sized datagrams and submits them with a
+/// single `sendmsg_x` call.
+#[allow(clippy::too_many_arguments)]
+fn send_chunks(
+    io: &SockRef<'_>,
+    sendmsg_x: SendmsgXFn,
+    destination: SocketAddr,
+    ecn: Option<EcnCodepoint>,
+    src_ip: Option<IpAddr>,
+    sendmsg_einval: bool,
+    segment_size: usize,
+    contents: &[u8],
+) -> io::Result<usize> {
     let mut hdrs = unsafe { mem::zeroed::<[msghdr_x; BATCH_SIZE]>() };
     let mut iovs = unsafe { mem::zeroed::<[libc::iovec; BATCH_SIZE]>() };
     let mut ctrls = [cmsg::Aligned([0u8; cmsg::LEN]); BATCH_SIZE];
-    let addr = socket2::SockAddr::from(transmit.destination);
-    let segment_size = transmit.segment_size.unwrap_or(transmit.contents.len());
+    let addr = socket2::SockAddr::from(destination);
     let mut cnt = 0;
-    debug_assert!(transmit.contents.len().div_ceil(segment_size) <= BATCH_SIZE);
-    for (i, chunk) in transmit
-        .contents
-        .chunks(segment_size)
-        .enumerate()
-        .take(BATCH_SIZE)
-    {
+    debug_assert!(contents.len().div_ceil(segment_size) <= BATCH_SIZE);
+    for (i, chunk) in contents.chunks(segment_size).enumerate().take(BATCH_SIZE) {
         prepare_msg_x(
             &Transmit {
-                destination: transmit.destination,
-                ecn: transmit.ecn,
+                destination,
+                ecn,
                 contents: chunk,
                 segment_size: Some(chunk.len()),
-                src_ip: transmit.src_ip,
+                src_ip,
             },
             &addr,
             &mut hdrs[i],
             &mut iovs[i],
             &mut ctrls[i],
             true,
-            state.sendmsg_einval(),
+            sendmsg_einval,
         );
         hdrs[i].msg_datalen = chunk.len();
         cnt += 1;
     }
-    let Some(sendmsg_x) = state.resolve_apple_fast_fn(sendmsg_x_fn) else {
-        return send_single(state, io, transmit);
-    };
-    retry_if_interrupted(|| unsafe { sendmsg_x(io.as_raw_fd(), hdrs.as_ptr(), cnt as u32, 0) })?;
-    Ok(())
+    let sent = retry_if_interrupted(|| unsafe {
+        sendmsg_x(io.as_raw_fd(), hdrs.as_ptr(), cnt as u32, 0)
+    })?;
+    Ok(sent as usize)
 }
 
 /// Prepares an `msghdr_x` for use with `sendmsg_x`
@@ -141,6 +234,16 @@ fn sendmsg_x_fn() -> Option<SendmsgXFn> {
 
 type SendmsgXFn =
     unsafe extern "C" fn(libc::c_int, *const msghdr_x, libc::c_uint, libc::c_int) -> isize;
+
+/// The unsent tail of a partially-completed `sendmsg_x` invocation.
+#[derive(Debug)]
+pub(crate) struct PartialTransmit {
+    destination: SocketAddr,
+    ecn: Option<EcnCodepoint>,
+    src_ip: Option<IpAddr>,
+    segment_size: usize,
+    buf: Vec<u8>,
+}
 
 /// Receive using the fast `recvmsg_x` API
 pub(crate) fn recv_via_recvmsg_x(

--- a/quinn-udp/src/apple_fast.rs
+++ b/quinn-udp/src/apple_fast.rs
@@ -101,13 +101,13 @@ fn send_via_sendmsg_x(
                     remainder.len()
                 );
 
-                *pending = Some(PartialTransmit {
-                    destination: transmit.destination,
-                    ecn: transmit.ecn,
-                    src_ip: transmit.src_ip,
-                    segment_size,
-                    buf: remainder.to_vec(),
-                });
+                // *pending = Some(PartialTransmit {
+                //     destination: transmit.destination,
+                //     ecn: transmit.ecn,
+                //     src_ip: transmit.src_ip,
+                //     segment_size,
+                //     buf: remainder.to_vec(),
+                // });
                 return Ok(());
             }
             // Surface any other error without buffering / retry.

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -20,7 +20,7 @@ use super::{
 };
 
 #[cfg(apple_fast)]
-use super::apple_fast::{msghdr_x, recv_via_recvmsg_x, send};
+use super::apple_fast::{PartialTransmit, msghdr_x, recv_via_recvmsg_x, send};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use super::linux::{LinuxError, gso};
 
@@ -48,6 +48,11 @@ pub struct UdpSocketState {
     /// Apple OS versions. Callers must verify availability before enabling.
     #[cfg(apple_fast)]
     apple_fast_path: AtomicBool,
+
+    /// Unsent tail of a partially-completed `sendmsg_x` invocation, flushed before the
+    /// next send so that a batch is accepted atomically.
+    #[cfg(apple_fast)]
+    partial_transmit: parking_lot::Mutex<Option<PartialTransmit>>,
 }
 
 impl UdpSocketState {
@@ -200,6 +205,8 @@ impl UdpSocketState {
             sendmsg_einval: AtomicBool::new(false),
             #[cfg(apple_fast)]
             apple_fast_path: AtomicBool::new(false),
+            #[cfg(apple_fast)]
+            partial_transmit: parking_lot::Mutex::new(None),
         })
     }
 
@@ -407,6 +414,13 @@ impl UdpSocketState {
             self.disable_apple_fast_path();
         }
         f
+    }
+
+    /// The queue holding the unsent tail of a partially-completed `sendmsg_x`
+    /// batch, flushed before the next send.
+    #[cfg(apple_fast)]
+    pub(crate) fn partial_transmit(&self) -> parking_lot::MutexGuard<'_, Option<PartialTransmit>> {
+        self.partial_transmit.lock()
     }
 }
 

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -462,6 +462,105 @@ fn apple_fast_datapath() {
     assert_eq!(total_received, segments, "should receive all segments");
 }
 
+/// A partial `sendmsg_x` batch must not silently drop its unsent tail.
+///
+/// `sendmsg_x` can accept fewer datagrams than submitted when the send buffer
+/// fills mid-batch. Shrinking `SO_SNDBUF` well below one batch forces that on
+/// essentially every call. Every datagram handed to the socket must still arrive
+/// exactly once and in order — none dropped, duplicated, or reordered — even as
+/// the unsent tail is carried over to the following send.
+#[test]
+#[cfg(apple_fast)]
+fn apple_fast_partial_send_is_not_dropped() {
+    let send = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let recv = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let dst_addr = recv.local_addr().unwrap();
+
+    let send_state = UdpSocketState::new((&send).into()).unwrap();
+
+    // SAFETY: assume `sendmsg_x`/`recvmsg_x` are available on the macOS test host.
+    unsafe {
+        send_state.set_apple_fast_path();
+    }
+
+    let segments = send_state.max_gso_segments();
+    assert!(segments > 1, "fast path should batch multiple datagrams");
+
+    const SEGMENT_SIZE: usize = 1024;
+
+    // A send buffer far smaller than a full batch makes each `sendmsg_x` accept
+    // only part of the batch, exercising the carry-over of the unsent tail.
+    send_state
+        .set_send_buffer_size((&send).into(), SEGMENT_SIZE * 4)
+        .unwrap();
+
+    recv.set_nonblocking(true).unwrap();
+
+    // Datagrams we require delivered before declaring success. Kept below 256 so
+    // each datagram's global index fits in the single-byte tag.
+    let target = (segments * 4).min(200);
+
+    // The first byte of each datagram carries its global index. Because every
+    // send flushes the previous remainder first, the received tags must form the
+    // contiguous, strictly increasing sequence 0, 1, 2, ...: a gap is a drop, a
+    // repeat a duplicate, disorder a reorder.
+    let mut next_to_send = 0usize;
+    let mut received: Vec<usize> = Vec::with_capacity(target);
+    let mut buf = [0u8; u16::MAX as usize];
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+
+    while received.len() < target {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out after receiving {}/{target} datagrams; tail was dropped",
+            received.len()
+        );
+
+        // Keep feeding fresh batches so the final batch's remainder is always
+        // flushed by a subsequent send.
+        let mut msg = vec![0u8; SEGMENT_SIZE * segments];
+        for i in 0..segments {
+            msg[i * SEGMENT_SIZE] = ((next_to_send + i) % 256) as u8;
+        }
+        match send_state.try_send(
+            (&send).into(),
+            &Transmit {
+                destination: dst_addr,
+                ecn: None,
+                contents: &msg,
+                segment_size: Some(SEGMENT_SIZE),
+                src_ip: None,
+            },
+        ) {
+            // Whole batch accepted; any unsent tail is now queued internally.
+            Ok(()) => next_to_send += segments,
+            // Socket still backed up: drain, then retry the same batch.
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(e) => panic!("unexpected send error: {e}"),
+        }
+
+        // Drain everything currently buffered on the receiver.
+        loop {
+            match recv.recv_from(&mut buf) {
+                Ok((n, _)) => {
+                    assert_eq!(n, SEGMENT_SIZE, "unexpected datagram length");
+                    received.push(buf[0] as usize);
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                Err(e) => panic!("unexpected recv error: {e}"),
+            }
+        }
+    }
+
+    for (i, &tag) in received.iter().enumerate() {
+        assert_eq!(
+            tag,
+            i % 256,
+            "datagram {i} arrived as tag {tag}: a partial send dropped, duplicated, or reordered the batch tail"
+        );
+    }
+}
+
 #[test]
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn recv_transport_error() {


### PR DESCRIPTION
Seeking some early feedback on this. Whilst debugging some performance problems, @jamilbk discovered that we are discarding the return value of `sendmsg_x` and may thus be silently dropping datagrams if e.g. only 4 out of 32 packets were sent.

In order to retain the current API, I opted for exploring a buffering approach. In case of a partial send, we buffer the remaining tail of the batch and return `Ok(())`. This will trigger the caller to pass us another `Transmit` at which point we will first try to flush the buffered tail before continuing on to the next batch.

An alternative would be to surface the partial send to the caller but that would leak into all other platforms.