### PR TITLE
ci: fix codecov tests

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -27,7 +27,7 @@ jobs:
         #       | paste -sd ',' -
         run: |
           cargo llvm-cov \
-            --features="arbitrary,aws-lc-rs,bloom,log,fast-apple-datapath,futures-io,json-output,lock_tracking,tracing-log,platform-verifier,qlog,ring,runtime-smol,runtime-tokio,rustls,rustls-aws-lc-rs,rustls-log,rustls-ring,serde,serde_json,smol,tracing" \
+            --features="arbitrary,aws-lc-rs,bloom,log,fast-apple-datapath,futures-io,json-output,lock_tracking,tracing-log,platform-verifier,qlog,ring,runtime-smol,runtime-tokio,rustls,rustls-aws-lc-rs,rustls-log,rustls-ring,serde,serde_json,tracing" \
             --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6


### PR DESCRIPTION
- error log

```log
win@Z10 cargo llvm-cov --features="arbitrary,aws-lc-rs,bloom,log,fast-apple-datapath,futures-io,json-output,lock_tracking,tracing-log,platform-verifier,qlog,ring,runtime-smol,runtime-tokio,rustls,rustls-aws-lc-rs,rustls-log,rustls-ring,serde,serde_json,smol,tracing" --workspace --lcov --output-path lcov.info                                                                                                          
info: cargo-llvm-cov currently setting cfg(coverage); you can opt-out it by passing --no-cfg-coverage
error: package `quinn v0.12.0 (E:\VSCode\quinn\quinn)` does not have feature `smol`

help: an optional dependency with that name exists, but the `features` table includes it with the "dep:" syntax so it does not have an implicit feature with that name
Dependency `smol` would be enabled by these features:
        - `runtime-smol`
error: process didn't exit successfully: `C:\Users\win\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\cargo.exe test --tests --manifest-path E:\VSCode\quinn\Cargo.toml --target-dir F:\Cargo\llvm-cov-target --features=arbitrary,aws-lc-rs,bloom,log,fast-apple-datapath,futures-io,json-output,lock_tracking,tracing-log,platform-verifier,qlog,ring,runtime-smol,runtime-tokio,rustls,rustls-aws-lc-rs,rustls-log,rustls-ring,serde,serde_json,smol,tracing --workspace` (exit code: 101)
```

https://github.com/quinn-rs/quinn/actions/runs/27032607737/job/79788459193

This is a worthwhile issue to fix.