### PR TITLE
Backport of #2495 to 0.11.x

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -928,7 +928,7 @@ impl Clone for ConnectionRef {
 
 impl Drop for ConnectionRef {
     fn drop(&mut self) {
-        if self.shared.ref_count.fetch_sub(1, Ordering::Relaxed) > 0 {
+        if self.shared.ref_count.fetch_sub(1, Ordering::Relaxed) > 1 {
             return;
         }
 

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -5,7 +5,10 @@ use std::{
     io,
     net::{IpAddr, SocketAddr},
     pin::Pin,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
     task::{Context, Poll, Waker, ready},
 };
 
@@ -901,7 +904,6 @@ impl ConnectionRef {
                 blocked_readers: FxHashMap::default(),
                 stopped: FxHashMap::default(),
                 error: None,
-                ref_count: 0,
                 io_poller: socket.clone().create_io_poller(),
                 socket,
                 runtime,
@@ -919,17 +921,19 @@ impl ConnectionRef {
 
 impl Clone for ConnectionRef {
     fn clone(&self) -> Self {
-        self.state.lock("clone").ref_count += 1;
+        self.shared.ref_count.fetch_add(1, Ordering::Relaxed);
         Self(self.0.clone())
     }
 }
 
 impl Drop for ConnectionRef {
     fn drop(&mut self) {
-        let conn = &mut *self.state.lock("drop");
-        if let Some(x) = conn.ref_count.checked_sub(1) {
-            conn.ref_count = x;
-            if x == 0 && !conn.inner.is_closed() {
+        let ref_count = self.shared.ref_count.fetch_sub(1, Ordering::Relaxed);
+
+        if ref_count == 0 {
+            let conn = &mut *self.state.lock("drop");
+
+            if !conn.inner.is_closed() {
                 // If the driver is alive, it's just it and us, so we'd better shut it down. If it's
                 // not, we can't do any harm. If there were any streams being opened, then either
                 // the connection will be closed for an unrelated reason or a fresh reference will
@@ -963,6 +967,8 @@ pub(crate) struct Shared {
     datagram_received: Notify,
     datagrams_unblocked: Notify,
     closed: Notify,
+    /// Number of live handles that can used to initiate or handle I/O; excludes the driver
+    ref_count: AtomicUsize,
 }
 
 pub(crate) struct State {
@@ -981,8 +987,6 @@ pub(crate) struct State {
     pub(crate) stopped: FxHashMap<StreamId, Arc<Notify>>,
     /// Always set to Some before the connection becomes drained
     pub(crate) error: Option<ConnectionError>,
-    /// Number of live handles that can be used to initiate or handle I/O; excludes the driver
-    ref_count: usize,
     socket: Arc<dyn AsyncUdpSocket>,
     io_poller: Pin<Box<dyn UdpPoller>>,
     runtime: Arc<dyn Runtime>,

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -928,18 +928,18 @@ impl Clone for ConnectionRef {
 
 impl Drop for ConnectionRef {
     fn drop(&mut self) {
-        let ref_count = self.shared.ref_count.fetch_sub(1, Ordering::Relaxed);
+        if self.shared.ref_count.fetch_sub(1, Ordering::Relaxed) > 0 {
+            return;
+        }
 
-        if ref_count == 0 {
-            let conn = &mut *self.state.lock("drop");
+        let conn = &mut *self.state.lock("drop");
 
-            if !conn.inner.is_closed() {
-                // If the driver is alive, it's just it and us, so we'd better shut it down. If it's
-                // not, we can't do any harm. If there were any streams being opened, then either
-                // the connection will be closed for an unrelated reason or a fresh reference will
-                // be constructed for the newly opened stream.
-                conn.implicit_close(&self.shared);
-            }
+        if !conn.inner.is_closed() {
+            // If the driver is alive, it's just it and us, so we'd better shut it down. If it's
+            // not, we can't do any harm. If there were any streams being opened, then either
+            // the connection will be closed for an unrelated reason or a fresh reference will
+            // be constructed for the newly opened stream.
+            conn.implicit_close(&self.shared);
         }
     }
 }

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -8,7 +8,10 @@ use std::{
     net::{SocketAddr, SocketAddrV6},
     pin::Pin,
     str,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
     task::{Context, Poll, Waker},
 };
 
@@ -378,7 +381,9 @@ impl Future for EndpointDriver {
             self.0.shared.incoming.notify_waiters();
         }
 
-        if endpoint.ref_count == 0 && endpoint.recv_state.connections.is_empty() {
+        if self.0.shared.ref_count.load(Ordering::Relaxed) == 0
+            && endpoint.recv_state.connections.is_empty()
+        {
             Poll::Ready(Ok(()))
         } else {
             drop(endpoint);
@@ -475,8 +480,6 @@ pub(crate) struct State {
     driver: Option<Waker>,
     ipv6: bool,
     events: mpsc::UnboundedReceiver<(ConnectionHandle, EndpointEvent)>,
-    /// Number of live handles that can be used to initiate or handle I/O; excludes the driver
-    ref_count: usize,
     driver_lost: bool,
     runtime: Arc<dyn Runtime>,
     stats: EndpointStats,
@@ -486,6 +489,8 @@ pub(crate) struct State {
 pub(crate) struct Shared {
     incoming: Notify,
     idle: Notify,
+    /// Number of live handles that can be used to initiate or handle I/O; excludes the driver
+    ref_count: AtomicUsize,
 }
 
 impl State {
@@ -685,6 +690,7 @@ impl EndpointRef {
             shared: Shared {
                 incoming: Notify::new(),
                 idle: Notify::new(),
+                ref_count: AtomicUsize::new(0),
             },
             state: Mutex::new(State {
                 socket,
@@ -693,7 +699,6 @@ impl EndpointRef {
                 ipv6,
                 events,
                 driver: None,
-                ref_count: 0,
                 driver_lost: false,
                 recv_state,
                 runtime,
@@ -705,22 +710,21 @@ impl EndpointRef {
 
 impl Clone for EndpointRef {
     fn clone(&self) -> Self {
-        self.0.state.lock().unwrap().ref_count += 1;
+        self.0.shared.ref_count.fetch_add(1, Ordering::Relaxed);
         Self(self.0.clone())
     }
 }
 
 impl Drop for EndpointRef {
     fn drop(&mut self) {
-        let endpoint = &mut *self.0.state.lock().unwrap();
-        if let Some(x) = endpoint.ref_count.checked_sub(1) {
-            endpoint.ref_count = x;
-            if x == 0 {
-                // If the driver is about to be on its own, ensure it can shut down if the last
-                // connection is gone.
-                if let Some(task) = endpoint.driver.take() {
-                    task.wake();
-                }
+        let ref_count = self.shared.ref_count.fetch_sub(1, Ordering::Relaxed);
+
+        if ref_count == 0 {
+            let endpoint = &mut *self.0.state.lock().unwrap();
+            // If the driver is about to be on its own, ensure it can shut down if the last
+            // connection is gone.
+            if let Some(task) = endpoint.driver.take() {
+                task.wake();
             }
         }
     }

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -717,15 +717,15 @@ impl Clone for EndpointRef {
 
 impl Drop for EndpointRef {
     fn drop(&mut self) {
-        let ref_count = self.shared.ref_count.fetch_sub(1, Ordering::Relaxed);
+        if self.shared.ref_count.fetch_sub(1, Ordering::Relaxed) > 0 {
+            return;
+        }
 
-        if ref_count == 0 {
-            let endpoint = &mut *self.0.state.lock().unwrap();
-            // If the driver is about to be on its own, ensure it can shut down if the last
-            // connection is gone.
-            if let Some(task) = endpoint.driver.take() {
-                task.wake();
-            }
+        let endpoint = &mut *self.0.state.lock().unwrap();
+        // If the driver is about to be on its own, ensure it can shut down if the last
+        // connection is gone.
+        if let Some(task) = endpoint.driver.take() {
+            task.wake();
         }
     }
 }

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -717,7 +717,7 @@ impl Clone for EndpointRef {
 
 impl Drop for EndpointRef {
     fn drop(&mut self) {
-        if self.shared.ref_count.fetch_sub(1, Ordering::Relaxed) > 0 {
+        if self.shared.ref_count.fetch_sub(1, Ordering::Relaxed) > 1 {
             return;
         }
 

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -280,6 +280,9 @@ impl RecvStream {
         conn.inner.recv_stream(self.stream).stop(error_code)?;
         conn.wake();
         self.all_data_read = true;
+        // Clean up shared state that might be left over from a cancalled read
+        // operation, so `drop` doesn't have to
+        conn.blocked_readers.remove(&self.stream);
         Ok(())
     }
 

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -10,6 +10,7 @@ use std::{
     future::Future,
     io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
+    pin::pin,
     str,
     sync::{
         Arc,
@@ -27,8 +28,11 @@ use rustls::{
     RootCertStore,
     pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
 };
-use tokio::runtime::{Builder, Runtime};
 use tokio::time::{sleep, timeout};
+use tokio::{
+    join,
+    runtime::{Builder, Runtime},
+};
 use tracing::{error_span, info};
 use tracing_futures::Instrument as _;
 use tracing_subscriber::EnvFilter;
@@ -1006,6 +1010,52 @@ async fn stream_drop_removes_blocked_reader() {
 
         server_task.await.unwrap();
     }
+}
+
+/// Test that dropping a `RecvStream` after cancelling a read and then
+/// explicitly `stop`ing it doesn't panic.
+#[tokio::test]
+async fn recv_stream_cancel_stop_drop() {
+    let _guard = subscribe();
+    let factory = EndpointFactory::new();
+    let server = {
+        let _guard = error_span!("server").entered();
+        factory.endpoint()
+    };
+    let server_addr = server.local_addr().unwrap();
+
+    let client = {
+        let _guard = error_span!("client").entered();
+        factory.endpoint()
+    };
+    let recv_dropped = tokio::sync::SetOnce::new();
+    join!(
+        async {
+            let conn = server.accept().await.unwrap().await.unwrap();
+            let mut recv = conn.accept_uni().await.unwrap();
+            // Create a future to read from the stream, poll it once, then immediately drop it
+            {
+                let fut = pin!(recv.read_to_end(usize::MAX));
+                let mut cx = Context::from_waker(Waker::noop());
+                assert!(fut.poll(&mut cx).is_pending());
+            }
+            recv_dropped.set(()).unwrap();
+            recv.stop(0u32.into()).unwrap();
+        },
+        async {
+            let conn = client
+                .connect(server_addr, "localhost")
+                .unwrap()
+                .await
+                .unwrap();
+            let mut send = conn.open_uni().await.unwrap();
+            _ = send.write_all(b"hello").await;
+            // Don't drop (finish) the send stream until the read has been
+            // cancelled by the server, ensuring that read_to_end can't complete
+            // immediately.
+            recv_dropped.wait().await;
+        },
+    );
 }
 
 #[derive(Default)]

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -7,10 +7,15 @@ use rustls::crypto::ring::default_provider;
 
 use std::{
     convert::TryInto,
+    future::Future,
     io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
     str,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
 };
 
 use crate::runtime::TokioRuntime;
@@ -23,6 +28,7 @@ use rustls::{
     pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
 };
 use tokio::runtime::{Builder, Runtime};
+use tokio::time::{sleep, timeout};
 use tracing::{error_span, info};
 use tracing_futures::Instrument as _;
 use tracing_subscriber::EnvFilter;
@@ -158,7 +164,7 @@ fn read_after_close() {
             .unwrap()
             .await
             .expect("connect");
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(100)).await;
         let mut stream = new_conn.accept_uni().await.expect("incoming streams");
         let msg = stream.read_to_end(usize::MAX).await.expect("read_to_end");
         assert_eq!(msg, MSG);
@@ -901,8 +907,7 @@ async fn stream_stopped() {
         let stopped3 = stopped3.await;
         assert_eq!(stopped3, Ok(Some(42u32.into())));
     };
-    let client =
-        tokio::time::timeout(Duration::from_millis(100), client).instrument(error_span!("client"));
+    let client = timeout(Duration::from_millis(100), client).instrument(error_span!("client"));
     let server = async move {
         let conn = server.accept().await.unwrap().await.unwrap();
         let mut stream = conn.accept_uni().await.unwrap();
@@ -930,7 +935,7 @@ async fn stream_stopped_2() {
     )
     .unwrap();
     let send_stream = conn.open_uni().await.unwrap();
-    let stopped = tokio::time::timeout(Duration::from_millis(100), send_stream.stopped())
+    let stopped = timeout(Duration::from_millis(100), send_stream.stopped())
         .instrument(error_span!("stopped"));
     tokio::pin!(stopped);
     // poll the future once so that the waker is registered.
@@ -944,4 +949,113 @@ async fn stream_stopped_2() {
     // make sure the stopped future still resolves
     let res = stopped.await;
     assert_eq!(res, Ok(Ok(None)));
+}
+
+#[tokio::test]
+async fn stream_drop_removes_blocked_reader() {
+    let _guard = subscribe();
+
+    for drop_stream in [false, true] {
+        let endpoint_factory = EndpointFactory::new();
+        let server = endpoint_factory.endpoint();
+        let server_address = server.local_addr().unwrap();
+        let client = endpoint_factory.endpoint();
+
+        let server_task = tokio::spawn(async move {
+            let conn = server.accept().await.unwrap().await.unwrap();
+            let mut stream = conn.accept_uni().await.unwrap();
+
+            // read "hello"
+            let mut buf = [0u8; 5];
+            stream.read_exact(&mut buf).await.unwrap();
+
+            let (waker, wake_counter) = new_count_waker();
+            let mut cx = Context::from_waker(&waker);
+            // do a blocking read which will add the stream in conn.blocked_readers
+            {
+                let mut buf = [0u8; 64];
+                let read_fut = stream.read(&mut buf);
+                tokio::pin!(read_fut);
+                assert!(matches!(read_fut.as_mut().poll(&mut cx), Poll::Pending));
+            }
+
+            if !drop_stream {
+                assert_eq!(wake_counter.wakes(), 0);
+                // We have a blocked reader, closing the connection should wake it. We use this as
+                // a proxy to assert that the stream is in conn.blocked_readers.
+                conn.close(0u32.into(), b"done");
+                assert_eq!(wake_counter.wakes(), 1);
+            } else {
+                // dropping the stream should remove it from conn.blocked_readers, so we don't
+                // expect any wakeups
+                drop(stream);
+                assert_eq!(wake_counter.wakes(), 0, "no wakeups should have occurred");
+                conn.close(0u32.into(), b"done");
+                assert_eq!(wake_counter.wakes(), 0, "no wakeups should have occurred");
+            }
+        });
+
+        let conn = client
+            .connect(server_address, "localhost")
+            .unwrap()
+            .await
+            .unwrap();
+        let mut stream = conn.open_uni().await.unwrap();
+        // need to send some data to actually start the stream
+        stream.write_all(b"hello").await.unwrap();
+
+        server_task.await.unwrap();
+    }
+}
+
+#[derive(Default)]
+struct WakeCounter {
+    wakes: AtomicUsize,
+}
+
+impl WakeCounter {
+    fn wakes(&self) -> usize {
+        self.wakes.load(Ordering::SeqCst)
+    }
+}
+
+fn new_count_waker() -> (Waker, Arc<WakeCounter>) {
+    // instance of WakeCounter
+    let counter = Arc::new(WakeCounter::default());
+
+    // convert
+    let waker = unsafe { Waker::from_raw(raw_waker(counter.clone())) };
+    (waker, counter)
+}
+
+fn raw_waker(counter: Arc<WakeCounter>) -> RawWaker {
+    // Store an Arc<WakeCounter> behind the raw pointer.
+    let ptr = Arc::into_raw(counter) as *const ();
+    RawWaker::new(ptr, &VTABLE)
+}
+
+static VTABLE: RawWakerVTable =
+    RawWakerVTable::new(clone_waker, wake_waker, wake_by_ref_waker, drop_waker);
+
+unsafe fn clone_waker(data: *const ()) -> RawWaker {
+    let arc = Arc::<WakeCounter>::from_raw(data as *const WakeCounter);
+    let cloned = arc.clone();
+    std::mem::forget(arc);
+    raw_waker(cloned)
+}
+
+unsafe fn wake_waker(data: *const ()) {
+    let arc = Arc::<WakeCounter>::from_raw(data as *const WakeCounter);
+    arc.wakes.fetch_add(1, Ordering::SeqCst);
+    // arc drops here
+}
+
+unsafe fn wake_by_ref_waker(data: *const ()) {
+    let arc = Arc::<WakeCounter>::from_raw(data as *const WakeCounter);
+    arc.wakes.fetch_add(1, Ordering::SeqCst);
+    std::mem::forget(arc);
+}
+
+unsafe fn drop_waker(data: *const ()) {
+    drop(Arc::<WakeCounter>::from_raw(data as *const WakeCounter));
 }


### PR DESCRIPTION
Backport of "Add early return in RecvStream::drop when all data read is true" https://github.com/quinn-rs/quinn/pull/2495 to 0.11.x.

What's included: the original 3 commits:
  f6113170  Move the ref counts out  [ conflicts due to 'State struct' divergence were resolved manually ]
  298a7c18  Fix the (pre-existing) rightward drift by inverting conditions
  80914039  Early return in `RecvStream::drop()`
    
 and 2 related fixes:
  5a26dc36  Remove `RecvStream`s from `blocked_readers` on `stop`
  dfe72254  quinn: fix ref count logic for ConnectionRef and EndpointRef