### PR TITLE
Add rustls-no-provider

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -27,7 +27,7 @@ jobs:
         #       | paste -sd ',' -
         run: |
           cargo llvm-cov \
-            --features="arbitrary,async-io,async-std,aws-lc-rs,bloom,direct-log,fast-apple-datapath,futures-io,json-output,lock_tracking,log,platform-verifier,qlog,ring,runtime-async-std,runtime-smol,runtime-tokio,rustls,rustls-aws-lc-rs,rustls-log,rustls-ring,serde,serde_json,smol,tracing" \
+            --features="arbitrary,async-io,async-std,aws-lc-rs,bloom,direct-log,fast-apple-datapath,futures-io,json-output,lock_tracking,log,platform-verifier,qlog,ring,runtime-async-std,runtime-smol,runtime-tokio,rustls,rustls-no-provider,rustls-aws-lc-rs,rustls-log,rustls-ring,serde,serde_json,smol,tracing" \
             --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,6 +126,9 @@ jobs:
       - run: RUST_BACKTRACE=1 cargo test --locked --manifest-path quinn-proto/Cargo.toml --no-default-features --features rustls-aws-lc-rs-fips
       - run: RUST_BACKTRACE=1 cargo test --locked --manifest-path quinn/Cargo.toml --no-default-features --features rustls-aws-lc-rs-fips,runtime-tokio
       - run: RUST_BACKTRACE=1 cargo test --locked --manifest-path quinn/Cargo.toml --no-default-features --features rustls-aws-lc-rs-fips,__rustls-post-quantum-test,runtime-tokio
+      # Provider-neutral rustls integration
+      - run: RUST_BACKTRACE=1 cargo check --locked --manifest-path quinn/Cargo.toml --no-default-features --features rustls-no-provider,runtime-tokio
+      - run: RUST_BACKTRACE=1 cargo check --locked --manifest-path quinn-proto/Cargo.toml --no-default-features --features rustls-no-provider
 
   wasm_test:
     name: test wasm32-unknown-unknown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +643,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,6 +794,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,6 +878,25 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "darling"
@@ -1110,6 +1183,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,6 +1217,16 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1459,6 +1552,15 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1804,6 +1906,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1933,6 +2041,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2175,7 @@ dependencies = [
 name = "quinn-proto"
 version = "0.11.14"
 dependencies = [
+ "aes-gcm",
  "arbitrary",
  "assert_matches",
  "aws-lc-rs",
@@ -2929,10 +3050,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -2975,6 +3112,12 @@ name = "value-bag"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ arbitrary = { version = "1.0.1", features = ["derive"] }
 async-io = "2"
 async-std = "1.11"
 assert_matches = "1.1"
+aes-gcm = { version = "0.10", default-features = false, features = ["aes"] }
 aws-lc-rs = { version = "1.9", default-features = false }
 bencher = "0.1.5"
 bytes = "1"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,30 @@ The project was founded by [Dirkjan Ochtman](https://github.com/djc) and
 - Future-based async API
 - Minimum supported Rust version of 1.74.1
 
+## TLS and Crypto Features
+
+By default, Quinn enables `rustls-ring`, which uses [rustls][rustls] with the
+[ring][ring] crypto provider. Applications that want a different provider can
+disable default features and select one explicitly.
+
+- `rustls`: alias for `rustls-ring`, kept for backwards compatibility.
+- `rustls-aws-lc-rs`: enables rustls with the [aws-lc-rs]([aws-lc-rs]) provider.
+- `rustls-aws-lc-rs-fips`: enables rustls with [aws-lc-rs][aws-lc-rs] in FIPS mode.
+- `rustls-ring`: enables rustls with the [ring][ring] provider.
+- `rustls-no-provider`: enables Quinn's rustls integration without selecting a
+  rustls crypto provider.
+
+Use `rustls-no-provider` for applications that install a process-wide rustls
+`CryptoProvider` themselves, or that pass Quinn already-built rustls
+configuration values. Code using Quinn's rustls convenience constructors with
+`rustls-no-provider` must install a default provider before constructing those
+configs.
+
+The lower-level `aws-lc-rs` and `ring` features enable Quinn's direct use of
+those crates for transport helpers such as randomized endpoint and server
+configuration constructors. The provider-specific rustls features enable these
+direct features automatically.
+
 ## Overview
 
 - **quinn:** High-level async API based on tokio, see [examples][examples] for usage. This will be used by most developers. (Basic benchmarks are included.)
@@ -115,6 +139,7 @@ crates will always be at least 6 months old at the time of release.
 [quic]: https://quicwg.github.io/
 [issues]: https://github.com/djc/quinn/issues
 [rustls]: https://github.com/ctz/rustls
+[aws-lc-rs]: https://github.com/aws/aws-lc-rs
 [ring]: https://github.com/briansmith/ring
 [talk]: https://paris.rustfest.eu/sessions/a-quic-future-in-rust
 [slides]: https://github.com/djc/talks/blob/ff760845b51ba4836cce82e7f2c640ecb5fd59fa/2018-05-26%20A%20QUIC%20future%20in%20Rust/Quinn-Speaker.pdf

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -20,6 +20,8 @@ aws-lc-rs-fips = ["aws-lc-rs", "aws-lc-rs?/fips"]
 bloom = ["dep:fastbloom"]
 # For backwards compatibility, `rustls` forwards to `rustls-ring`
 rustls = ["rustls-ring"]
+# Enable rustls without selecting a crypto provider
+rustls-no-provider = ["dep:rustls", "dep:aes-gcm"]
 # Enable rustls with the `aws-lc-rs` crypto provider
 rustls-aws-lc-rs = ["dep:rustls", "rustls?/aws-lc-rs", "aws-lc-rs"]
 rustls-aws-lc-rs-fips = ["rustls-aws-lc-rs", "aws-lc-rs-fips"]
@@ -43,6 +45,7 @@ __rustls-post-quantum-test =  []
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }
+aes-gcm = { workspace = true, optional = true }
 aws-lc-rs = { workspace = true, optional = true }
 bytes = { workspace = true }
 fastbloom = { workspace = true, optional = true }
@@ -81,4 +84,4 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 
 [package.metadata.docs.rs]
 # all non-default features except fips (cannot build on docs.rs environment)
-features = ["rustls-aws-lc-rs", "rustls-ring", "platform-verifier", "log", "rustls-log"]
+features = ["rustls-no-provider", "rustls-aws-lc-rs", "rustls-ring", "platform-verifier", "log", "rustls-log"]

--- a/quinn-proto/src/config/mod.rs
+++ b/quinn-proto/src/config/mod.rs
@@ -5,7 +5,11 @@ use std::{
     sync::Arc,
 };
 
-#[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+#[cfg(any(
+    feature = "rustls-no-provider",
+    feature = "rustls-aws-lc-rs",
+    feature = "rustls-ring"
+))]
 use rustls::client::WebPkiServerVerifier;
 #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
@@ -16,7 +20,13 @@ use crate::BloomTokenLog;
 #[cfg(not(feature = "bloom"))]
 use crate::NoneTokenLog;
 #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
-use crate::crypto::rustls::{QuicServerConfig, configured_provider};
+use crate::crypto::rustls::QuicServerConfig;
+#[cfg(any(
+    feature = "rustls-no-provider",
+    feature = "rustls-aws-lc-rs",
+    feature = "rustls-ring"
+))]
+use crate::crypto::rustls::configured_provider;
 use crate::{
     DEFAULT_SUPPORTED_VERSIONS, Duration, MAX_CID_SIZE, RandomConnectionIdGenerator, SystemTime,
     TokenLog, TokenMemoryCache, TokenStore, VarInt, VarIntBoundsExceeded,
@@ -618,7 +628,11 @@ impl ClientConfig {
     }
 }
 
-#[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+#[cfg(any(
+    feature = "rustls-no-provider",
+    feature = "rustls-aws-lc-rs",
+    feature = "rustls-ring"
+))]
 impl ClientConfig {
     /// Create a client configuration that trusts the platform's native roots
     #[deprecated(since = "0.11.13", note = "use `try_with_platform_verifier()` instead")]

--- a/quinn-proto/src/crypto.rs
+++ b/quinn-proto/src/crypto.rs
@@ -2,8 +2,8 @@
 //!
 //! The protocol logic in Quinn is contained in types that abstract over the actual
 //! cryptographic protocol used. This module contains the traits used for this
-//! abstraction layer as well as a single implementation of these traits that uses
-//! *ring* and rustls to implement the TLS protocol support.
+//! abstraction layer as well as a single implementation of these traits that uses rustls to
+//! implement the TLS protocol support.
 //!
 //! Note that usage of any protocol (version) other than TLS 1.3 does not conform to any
 //! published versions of the specification, and will not be supported in QUIC v1.
@@ -21,7 +21,11 @@ use crate::{
 #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
 pub(crate) mod ring_like;
 /// TLS interface based on rustls
-#[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+#[cfg(any(
+    feature = "rustls-no-provider",
+    feature = "rustls-aws-lc-rs",
+    feature = "rustls-ring"
+))]
 pub mod rustls;
 
 /// A cryptographic session (commonly TLS)

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -1,5 +1,10 @@
 use std::{any::Any, io, str, sync::Arc};
 
+#[cfg(not(any(feature = "aws-lc-rs", feature = "ring")))]
+use aes_gcm::{
+    Aes128Gcm,
+    aead::{AeadInPlace, KeyInit},
+};
 #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
 use aws_lc_rs::aead;
 use bytes::BytesMut;
@@ -8,10 +13,12 @@ use ring::aead;
 pub use rustls::Error;
 #[cfg(feature = "__rustls-post-quantum-test")]
 use rustls::NamedGroup;
+#[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+use rustls::pki_types::PrivateKeyDer;
 use rustls::{
     self, CipherSuite,
     client::danger::ServerCertVerifier,
-    pki_types::{CertificateDer, PrivateKeyDer, ServerName},
+    pki_types::{CertificateDer, ServerName},
     quic::{Connection, HeaderProtectionKey, KeyChange, PacketKey, Secrets, Suite, Version},
 };
 #[cfg(feature = "platform-verifier")]
@@ -191,11 +198,8 @@ impl crypto::Session for TlsSession {
             _ => unreachable!(),
         };
 
-        let nonce = aead::Nonce::assume_unique_for_key(nonce);
-        let key = aead::LessSafeKey::new(aead::UnboundKey::new(&aead::AES_128_GCM, &key).unwrap());
-
         let (aad, tag) = pseudo_packet.split_at_mut(tag_start);
-        key.open_in_place(nonce, aead::Aad::from(aad), tag).is_ok()
+        is_valid_retry_tag(key, nonce, aad, tag)
     }
 
     fn export_keying_material(
@@ -443,6 +447,7 @@ pub struct QuicServerConfig {
 }
 
 impl QuicServerConfig {
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     pub(crate) fn new(
         cert_chain: Vec<CertificateDer<'static>>,
         key: PrivateKeyDer<'static>,
@@ -474,6 +479,7 @@ impl QuicServerConfig {
     /// QUIC requires that TLS 1.3 be enabled, and that the maximum early data size is either 0 or
     /// `u32::MAX`. Advanced users can use any [`rustls::ServerConfig`] that satisfies these
     /// requirements.
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     pub(crate) fn inner(
         cert_chain: Vec<CertificateDer<'static>>,
         key: PrivateKeyDer<'static>,
@@ -552,16 +558,61 @@ impl crypto::ServerConfig for QuicServerConfig {
         pseudo_packet.extend_from_slice(orig_dst_cid);
         pseudo_packet.extend_from_slice(packet);
 
-        let nonce = aead::Nonce::assume_unique_for_key(nonce);
-        let key = aead::LessSafeKey::new(aead::UnboundKey::new(&aead::AES_128_GCM, &key).unwrap());
-
-        let tag = key
-            .seal_in_place_separate_tag(nonce, aead::Aad::from(pseudo_packet), &mut [])
-            .unwrap();
-        let mut result = [0; 16];
-        result.copy_from_slice(tag.as_ref());
-        result
+        retry_tag(key, nonce, &pseudo_packet)
     }
+}
+
+#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+fn retry_tag(key: [u8; 16], nonce: [u8; 12], additional_data: &[u8]) -> [u8; 16] {
+    let nonce = aead::Nonce::assume_unique_for_key(nonce);
+    let key = aead::LessSafeKey::new(aead::UnboundKey::new(&aead::AES_128_GCM, &key).unwrap());
+
+    let tag = key
+        .seal_in_place_separate_tag(nonce, aead::Aad::from(additional_data), &mut [])
+        .unwrap();
+    let mut result = [0; 16];
+    result.copy_from_slice(tag.as_ref());
+    result
+}
+
+#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+fn is_valid_retry_tag(
+    key: [u8; 16],
+    nonce: [u8; 12],
+    additional_data: &[u8],
+    tag: &mut [u8],
+) -> bool {
+    let nonce = aead::Nonce::assume_unique_for_key(nonce);
+    let key = aead::LessSafeKey::new(aead::UnboundKey::new(&aead::AES_128_GCM, &key).unwrap());
+    key.open_in_place(nonce, aead::Aad::from(additional_data), tag)
+        .is_ok()
+}
+
+#[cfg(not(any(feature = "aws-lc-rs", feature = "ring")))]
+fn retry_tag(key: [u8; 16], nonce: [u8; 12], additional_data: &[u8]) -> [u8; 16] {
+    let key = aes_gcm::Key::<Aes128Gcm>::from_slice(&key);
+    let nonce = aes_gcm::Nonce::from_slice(&nonce);
+    let tag = Aes128Gcm::new(key)
+        .encrypt_in_place_detached(nonce, additional_data, &mut [])
+        .unwrap();
+    let mut result = [0; 16];
+    result.copy_from_slice(&tag);
+    result
+}
+
+#[cfg(not(any(feature = "aws-lc-rs", feature = "ring")))]
+fn is_valid_retry_tag(
+    key: [u8; 16],
+    nonce: [u8; 12],
+    additional_data: &[u8],
+    tag: &mut [u8],
+) -> bool {
+    let key = aes_gcm::Key::<Aes128Gcm>::from_slice(&key);
+    let nonce = aes_gcm::Nonce::from_slice(&nonce);
+    let tag = aes_gcm::Tag::from_slice(tag);
+    Aes128Gcm::new(key)
+        .decrypt_in_place_detached(nonce, additional_data, &mut [], tag)
+        .is_ok()
 }
 
 pub(crate) fn initial_suite_from_provider(
@@ -584,6 +635,11 @@ pub(crate) fn configured_provider() -> Arc<rustls::crypto::CryptoProvider> {
     let provider = rustls::crypto::aws_lc_rs::default_provider();
     #[cfg(feature = "rustls-ring")]
     let provider = rustls::crypto::ring::default_provider();
+    #[cfg(not(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring")))]
+    return rustls::crypto::CryptoProvider::get_default()
+        .cloned()
+        .expect("no process-level rustls CryptoProvider has been installed");
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     Arc::new(provider)
 }
 

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -27,6 +27,8 @@ lock_tracking = []
 platform-verifier = ["proto/platform-verifier"]
 # For backwards compatibility, `rustls` forwards to `rustls-ring`
 rustls = ["rustls-ring"]
+# Enable rustls without selecting a crypto provider
+rustls-no-provider = ["dep:rustls", "proto/rustls-no-provider"]
 # Enable rustls with the `aws-lc-rs` crypto provider
 rustls-aws-lc-rs = ["dep:rustls", "aws-lc-rs", "proto/rustls-aws-lc-rs", "proto/aws-lc-rs"]
 rustls-aws-lc-rs-fips = ["dep:rustls", "aws-lc-rs-fips", "proto/rustls-aws-lc-rs-fips", "proto/aws-lc-rs-fips"]
@@ -120,4 +122,4 @@ required-features = ["rustls-ring"]
 
 [package.metadata.docs.rs]
 # all non-default features except fips (cannot build on docs.rs environment)
-features = ["lock_tracking", "rustls-aws-lc-rs", "rustls-ring", "runtime-tokio", "runtime-async-std", "runtime-smol", "log", "rustls-log"]
+features = ["lock_tracking", "rustls-no-provider", "rustls-aws-lc-rs", "rustls-ring", "runtime-tokio", "runtime-async-std", "runtime-smol", "log", "rustls-log"]

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -70,7 +70,11 @@ pub use proto::{
 };
 #[cfg(feature = "qlog")]
 pub use proto::{QlogConfig, QlogStream};
-#[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+#[cfg(any(
+    feature = "rustls-no-provider",
+    feature = "rustls-aws-lc-rs",
+    feature = "rustls-ring"
+))]
 pub use rustls;
 pub use udp;
 


### PR DESCRIPTION
- Add: new crate feature `rustls-no-provider` in `quinn` and `quinn-proto`
- Closes: https://github.com/quinn-rs/quinn/issues/2341
- See also: https://github.com/seanmonstar/reqwest/issues/2935

This is my first quinn contribution, so I'm very open to feedback. I did my best to preserve  the existing structure and make this change as minimal as possible.

CC: @TroyKomodo is this something you can test for your use case? 