### PR TITLE
Abstract `Instant` for server-side WASM support

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -51,7 +51,7 @@ impl Connecting {
         endpoint_events: mpsc::UnboundedSender<(ConnectionHandle, EndpointEvent)>,
         conn_events: mpsc::UnboundedReceiver<ConnectionEvent>,
         sender: Pin<Box<dyn UdpSender>>,
-        runtime: Arc<dyn Runtime>,
+        runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
     ) -> Self {
         let (on_handshake_data_send, on_handshake_data_recv) = oneshot::channel();
 
@@ -1002,7 +1002,7 @@ pub(crate) struct State {
     on_handshake_data: Option<oneshot::Sender<()>>,
     connected: bool,
     handshake_confirmed: bool,
-    timer: Option<Pin<Box<dyn AsyncTimer>>>,
+    timer: Option<Pin<Box<dyn AsyncTimer<Instant = crate::Instant>>>>,
     timer_deadline: Option<Instant>,
     conn_events: mpsc::UnboundedReceiver<ConnectionEvent>,
     endpoint_events: mpsc::UnboundedSender<(ConnectionHandle, EndpointEvent)>,
@@ -1012,7 +1012,7 @@ pub(crate) struct State {
     /// Always set to Some before the connection becomes drained
     pub(crate) error: Option<ConnectionError>,
     sender: Pin<Box<dyn UdpSender>>,
-    runtime: Arc<dyn Runtime>,
+    runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
     send_buffer: Vec<u8>,
     /// We buffer a transmit when the underlying I/O would block
     buffered_transmit: Option<proto::Transmit>,
@@ -1027,7 +1027,7 @@ impl State {
         conn_events: mpsc::UnboundedReceiver<ConnectionEvent>,
         on_handshake_data: oneshot::Sender<()>,
         sender: Pin<Box<dyn UdpSender>>,
-        runtime: Arc<dyn Runtime>,
+        runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
     ) -> Self {
         Self {
             inner,

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -51,7 +51,7 @@ impl Connecting {
         endpoint_events: mpsc::UnboundedSender<(ConnectionHandle, EndpointEvent)>,
         conn_events: mpsc::UnboundedReceiver<ConnectionEvent>,
         sender: Pin<Box<dyn UdpSender>>,
-        runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
+        runtime: Arc<dyn Runtime<Instant = Instant>>,
     ) -> Self {
         let (on_handshake_data_send, on_handshake_data_recv) = oneshot::channel();
 
@@ -1002,7 +1002,7 @@ pub(crate) struct State {
     on_handshake_data: Option<oneshot::Sender<()>>,
     connected: bool,
     handshake_confirmed: bool,
-    timer: Option<Pin<Box<dyn AsyncTimer<Instant = crate::Instant>>>>,
+    timer: Option<Pin<Box<dyn AsyncTimer<Instant = Instant>>>>,
     timer_deadline: Option<Instant>,
     conn_events: mpsc::UnboundedReceiver<ConnectionEvent>,
     endpoint_events: mpsc::UnboundedSender<(ConnectionHandle, EndpointEvent)>,
@@ -1012,7 +1012,7 @@ pub(crate) struct State {
     /// Always set to Some before the connection becomes drained
     pub(crate) error: Option<ConnectionError>,
     sender: Pin<Box<dyn UdpSender>>,
-    runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
+    runtime: Arc<dyn Runtime<Instant = Instant>>,
     send_buffer: Vec<u8>,
     /// We buffer a transmit when the underlying I/O would block
     buffered_transmit: Option<proto::Transmit>,
@@ -1027,7 +1027,7 @@ impl State {
         conn_events: mpsc::UnboundedReceiver<ConnectionEvent>,
         on_handshake_data: oneshot::Sender<()>,
         sender: Pin<Box<dyn UdpSender>>,
-        runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
+        runtime: Arc<dyn Runtime<Instant = Instant>>,
     ) -> Self {
         Self {
             inner,

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -56,7 +56,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct Endpoint {
     pub(crate) inner: EndpointRef,
-    runtime: Arc<dyn Runtime>,
+    runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
 }
 
 impl Endpoint {
@@ -148,7 +148,7 @@ impl Endpoint {
         config: EndpointConfig,
         server_config: Option<ServerConfig>,
         socket: std::net::UdpSocket,
-        runtime: Arc<dyn Runtime>,
+        runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
     ) -> io::Result<Self> {
         let socket = runtime.wrap_udp_socket(socket)?;
         Self::new_with_abstract_socket(config, server_config, socket, runtime)
@@ -162,7 +162,7 @@ impl Endpoint {
         config: EndpointConfig,
         server_config: Option<ServerConfig>,
         socket: Box<dyn AsyncUdpSocket>,
-        runtime: Arc<dyn Runtime>,
+        runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
     ) -> io::Result<Self> {
         let addr = socket.local_addr()?;
         let allow_mtud = !socket.may_fragment();
@@ -508,7 +508,7 @@ pub(crate) struct State {
     ipv6: bool,
     events: mpsc::UnboundedReceiver<(ConnectionHandle, EndpointEvent)>,
     driver_lost: bool,
-    runtime: Arc<dyn Runtime>,
+    runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
     stats: EndpointStats,
     default_client_config: Option<ClientConfig>,
 }
@@ -673,7 +673,7 @@ impl ConnectionSet {
         handle: ConnectionHandle,
         conn: proto::Connection,
         sender: Pin<Box<dyn UdpSender>>,
-        runtime: Arc<dyn Runtime>,
+        runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
     ) -> Connecting {
         let (send, recv) = mpsc::unbounded_channel();
         if let Some((error_code, ref reason)) = self.close {
@@ -746,7 +746,7 @@ impl EndpointRef {
         socket: Box<dyn AsyncUdpSocket>,
         inner: proto::Endpoint,
         ipv6: bool,
-        runtime: Arc<dyn Runtime>,
+        runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
     ) -> Self {
         let (sender, events) = mpsc::unbounded_channel();
         let recv_state = RecvState::new(sender, socket.max_receive_segments(), &inner);
@@ -842,7 +842,7 @@ impl RecvState {
         endpoint: &mut proto::Endpoint,
         socket: &mut dyn AsyncUdpSocket,
         sender: &mut Pin<Box<dyn UdpSender>>,
-        runtime: &dyn Runtime,
+        runtime: &dyn Runtime<Instant = crate::Instant>,
         now: Instant,
     ) -> Result<PollProgress, io::Error> {
         let mut received_connection_packet = false;

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -56,7 +56,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct Endpoint {
     pub(crate) inner: EndpointRef,
-    runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
+    runtime: Arc<dyn Runtime<Instant = Instant>>,
 }
 
 impl Endpoint {
@@ -148,7 +148,7 @@ impl Endpoint {
         config: EndpointConfig,
         server_config: Option<ServerConfig>,
         socket: std::net::UdpSocket,
-        runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
+        runtime: Arc<dyn Runtime<Instant = Instant>>,
     ) -> io::Result<Self> {
         let socket = runtime.wrap_udp_socket(socket)?;
         Self::new_with_abstract_socket(config, server_config, socket, runtime)
@@ -162,7 +162,7 @@ impl Endpoint {
         config: EndpointConfig,
         server_config: Option<ServerConfig>,
         socket: Box<dyn AsyncUdpSocket>,
-        runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
+        runtime: Arc<dyn Runtime<Instant = Instant>>,
     ) -> io::Result<Self> {
         let addr = socket.local_addr()?;
         let allow_mtud = !socket.may_fragment();
@@ -508,7 +508,7 @@ pub(crate) struct State {
     ipv6: bool,
     events: mpsc::UnboundedReceiver<(ConnectionHandle, EndpointEvent)>,
     driver_lost: bool,
-    runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
+    runtime: Arc<dyn Runtime<Instant = Instant>>,
     stats: EndpointStats,
     default_client_config: Option<ClientConfig>,
 }
@@ -673,7 +673,7 @@ impl ConnectionSet {
         handle: ConnectionHandle,
         conn: proto::Connection,
         sender: Pin<Box<dyn UdpSender>>,
-        runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
+        runtime: Arc<dyn Runtime<Instant = Instant>>,
     ) -> Connecting {
         let (send, recv) = mpsc::unbounded_channel();
         if let Some((error_code, ref reason)) = self.close {
@@ -746,7 +746,7 @@ impl EndpointRef {
         socket: Box<dyn AsyncUdpSocket>,
         inner: proto::Endpoint,
         ipv6: bool,
-        runtime: Arc<dyn Runtime<Instant = crate::Instant>>,
+        runtime: Arc<dyn Runtime<Instant = Instant>>,
     ) -> Self {
         let (sender, events) = mpsc::unbounded_channel();
         let recv_state = RecvState::new(sender, socket.max_receive_segments(), &inner);
@@ -842,7 +842,7 @@ impl RecvState {
         endpoint: &mut proto::Endpoint,
         socket: &mut dyn AsyncUdpSocket,
         sender: &mut Pin<Box<dyn UdpSender>>,
-        runtime: &dyn Runtime<Instant = crate::Instant>,
+        runtime: &dyn Runtime<Instant = Instant>,
         now: Instant,
     ) -> Result<PollProgress, io::Error> {
         let mut received_connection_packet = false;

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -85,7 +85,7 @@ pub use crate::runtime::SmolRuntime;
 pub use crate::runtime::TokioRuntime;
 #[cfg(any(feature = "runtime-tokio", feature = "runtime-smol"))]
 pub use crate::runtime::default_runtime;
-pub use crate::runtime::{AsyncTimer, AsyncUdpSocket, Runtime, UdpSender};
+pub use crate::runtime::{AsyncTimer, AsyncUdpSocket, Runtime, RuntimeInstant, UdpSender};
 pub use crate::send_stream::{SendStream, StoppedError, WriteError};
 
 #[cfg(test)]

--- a/quinn/src/runtime/mod.rs
+++ b/quinn/src/runtime/mod.rs
@@ -11,12 +11,48 @@ use std::{
 
 use udp::{RecvMeta, Transmit};
 
-use crate::Instant;
+/// Abstracts the `Instant` type for server-side WASM environments that require their own
+/// timer implementations.
+pub trait RuntimeInstant: Clone {
+    /// The `Duration` type used by the abstraction
+    type Duration;
+
+    /// Returns an instant corresponding to "now".
+    fn now() -> Self;
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or zero duration if that instant is later than this one.
+    fn duration_since(&self, earlier: Self) -> Self::Duration;
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or None if that instant is later than this one.
+    fn checked_duration_since(&self, earlier: Self) -> Option<Self::Duration>;
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or zero duration if that instant is later than this one.
+    fn saturating_duration_since(&self, earlier: Self) -> Self::Duration;
+
+    /// Returns the amount of time elapsed since this instant.
+    fn elapsed(&self) -> Self::Duration;
+
+    /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as
+    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    fn checked_add(&self, duration: Self::Duration) -> Option<Self>;
+
+    /// Returns `Some(t)` where `t` is the time `self - duration` if `t` can be represented as
+    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    fn checked_sub(&self, duration: Self::Duration) -> Option<Self>;
+}
 
 /// Abstracts I/O and timer operations for runtime independence
 pub trait Runtime: Send + Sync + Debug + 'static {
+    /// Abstracts the `Instant` type for server-side WASM environments
+    type Instant: RuntimeInstant;
+
     /// Construct a timer that will expire at `i`
-    fn new_timer(&self, i: Instant) -> Pin<Box<dyn AsyncTimer>>;
+    fn new_timer(&self, i: Self::Instant) -> Pin<Box<dyn AsyncTimer<Instant = Self::Instant>>>;
     /// Drive `future` to completion in the background
     #[track_caller]
     fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>);
@@ -26,15 +62,18 @@ pub trait Runtime: Send + Sync + Debug + 'static {
     /// Look up the current time
     ///
     /// Allows simulating the flow of time for testing.
-    fn now(&self) -> Instant {
-        Instant::now()
+    fn now(&self) -> Self::Instant {
+        Self::Instant::now()
     }
 }
 
 /// Abstract implementation of an async timer for runtime independence
 pub trait AsyncTimer: Send + Debug + 'static {
+    /// Abstracts the `Instant` type for server-side WASM environments
+    type Instant: RuntimeInstant;
+
     /// Update the timer to expire at `i`
-    fn reset(self: Pin<&mut Self>, i: Instant);
+    fn reset(self: Pin<&mut Self>, i: Self::Instant);
     /// Check whether the timer has expired, and register to be woken if not
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()>;
 }
@@ -214,6 +253,72 @@ trait UdpSenderHelperSocket: Send + Sync + 'static {
     fn max_transmit_segments(&self) -> usize;
 }
 
+#[cfg(not(wasm_browser))]
+impl RuntimeInstant for std::time::Instant {
+    type Duration = std::time::Duration;
+
+    fn now() -> Self {
+        std::time::Instant::now()
+    }
+
+    fn duration_since(&self, earlier: Self) -> Self::Duration {
+        std::time::Instant::duration_since(self, earlier)
+    }
+
+    fn checked_duration_since(&self, earlier: Self) -> Option<Self::Duration> {
+        std::time::Instant::checked_duration_since(self, earlier)
+    }
+
+    fn saturating_duration_since(&self, earlier: Self) -> Self::Duration {
+        std::time::Instant::saturating_duration_since(self, earlier)
+    }
+
+    fn elapsed(&self) -> Self::Duration {
+        std::time::Instant::elapsed(self)
+    }
+
+    fn checked_add(&self, duration: Self::Duration) -> Option<Self> {
+        std::time::Instant::checked_add(self, duration)
+    }
+
+    fn checked_sub(&self, duration: Self::Duration) -> Option<Self> {
+        std::time::Instant::checked_sub(self, duration)
+    }
+}
+
+#[cfg(wasm_browser)]
+impl RuntimeInstant for web_time::Instant {
+    type Duration = web_time::Duration;
+
+    fn now() -> Self {
+        web_time::Instant::now()
+    }
+
+    fn duration_since(&self, earlier: Self) -> Self::Duration {
+        web_time::Instant::duration_since(self, earlier)
+    }
+
+    fn checked_duration_since(&self, earlier: Self) -> Option<Self::Duration> {
+        web_time::Instant::checked_duration_since(self, earlier)
+    }
+
+    fn saturating_duration_since(&self, earlier: Self) -> Self::Duration {
+        web_time::Instant::saturating_duration_since(self, earlier)
+    }
+
+    fn elapsed(&self) -> Self::Duration {
+        web_time::Instant::elapsed(self)
+    }
+
+    fn checked_add(&self, duration: Self::Duration) -> Option<Self> {
+        web_time::Instant::checked_add(self, duration)
+    }
+
+    fn checked_sub(&self, duration: Self::Duration) -> Option<Self> {
+        web_time::Instant::checked_sub(self, duration)
+    }
+}
+
 /// Automatically select an appropriate runtime from those enabled at compile time
 ///
 /// If `runtime-tokio` is enabled and this function is called from within a Tokio runtime context,
@@ -221,7 +326,7 @@ trait UdpSenderHelperSocket: Send + Sync + 'static {
 /// returned. Otherwise, `None` is returned.
 #[cfg(any(feature = "runtime-tokio", feature = "runtime-smol"))]
 #[allow(clippy::needless_return)] // Be sure we return the right thing
-pub fn default_runtime() -> Option<Arc<dyn Runtime>> {
+pub fn default_runtime() -> Option<Arc<dyn Runtime<Instant = crate::Instant>>> {
     #[cfg(feature = "runtime-tokio")]
     {
         if ::tokio::runtime::Handle::try_current().is_ok() {

--- a/quinn/src/runtime/mod.rs
+++ b/quinn/src/runtime/mod.rs
@@ -258,31 +258,31 @@ impl RuntimeInstant for std::time::Instant {
     type Duration = std::time::Duration;
 
     fn now() -> Self {
-        std::time::Instant::now()
+        Self::now()
     }
 
     fn duration_since(&self, earlier: Self) -> Self::Duration {
-        std::time::Instant::duration_since(self, earlier)
+        Self::duration_since(self, earlier)
     }
 
     fn checked_duration_since(&self, earlier: Self) -> Option<Self::Duration> {
-        std::time::Instant::checked_duration_since(self, earlier)
+        Self::checked_duration_since(self, earlier)
     }
 
     fn saturating_duration_since(&self, earlier: Self) -> Self::Duration {
-        std::time::Instant::saturating_duration_since(self, earlier)
+        Self::saturating_duration_since(self, earlier)
     }
 
     fn elapsed(&self) -> Self::Duration {
-        std::time::Instant::elapsed(self)
+        Self::elapsed(self)
     }
 
     fn checked_add(&self, duration: Self::Duration) -> Option<Self> {
-        std::time::Instant::checked_add(self, duration)
+        Self::checked_add(self, duration)
     }
 
     fn checked_sub(&self, duration: Self::Duration) -> Option<Self> {
-        std::time::Instant::checked_sub(self, duration)
+        Self::checked_sub(self, duration)
     }
 }
 

--- a/quinn/src/runtime/smol.rs
+++ b/quinn/src/runtime/smol.rs
@@ -17,7 +17,9 @@ use super::{AsyncUdpSocket, Runtime, UdpSender, UdpSenderHelper, UdpSenderHelper
 pub struct SmolRuntime;
 
 impl Runtime for SmolRuntime {
-    fn new_timer(&self, t: Instant) -> Pin<Box<dyn AsyncTimer>> {
+    type Instant = Instant;
+
+    fn new_timer(&self, t: Instant) -> Pin<Box<dyn AsyncTimer<Instant = Self::Instant>>> {
         Box::pin(Timer::at(t))
     }
 
@@ -31,6 +33,8 @@ impl Runtime for SmolRuntime {
 }
 
 impl AsyncTimer for Timer {
+    type Instant = Instant;
+
     fn reset(mut self: Pin<&mut Self>, t: Instant) {
         self.set_at(t)
     }

--- a/quinn/src/runtime/tokio.rs
+++ b/quinn/src/runtime/tokio.rs
@@ -19,7 +19,9 @@ use super::{AsyncTimer, AsyncUdpSocket, Runtime, UdpSenderHelper, UdpSenderHelpe
 pub struct TokioRuntime;
 
 impl Runtime for TokioRuntime {
-    fn new_timer(&self, t: Instant) -> Pin<Box<dyn AsyncTimer>> {
+    type Instant = Instant;
+
+    fn new_timer(&self, t: Instant) -> Pin<Box<dyn AsyncTimer<Instant = Self::Instant>>> {
         Box::pin(sleep_until(t.into()))
     }
 
@@ -40,6 +42,8 @@ impl Runtime for TokioRuntime {
 }
 
 impl AsyncTimer for Sleep {
+    type Instant = Instant;
+
     fn reset(self: Pin<&mut Self>, t: Instant) {
         Self::reset(self, t.into())
     }


### PR DESCRIPTION
When building for `wasm(n)` targets, Quinn defaults to `web_time::Instant`, which only works when run inside the browser. For server-side runtime environments, e.g. `wasmtime`, `wasmer` etc. we need a different abstraction.

This PR allows implementors to provide that abstraction.