### PR TITLE
quinn-proto: Fix RTT measurements with max_ack_delay timer resolution

### DIFF
--- a/quinn-proto/src/connection/ack_frequency.rs
+++ b/quinn-proto/src/connection/ack_frequency.rs
@@ -17,7 +17,7 @@ pub(super) struct AckFrequencyState {
     // Receiving ACK_FREQUENCY frames
     //
     last_ack_frequency_frame: Option<u64>,
-    pub(super) max_ack_delay: Duration,
+    max_ack_delay: Duration,
 }
 
 impl AckFrequencyState {
@@ -30,6 +30,15 @@ impl AckFrequencyState {
             last_ack_frequency_frame: None,
             max_ack_delay: default_max_ack_delay,
         }
+    }
+
+    /// Returns the duration after which a delayed ACK must be sent
+    ///
+    /// One timer granularity shorter than the `max_ack_delay` the peer subtracts from its RTT
+    /// samples, so that late-firing alarms don't push the actual delay past that bound
+    /// (RFC 9000 §18.2 expects advertised `max_ack_delay` to absorb alarm slop).
+    pub(super) fn max_ack_delay_timer(&self) -> Duration {
+        self.max_ack_delay.saturating_sub(TIMER_GRANULARITY)
     }
 
     /// Returns the `max_ack_delay` that should be requested of the peer when sending an

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3027,7 +3027,7 @@ impl Connection {
                     // timeout
                     if let Some(timeout) = space
                         .pending_acks
-                        .max_ack_delay_timeout(self.ack_frequency.max_ack_delay)
+                        .max_ack_delay_timeout(self.ack_frequency.max_ack_delay_timer())
                     {
                         self.timers.set(Timer::MaxAckDelay, timeout);
                     }
@@ -3058,8 +3058,10 @@ impl Connection {
             .pending_acks
             .packet_received(now, number, ack_eliciting, &space.dedup)
         {
-            self.timers
-                .set(Timer::MaxAckDelay, now + self.ack_frequency.max_ack_delay);
+            self.timers.set(
+                Timer::MaxAckDelay,
+                now + self.ack_frequency.max_ack_delay_timer(),
+            );
         }
 
         // Issue stream ID credit due to ACKs of outgoing finish/resets and incoming finish/resets

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -467,3 +467,38 @@ impl InFlight {
         self.ack_eliciting -= u64::from(packet.ack_eliciting);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rtt_first_sample_ignores_ack_delay() {
+        let mut rtt = RttEstimator::new(Duration::from_millis(333));
+        rtt.update(Duration::from_millis(10), Duration::from_micros(100));
+        assert_eq!(rtt.get(), Duration::from_micros(100));
+        assert_eq!(rtt.min(), Duration::from_micros(100));
+        assert_eq!(rtt.var, Duration::from_micros(50));
+    }
+
+    #[test]
+    fn rtt_subtracts_ack_delay_when_above_min() {
+        let mut rtt = RttEstimator::new(Duration::from_millis(333));
+        rtt.update(Duration::ZERO, Duration::from_micros(100));
+        // Raw sample 25.2ms with 25ms ack delay adjusts to 200µs
+        rtt.update(Duration::from_millis(25), Duration::from_micros(25_200));
+        assert_eq!(rtt.get(), Duration::from_nanos((7 * 100_000 + 200_000) / 8));
+        assert_eq!(rtt.min(), Duration::from_micros(100));
+    }
+
+    #[test]
+    fn rtt_min_tracks_raw_samples() {
+        let mut rtt = RttEstimator::new(Duration::from_millis(333));
+        rtt.update(Duration::ZERO, Duration::from_micros(100));
+        rtt.update(Duration::ZERO, Duration::from_micros(50));
+        assert_eq!(rtt.min(), Duration::from_micros(50));
+        // min ignores ack delay: a 60µs raw sample does not lower it further
+        rtt.update(Duration::from_micros(40), Duration::from_micros(60));
+        assert_eq!(rtt.min(), Duration::from_micros(50));
+    }
+}

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -349,11 +349,13 @@ impl RttEstimator {
         self.min = cmp::min(self.min, self.latest);
         // Based on RFC6298.
         if let Some(smoothed) = self.smoothed {
-            let adjusted_rtt = if self.min + ack_delay <= self.latest {
-                self.latest - ack_delay
-            } else {
-                self.latest
-            };
+            // RFC 9002 §5.3 forbids subtracting ack_delay if the result would fall below
+            // min_rtt. We clamp to min_rtt rather than falling back to the raw sample
+            // (Appendix A.7, non-normative): ack_delay includes receiver processing time
+            // that min_rtt also contains, so on low-RTT paths the honest adjustment
+            // routinely lands below min_rtt and the raw fallback would feed the entire
+            // ack delay (typically max_ack_delay, ~25ms) into the smoothed RTT.
+            let adjusted_rtt = cmp::max(self.min, self.latest.saturating_sub(ack_delay));
             let var_sample = smoothed.abs_diff(adjusted_rtt);
             self.var = (3 * self.var + var_sample) / 4;
             self.smoothed = Some((7 * smoothed + adjusted_rtt) / 8);
@@ -489,6 +491,26 @@ mod tests {
         rtt.update(Duration::from_millis(25), Duration::from_micros(25_200));
         assert_eq!(rtt.get(), Duration::from_nanos((7 * 100_000 + 200_000) / 8));
         assert_eq!(rtt.min(), Duration::from_micros(100));
+    }
+
+    #[test]
+    fn rtt_clamps_adjusted_sample_to_min() {
+        let mut rtt = RttEstimator::new(Duration::from_millis(333));
+        rtt.update(Duration::ZERO, Duration::from_micros(80));
+        // Honest adjustment (26.1ms - 26.05ms = 50µs) lands below min_rtt (80µs) because
+        // ack_delay includes receiver processing time that min_rtt also contains. The
+        // sample must clamp to min_rtt, not fall back to the raw 26.1ms.
+        rtt.update(Duration::from_micros(26_050), Duration::from_micros(26_100));
+        assert_eq!(rtt.get(), Duration::from_micros(80));
+        assert_eq!(rtt.min(), Duration::from_micros(80));
+    }
+
+    #[test]
+    fn rtt_ack_delay_exceeding_sample_saturates() {
+        let mut rtt = RttEstimator::new(Duration::from_millis(333));
+        rtt.update(Duration::ZERO, Duration::from_micros(80));
+        rtt.update(Duration::from_millis(30), Duration::from_millis(10));
+        assert_eq!(rtt.get(), Duration::from_micros(80));
     }
 
     #[test]

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -26,7 +26,7 @@ use tracing::info;
 
 use super::*;
 use crate::{
-    Duration, Instant,
+    Duration, Instant, TIMER_GRANULARITY,
     cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator},
     crypto::rustls::QuicServerConfig,
     frame::FrameStruct,
@@ -2652,11 +2652,12 @@ fn single_ack_eliciting_packet_triggers_ack_after_delay() {
         1
     );
 
-    // The time is start + max_ack_delay
+    // The timer is armed one granularity early so late-firing alarms stay within the
+    // max_ack_delay the peer subtracts from its RTT samples
     let default_max_ack_delay_ms = TransportParameters::default().max_ack_delay.into_inner();
     assert_eq!(
         pair.time,
-        start + Duration::from_millis(default_max_ack_delay_ms)
+        start + Duration::from_millis(default_max_ack_delay_ms) - TIMER_GRANULARITY
     );
 
     // The ACK delay is properly calculated
@@ -2669,7 +2670,10 @@ fn single_ack_eliciting_packet_triggers_ack_after_delay() {
     if let Frame::Ack(ack) = frames.remove(0) {
         let ack_delay_exp = TransportParameters::default().ack_delay_exponent;
         let delay = ack.delay << ack_delay_exp.into_inner();
-        assert_eq!(delay, default_max_ack_delay_ms * 1_000);
+        assert_eq!(
+            delay,
+            default_max_ack_delay_ms * 1_000 - TIMER_GRANULARITY.as_micros() as u64
+        );
     } else {
         panic!("Expected ACK frame");
     }
@@ -2885,7 +2889,10 @@ fn ack_frequency_ack_delayed_from_first_of_flight() {
 #[test]
 fn ack_frequency_ack_sent_after_max_ack_delay() {
     let _guard = subscribe();
-    let max_ack_delay = Duration::from_millis(30);
+    // Must stay below MIN_AUTOMATIC_ACK_DELAY: `candidate_max_ack_delay` clamps larger
+    // requests down, which would silently decouple this test's arithmetic from the
+    // delay actually in effect
+    let max_ack_delay = Duration::from_millis(20);
     let (mut pair, client_ch, server_ch) = setup_ack_frequency_test(max_ack_delay);
 
     // Client sends a ping
@@ -2906,8 +2913,18 @@ fn ack_frequency_ack_sent_after_max_ack_delay() {
         0
     );
 
-    // Server: send an ack after max_ack_delay has elapsed
-    pair.time += max_ack_delay;
+    // Server: still no ACK one granularity before the early-armed timer's deadline
+    pair.time += max_ack_delay - 2 * TIMER_GRANULARITY;
+    let server_stats_before = pair.server_conn_mut(server_ch).stats();
+    pair.drive_server();
+    let server_stats_after = pair.server_conn_mut(server_ch).stats();
+    assert_eq!(
+        server_stats_after.frame_tx.acks - server_stats_before.frame_tx.acks,
+        0
+    );
+
+    // Server: send an ack once the timer fires, one granularity before max_ack_delay
+    pair.time += TIMER_GRANULARITY;
     let server_stats_before = pair.server_conn_mut(server_ch).stats();
     pair.drive_server();
     let server_stats_after = pair.server_conn_mut(server_ch).stats();

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -2674,6 +2674,11 @@ fn single_ack_eliciting_packet_triggers_ack_after_delay() {
             delay,
             default_max_ack_delay_ms * 1_000 - TIMER_GRANULARITY.as_micros() as u64
         );
+        // The reported delay fits under the advertised max_ack_delay (timer base plus one
+        // granularity of alarm headroom), so the peer's RFC 9002 §5.3 clamp discards none of it
+        let advertised_max_ack_delay_us =
+            (default_max_ack_delay_ms + TIMER_GRANULARITY.as_millis() as u64) * 1_000;
+        assert!(delay <= advertised_max_ack_delay_us);
     } else {
         panic!("Expected ACK frame");
     }

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -171,6 +171,13 @@ impl TransportParameters {
                 .datagram_receive_buffer_size
                 .map(|x| (x.min(u16::MAX.into()) as u16).into()),
             grease_quic_bit: endpoint_config.grease_quic_bit,
+            // One granularity above the timer base the MaxAckDelay timer is derived from:
+            // RFC 9000 §18.2 says the advertisement SHOULD include "the receiver's expected
+            // delays in alarms firing", and the peer clamps the ack delay it subtracts from
+            // RTT samples to this value, so alarm slop must fit under it
+            max_ack_delay: VarInt(
+                Self::default().max_ack_delay.0 + TIMER_GRANULARITY.as_millis() as u64,
+            ),
             min_ack_delay: Some(
                 VarInt::from_u64(u64::try_from(TIMER_GRANULARITY.as_micros()).unwrap()).unwrap(),
             ),
@@ -751,6 +758,22 @@ mod test {
         assert_eq!(
             TransportParameters::read(Side::Client, &mut buf.as_slice()).unwrap(),
             params
+        );
+    }
+
+    #[test]
+    fn advertised_max_ack_delay_includes_alarm_headroom() {
+        let params = TransportParameters::new(
+            &TransportConfig::default(),
+            &EndpointConfig::default(),
+            &crate::cid_generator::RandomConnectionIdGenerator::default(),
+            ConnectionId::new(&[]),
+            None,
+            &mut rand::rng(),
+        );
+        assert_eq!(
+            params.max_ack_delay.0,
+            TransportParameters::default().max_ack_delay.0 + TIMER_GRANULARITY.as_millis() as u64
         );
     }
 


### PR DESCRIPTION
Because tokio timers are roughly 0-2ms late (uniform distribution in my testing), the max_ack_delay can sometimes be 2ms late (1ms on average). I found the following scenario would play out:

1. sender sends a packet to receiver
2. receiver receives a packet, queues an ACK
3. receiver sleeps for 25ms (max_ack_delay)
4. receiver wakes up at 26.5s (1.5ms late)
5. ACK is sent with delay=26500 us
6. sender clamps the [delay back down to 25ms (max_ack_delay)](https://github.com/quinn-rs/quinn/blob/2c315aa7f9c2a6c1db87f8f51f40623a427c78fd/quinn-proto/src/connection/mod.rs#L1516-L1519)
7. sender RTT ends up inflated by 1.5ms

I saw the following guidance in https://www.rfc-editor.org/rfc/rfc9000.html#section-18.2-4.28.1
> The maximum acknowledgment delay is an integer value indicating the maximum amount of time in milliseconds by which the endpoint will delay sending acknowledgments. This value SHOULD include the receiver's expected delays in alarms firing. For example, if a receiver sets a timer for 5ms and alarms commonly fire up to 1ms late, then it should send a max_ack_delay of 6ms.

So, if we expect a 1ms delay, we should add that to the the reported max_ack_delay.

However, I (well, Claude Fable 5) found a potential issue when testing this. From the following https://www.rfc-editor.org/rfc/rfc9002.html#section-5.3-7.4

> MUST NOT subtract the acknowledgment delay from the RTT sample if the resulting value is smaller than the min_rtt. This limits the underestimation of the smoothed_rtt due to a misreporting peer.

Now that the delay is closer to what we actually expect, when performing `latest_rtt - delay` it has a natural tendency to fall around the `min_rtt` value. In the current code, if this occurs we always take the `latest_rtt` value to update the `smoothed_rtt`, which in this case would be ~27ms. So by accounting for the timing delay in the `max_ack_delay`, we end up making the `smoothed_rtt` value explode higher. This is more likely to manifest if the first handshake is slower than the network latency (eg, public-key cryptography compared to loopback network).

Right now, the simple "fix" was to clamp the `adjusted_rtt` to `min_rtt` in this event, rather than `latest_rtt`. But I'm not confident that it's really the correct thing to do, according to the spec.

---

I'll add, this problem only occurred with light load with a unidirectional stream. Once we introduced additional bidirectional streams, the problem went away. I imagine in this scenario the `min_rtt` will also be updated accordingly to avoid the issue described above.