### PR TITLE
Fix Windows IPv6 bind option selection

### DIFF
--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -84,6 +84,14 @@ mod log {
 #[cfg(not(wasm_browser))]
 pub use imp::UdpSocketState;
 
+#[cfg_attr(not(windows), allow(dead_code))]
+fn should_set_ipv4_options(addr: SocketAddr, v6only: bool) -> bool {
+    match addr {
+        SocketAddr::V4(_) => true,
+        SocketAddr::V6(addr) => !v6only && addr.ip().is_unspecified(),
+    }
+}
+
 /// Number of UDP packets to send/receive at a time
 #[cfg(not(wasm_browser))]
 pub const BATCH_SIZE: usize = imp::BATCH_SIZE;
@@ -315,9 +323,29 @@ impl EcnCodepoint {
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
     use super::*;
+
+    #[test]
+    fn ipv4_options_are_only_for_ipv4_or_wildcard_dual_stack() {
+        assert!(should_set_ipv4_options(
+            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4433)),
+            false,
+        ));
+        assert!(should_set_ipv4_options(
+            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 4433, 0, 0)),
+            false,
+        ));
+        assert!(!should_set_ipv4_options(
+            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 4433, 0, 0)),
+            false,
+        ));
+        assert!(!should_set_ipv4_options(
+            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 4433, 0, 0)),
+            true,
+        ));
+    }
 
     #[test]
     fn effective_segment_size() {

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -18,7 +18,7 @@ use crate::{
     EcnCodepoint, IO_ERROR_LOG_INTERVAL, RecvMeta, Transmit, UdpSockRef,
     cmsg::{self, CMsgHdr},
     log::debug,
-    log_sendmsg_error,
+    log_sendmsg_error, should_set_ipv4_options,
 };
 
 /// QUIC-friendly UDP socket for Windows
@@ -70,7 +70,7 @@ impl UdpSocketState {
             }
             result != 0
         };
-        let is_ipv4 = addr.as_socket_ipv4().is_some() || !v6only;
+        let is_ipv4 = should_set_ipv4_options(addr, v6only);
 
         // We don't support old versions of Windows that do not enable access to `WSARecvMsg()`
         if WSARECVMSG_PTR.is_none() {

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -55,6 +55,9 @@ impl UdpSocketState {
         socket.0.set_nonblocking(true)?;
         let addr = socket.0.local_addr()?;
         let is_ipv6 = addr.as_socket_ipv6().is_some();
+        let socket_addr = addr.as_socket().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "socket address must be IP")
+        })?;
         let v6only = unsafe {
             let mut result: u32 = 0;
             let mut len = size_of_val(&result) as i32;
@@ -70,7 +73,7 @@ impl UdpSocketState {
             }
             result != 0
         };
-        let is_ipv4 = should_set_ipv4_options(addr, v6only);
+        let is_ipv4 = should_set_ipv4_options(socket_addr, v6only);
 
         // We don't support old versions of Windows that do not enable access to `WSARecvMsg()`
         if WSARECVMSG_PTR.is_none() {


### PR DESCRIPTION
Fixes #2682.

This changes the Windows UDP socket setup so IPv4 packet-info options are only
enabled for IPv4 sockets and wildcard dual-stack IPv6 sockets. Non-wildcard
IPv6 binds such as `[::1]:4433` no longer take the IPv4 option path.

Testing:

- `cargo test -p quinn-udp --no-default-features`
