### PR TITLE
Implement `Connection::watch_remote_address`

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1201,6 +1201,7 @@ impl Connection {
                     if let Some((_, prev)) = self.prev_path.take() {
                         self.path = prev;
                         self.set_loss_detection_timer(now);
+                        self.events.push_back(Event::PathUpdated);
                     }
                     self.path.challenge = None;
                     self.path.challenge_pending = false;
@@ -3129,6 +3130,8 @@ impl Connection {
         let prev_pto = self.pto(SpaceId::Data);
 
         let mut prev = mem::replace(&mut self.path, new_path);
+        self.events.push_back(Event::PathUpdated);
+
         // Don't clobber the original path if the previous one hasn't been validated yet
         if prev.challenge.is_none() {
             prev.challenge = Some(self.rng.random());
@@ -4055,6 +4058,8 @@ pub enum Event {
     DatagramReceived,
     /// One or more application datagrams have been sent after blocking
     DatagramsUnblocked,
+    /// The currently active path was updated
+    PathUpdated,
 }
 
 fn get_max_ack_delay(params: &TransportParameters) -> Duration {

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 use tokio::sync::{
     Notify,
     futures::{Notified, OwnedNotified},
-    mpsc, oneshot,
+    mpsc, oneshot, watch,
 };
 use tracing::{Instrument, Span, debug_span};
 
@@ -559,6 +559,21 @@ impl Connection {
         self.0.state.lock("remote_address").inner.remote_address()
     }
 
+    /// Watch the peer's UDP address.
+    ///
+    /// If `ServerConfig::migration` is `true`, clients may change addresses at will, e.g. when
+    /// switching to a cellular internet connection.
+    pub fn watch_remote_address(&self) -> RemoteAddressWatcher {
+        let receiver = self
+            .0
+            .state
+            .lock("watch_remote_address")
+            .remote_address
+            .subscribe();
+
+        RemoteAddressWatcher { receiver }
+    }
+
     /// The local IP address which was used when the peer established
     /// the connection
     ///
@@ -944,6 +959,25 @@ impl Future for SendDatagram<'_> {
     }
 }
 
+/// Watcher produced by [`Connection::watch_remote_address`]
+pub struct RemoteAddressWatcher {
+    receiver: watch::Receiver<SocketAddr>,
+}
+
+impl RemoteAddressWatcher {
+    /// Wait for an address change, mark it as seen and return the address.
+    ///
+    /// If multiple migrations occur between calls to `wait` or polls of the resulting future,
+    /// the last observed address will be returned, skipping intermediate updates.
+    pub async fn wait(&mut self) -> Option<SocketAddr> {
+        if self.receiver.changed().await.is_err() {
+            return None;
+        }
+
+        Some(*self.receiver.borrow())
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct ConnectionRef(Arc<ConnectionInner>);
 
@@ -1028,6 +1062,7 @@ pub(crate) struct State {
     send_buffer: Vec<u8>,
     /// We buffer a transmit when the underlying I/O would block
     buffered_transmit: Option<proto::Transmit>,
+    remote_address: watch::Sender<SocketAddr>,
 }
 
 impl State {
@@ -1041,6 +1076,8 @@ impl State {
         sender: Pin<Box<dyn UdpSender>>,
         runtime: Arc<dyn Runtime>,
     ) -> Self {
+        let remote_address = inner.remote_address();
+
         Self {
             inner,
             driver: None,
@@ -1060,6 +1097,7 @@ impl State {
             runtime,
             send_buffer: Vec::new(),
             buffered_transmit: None,
+            remote_address: watch::Sender::new(remote_address),
         }
     }
 
@@ -1208,6 +1246,13 @@ impl State {
                 Stream(StreamEvent::Stopped { id, .. }) => {
                     wake_stream_notify(id, &mut self.stopped);
                     wake_stream(id, &mut self.blocked_writers);
+                }
+                PathUpdated => {
+                    // Using `send_replace` since `send` does not update the value
+                    // when there are no subscribed receivers.
+                    let _ = self
+                        .remote_address
+                        .send_replace(self.inner.remote_address());
                 }
             }
         }

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -73,8 +73,8 @@ pub use rustls;
 pub use udp;
 
 pub use crate::connection::{
-    AcceptBi, AcceptUni, Connecting, Connection, OpenBi, OpenUni, ReadDatagram, SendDatagram,
-    SendDatagramError,
+    AcceptBi, AcceptUni, Connecting, Connection, OpenBi, OpenUni, ReadDatagram,
+    RemoteAddressWatcher, SendDatagram, SendDatagramError,
 };
 pub use crate::endpoint::{Accept, Endpoint, EndpointStats};
 pub use crate::incoming::{Incoming, IncomingFuture, RetryError};

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -759,6 +759,67 @@ async fn rebind_recv() {
 }
 
 #[tokio::test]
+async fn remote_address_monitoring() {
+    let _guard = subscribe();
+
+    let factory = EndpointFactory::new();
+    let server = factory.endpoint();
+    let server_addr = server.local_addr().unwrap();
+    let client = factory.endpoint();
+
+    let trigger_migration = Arc::new(tokio::sync::Notify::new());
+    let trigger_migration_clone = trigger_migration.clone();
+
+    let server_task = tokio::spawn(async move {
+        let conn = server.accept().await.unwrap().await.unwrap();
+        let old_remote = conn.remote_address();
+        let mut addr_watch = conn.watch_remote_address();
+
+        trigger_migration_clone.notify_one();
+
+        let addr_a = addr_watch.wait().await.unwrap();
+        assert_eq!(addr_a.port(), 23_001);
+        assert_ne!(old_remote, addr_a);
+
+        trigger_migration_clone.notify_one();
+
+        let addr_b = addr_watch.wait().await.unwrap();
+        assert_eq!(addr_b.port(), 23_003);
+        assert_ne!(addr_a, addr_b);
+    });
+
+    let client_conn = client
+        .connect(server_addr, "localhost")
+        .unwrap()
+        .await
+        .unwrap();
+
+    let mut port = 23_000;
+    let mut migrate = async || {
+        port += 1;
+        client
+            .rebind(
+                UdpSocket::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port)).unwrap(),
+            )
+            .unwrap();
+
+        // send data from the new socket to trigger migration on the server
+        let mut stream = client_conn.open_uni().await.unwrap();
+        stream.write_all(b"hello").await.unwrap();
+        stream.finish().unwrap();
+    };
+
+    trigger_migration.notified().await;
+    migrate().await;
+    trigger_migration.notified().await;
+    migrate().await;
+    migrate().await;
+
+    server_task.await.unwrap();
+    client_conn.close(0u32.into(), b"done");
+}
+
+#[tokio::test]
 async fn stream_id_flow_control() {
     let _guard = subscribe();
     let mut cfg = TransportConfig::default();


### PR DESCRIPTION
As discussed on [Discord](https://discord.com/channels/976380008299917365/1063547094863978677/1507029204083150869), this PR adds a `watch_remote_address` method on `quinn::Connection` that allows the user to watch for remote address changes without having to periodically call the existing `remote_address` method.

The implementation uses a `tokio::sync::watch` channel since it has good semantics. I wrapped it in a new type that does not leak this implementation detail.