### PR TITLE
quinn-proto: fix unresolved intra-doc link for platform verifier

### DIFF
--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -288,7 +288,12 @@ pub struct HandshakeData {
 /// A QUIC-compatible TLS client configuration
 ///
 /// Quinn implicitly constructs a `QuicClientConfig` with reasonable defaults within
-/// [`ClientConfig::with_root_certificates()`][root_certs] and [`ClientConfig::try_with_platform_verifier()`][platform].
+/// [`ClientConfig::with_root_certificates()`][root_certs].
+#[cfg_attr(
+    feature = "platform-verifier",
+    doc = "It is also constructed implicitly within [`ClientConfig::try_with_platform_verifier()`][platform]."
+)]
+///
 /// Alternatively, `QuicClientConfig`'s [`TryFrom`] implementation can be used to wrap around a
 /// custom [`rustls::ClientConfig`], in which case care should be taken around certain points:
 ///
@@ -302,7 +307,10 @@ pub struct HandshakeData {
 /// 256 server names.
 ///
 /// [root_certs]: crate::config::ClientConfig::with_root_certificates()
-/// [platform]: crate::config::ClientConfig::try_with_platform_verifier()
+#[cfg_attr(
+    feature = "platform-verifier",
+    doc = "[platform]: crate::config::ClientConfig::try_with_platform_verifier()"
+)]
 pub struct QuicClientConfig {
     pub(crate) inner: Arc<rustls::ClientConfig>,
     initial: Suite,


### PR DESCRIPTION
`QuicClientConfig`'s docs link to
`ClientConfig::try_with_platform_verifier()`, which is gated behind
`#[cfg(feature = "platform-verifier")]`. When docs are built without that
feature, the intra-doc link is unresolved and `cargo doc` fails under
`-D warnings` (the same bar CI enforces).

This gates the doc sentence and its link reference to the same feature, so
the link is only present when its target is. Verified `cargo doc --no-deps`
is clean both with and without `--features platform-verifier`.

No code or API changes.
