### PR TITLE
proto: widen packet dedup window to 2048 bits

### DIFF
--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -1,5 +1,4 @@
 use std::{
-    cmp,
     collections::{BTreeMap, VecDeque},
     mem,
     ops::{Bound, Index, IndexMut},
@@ -462,7 +461,10 @@ pub(super) struct Dedup {
 impl Dedup {
     /// Construct an empty window positioned at the start.
     pub(super) fn new() -> Self {
-        Self { window: 0, next: 0 }
+        Self {
+            window: Window::ZERO,
+            next: 0,
+        }
     }
 
     /// Highest packet number authenticated.
@@ -476,18 +478,17 @@ impl Dedup {
     pub(super) fn insert(&mut self, packet: u64) -> bool {
         if let Some(diff) = packet.checked_sub(self.next) {
             // Right of window
-            self.window = ((self.window << 1) | 1)
-                .checked_shl(cmp::min(diff, u64::from(u32::MAX)) as u32)
-                .unwrap_or(0);
+            let mut shifted = self.window.shl(1);
+            shifted.set(0);
+            self.window = shifted.shl(diff); // saturates to zero past the window width
             self.next = packet + 1;
             false
         } else if self.highest() - packet < WINDOW_SIZE {
             // Within window
             if let Some(bit) = (self.highest() - packet).checked_sub(1) {
                 // < highest
-                let mask = 1 << bit;
-                let duplicate = self.window & mask != 0;
-                self.window |= mask;
+                let duplicate = self.window.get(bit);
+                self.window.set(bit);
                 duplicate
             } else {
                 // == highest
@@ -533,16 +534,13 @@ impl Dedup {
             return None;
         }
 
-        // Ensure the shift is within bounds (we already know start_offset < BITFIELD_SIZE,
-        // because of the early return)
-        let mask = if range_len == BITFIELD_SIZE {
-            u128::MAX
-        } else {
-            ((1u128 << range_len) - 1) << start_offset
-        };
-        let gaps = !self.window & mask;
-
-        let smallest_missing_offset = 128 - gaps.leading_zeros() as u64;
+        // Highest un-received offset within the window slice (the bitwise
+        // `(!window & mask).leading_zeros()` scan, expressed on the wide window); earlier
+        // packets are considered received.
+        let smallest_missing_offset = self
+            .window
+            .highest_zero_in(start_offset, start_offset + range_len)?
+            + 1;
         let smallest_missing_packet = self.highest() - smallest_missing_offset;
 
         if smallest_missing_packet <= upper_bound {
@@ -564,8 +562,101 @@ impl Dedup {
 /// Inner bitfield type
 ///
 /// Because QUIC never reuses packet numbers, this only needs to be large enough to deal with
-/// packets that are reordered but still delivered in a timely manner.
-type Window = u128;
+/// packets that are reordered but still delivered in a timely manner. Reordering displacement in
+/// packet numbers scales with send rate (~130 packet numbers per millisecond of reordering at
+/// 1.6 Gbit/s), so the previous 128-bit window discarded delivered packets as possible duplicates
+/// on reordering paths at high rates (#2710). 2048 bits tolerates ~10 ms of reordering at
+/// ~200k packets/s for 240 extra bytes per connection.
+type Window = BigWindow;
+
+/// Number of `u64` words in [`BigWindow`]
+const WINDOW_WORDS: usize = 32;
+
+/// Fixed 2048-bit window providing the operations `Dedup` needs from the former `u128`
+///
+/// Bit 0 is the least significant bit of word 0.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct BigWindow([u64; WINDOW_WORDS]);
+
+impl BigWindow {
+    const ZERO: Self = Self([0; WINDOW_WORDS]);
+    /// Number of bits in the window, mirroring `uN::BITS`
+    const BITS: u32 = (WINDOW_WORDS as u32) * 64;
+
+    /// `self << n`, saturating to all-zero when `n >= Self::BITS`
+    /// (mirrors `u128::checked_shl(..).unwrap_or(0)`)
+    fn shl(&self, n: u64) -> Self {
+        if n >= u64::from(Self::BITS) {
+            return Self::ZERO;
+        }
+        let (ws, bs) = ((n / 64) as usize, (n % 64) as u32);
+        let mut out = [0u64; WINDOW_WORDS];
+        for i in (ws..WINDOW_WORDS).rev() {
+            let lo = self.0[i - ws];
+            out[i] = if bs == 0 {
+                lo
+            } else {
+                let carry = if i > ws {
+                    self.0[i - ws - 1] >> (64 - bs)
+                } else {
+                    0
+                };
+                (lo << bs) | carry
+            };
+        }
+        Self(out)
+    }
+
+    fn get(&self, bit: u64) -> bool {
+        debug_assert!(bit < u64::from(Self::BITS));
+        self.0[(bit / 64) as usize] & (1u64 << (bit % 64)) != 0
+    }
+
+    fn set(&mut self, bit: u64) {
+        debug_assert!(bit < u64::from(Self::BITS));
+        self.0[(bit / 64) as usize] |= 1u64 << (bit % 64);
+    }
+
+    /// Test helper mirroring the former `u128` literal comparisons
+    #[cfg(test)]
+    fn from_u128(v: u128) -> Self {
+        let mut w = Self::ZERO;
+        w.0[0] = v as u64;
+        w.0[1] = (v >> 64) as u64;
+        w
+    }
+
+    /// Position of the highest ZERO bit within `[lo, hi)` (`hi` clamped to `Self::BITS`), or
+    /// `None` if every bit in the range is set
+    ///
+    /// Mirrors the former `(!window & mask).leading_zeros()` gap scan.
+    fn highest_zero_in(&self, lo: u64, hi: u64) -> Option<u64> {
+        let hi = hi.min(u64::from(Self::BITS));
+        if lo >= hi {
+            return None;
+        }
+        let (lo_w, hi_w) = ((lo / 64) as usize, ((hi - 1) / 64) as usize);
+        for w in (lo_w..=hi_w).rev() {
+            let mut gaps = !self.0[w];
+            if w == hi_w {
+                let top = (hi - 1) % 64; // highest in-range bit within this word
+                if top < 63 {
+                    gaps &= (1u64 << (top + 1)) - 1;
+                }
+            }
+            if w == lo_w {
+                let bottom = lo % 64;
+                if bottom > 0 {
+                    gaps &= !((1u64 << bottom) - 1);
+                }
+            }
+            if gaps != 0 {
+                return Some((w as u64) * 64 + 63 - u64::from(gaps.leading_zeros()));
+            }
+        }
+        None
+    }
+}
 
 /// Number of packets tracked by `Dedup`
 const WINDOW_SIZE: u64 = 1 + size_of::<Window>() as u64 * 8;
@@ -913,32 +1004,32 @@ mod test {
         let mut dedup = Dedup::new();
         assert!(!dedup.insert(0));
         assert_eq!(dedup.next, 1);
-        assert_eq!(dedup.window, 0b1);
+        assert_eq!(dedup.window, BigWindow::from_u128(0b1));
         assert!(dedup.insert(0));
         assert_eq!(dedup.next, 1);
-        assert_eq!(dedup.window, 0b1);
+        assert_eq!(dedup.window, BigWindow::from_u128(0b1));
         assert!(!dedup.insert(1));
         assert_eq!(dedup.next, 2);
-        assert_eq!(dedup.window, 0b11);
+        assert_eq!(dedup.window, BigWindow::from_u128(0b11));
         assert!(!dedup.insert(2));
         assert_eq!(dedup.next, 3);
-        assert_eq!(dedup.window, 0b111);
+        assert_eq!(dedup.window, BigWindow::from_u128(0b111));
         assert!(!dedup.insert(4));
         assert_eq!(dedup.next, 5);
-        assert_eq!(dedup.window, 0b11110);
+        assert_eq!(dedup.window, BigWindow::from_u128(0b11110));
         assert!(!dedup.insert(7));
         assert_eq!(dedup.next, 8);
-        assert_eq!(dedup.window, 0b1111_0100);
+        assert_eq!(dedup.window, BigWindow::from_u128(0b1111_0100));
         assert!(dedup.insert(4));
         assert!(!dedup.insert(3));
         assert_eq!(dedup.next, 8);
-        assert_eq!(dedup.window, 0b1111_1100);
+        assert_eq!(dedup.window, BigWindow::from_u128(0b1111_1100));
         assert!(!dedup.insert(6));
         assert_eq!(dedup.next, 8);
-        assert_eq!(dedup.window, 0b1111_1101);
+        assert_eq!(dedup.window, BigWindow::from_u128(0b1111_1101));
         assert!(!dedup.insert(5));
         assert_eq!(dedup.next, 8);
-        assert_eq!(dedup.window, 0b1111_1111);
+        assert_eq!(dedup.window, BigWindow::from_u128(0b1111_1111));
     }
 
     #[test]
@@ -958,10 +1049,15 @@ mod test {
         dedup.insert(2 * WINDOW_SIZE);
         assert!(dedup.insert(WINDOW_SIZE));
         assert_eq!(dedup.next, 2 * WINDOW_SIZE + 1);
-        assert_eq!(dedup.window, 0);
+        assert_eq!(dedup.window, BigWindow::ZERO);
         assert!(!dedup.insert(WINDOW_SIZE + 1));
         assert_eq!(dedup.next, 2 * WINDOW_SIZE + 1);
-        assert_eq!(dedup.window, 1 << (WINDOW_SIZE - 2));
+        let expected = {
+            let mut w = BigWindow::ZERO;
+            w.set(WINDOW_SIZE - 2);
+            w
+        };
+        assert_eq!(dedup.window, expected);
     }
 
     #[test]
@@ -1019,15 +1115,24 @@ mod test {
         dedup.insert(2);
         assert_eq!(dedup.smallest_missing_in_interval(1, 7), Some(3));
 
+        // Window-width-dependent cases (were 300/500/372 for the 129-packet u128 window):
+        // b1 pushes the gap at 171 just outside the window, where packets are considered
+        // received; expected is the lowest packet still inside the window after b2.
         dedup.insert(170);
         dedup.insert(172);
-        dedup.insert(300);
+        let b1 = 171 + WINDOW_SIZE;
+        dedup.insert(b1);
         assert_eq!(dedup.smallest_missing_in_interval(170, 172), None);
 
-        dedup.insert(500);
-        assert_eq!(dedup.smallest_missing_in_interval(0, 500), Some(372));
-        assert_eq!(dedup.smallest_missing_in_interval(0, 373), Some(372));
-        assert_eq!(dedup.smallest_missing_in_interval(0, 372), None);
+        let b2 = b1 + 200;
+        dedup.insert(b2);
+        let expected = b2 - (WINDOW_SIZE - 1);
+        assert_eq!(dedup.smallest_missing_in_interval(0, b2), Some(expected));
+        assert_eq!(
+            dedup.smallest_missing_in_interval(0, expected + 1),
+            Some(expected)
+        );
+        assert_eq!(dedup.smallest_missing_in_interval(0, expected), None);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2710.

## Problem

The `Dedup` window is a `u128` bitmask, so any packet arriving more than 129 packet numbers behind the highest authenticated one is treated as a possible duplicate and silently discarded — even though it was delivered and decrypts fine. Reordering displacement in packet-number space scales with send rate (~130 PN per ms of reordering at 1.6 Gbit/s with 1452-byte packets), so at WAN rates a few milliseconds of path reordering silently discards a large fraction of delivered packets. The peer never sees ACKs for them, spuriously retransmits, and the retransmissions widen the packet-number spread further — a feedback loop that collapsed measured throughput several-fold below TCP on the same path (details and elimination chain in #2710).

## Change

`type Window = u128` → a fixed 2048-bit window (`BigWindow([u64; 32])`) exposing the same operations `Dedup` used on the `u128` (`shl` saturating to zero, bit test/set, and the highest-zero-in-range scan used by `smallest_missing_in_interval`). `WINDOW_SIZE` and `BITFIELD_SIZE` are derived from `size_of::<Window>()` / `Window::BITS` as before, so every bound scales automatically. Replay-protection semantics are unchanged — the window is just wider. Cost: 240 additional bytes per connection.

Width-dependent constants in the `Dedup` tests are parametrized on `WINDOW_SIZE` so they express the same scenarios at any width; the remaining tests are untouched and pass unchanged (275/275 `quinn-proto --lib`).

## Measurements

Two 8-vCPU VMs, Sydney↔Chicago (197 ms RTT), BBR, 512 MiB bulk transfers, `netem delay 5ms reorder 25% 50%` on the sender egress:

| configuration | goodput |
|---|---|
| u128 window (this crate today), packet_threshold=300 | 205 Mbit/s |
| **2048-bit window (this PR)**, packet_threshold=300 | **306 Mbit/s** |
| 2048-bit window + large packet_threshold (see #2711) | 632–710 Mbit/s (clean-path: ~730–830) |

Also verified no regression on clean, 1%-loss, and 10%-loss profiles.

Happy to reshape (e.g. const-generic width or a config knob) if you'd prefer not to grow the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)