### PR TITLE
quinn-udp: handle EIO from sendmsg in the cmsg fallback (not just EINVAL)

### DIFF
--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -479,7 +479,9 @@ fn send(
 
                 // Some arguments to `sendmsg` are not supported. Switch to
                 // fallback mode and retry if we haven't already.
-                if e.raw_os_error() == Some(libc::EINVAL) && !state.sendmsg_einval() {
+                if matches!(e.raw_os_error(), Some(libc::EINVAL) | Some(libc::EIO))
+                    && !state.sendmsg_einval()
+                {
                     state.set_sendmsg_einval();
                     prepare_msg(
                         transmit,


### PR DESCRIPTION
The GSO-disable path just above already handles both `EIO` and `EINVAL`, but the cmsg fallback (`sendmsg_einval`, which stops setting the ECN `IP_TOS` cmsg) only triggers on `EINVAL`. Some Android kernels return `EIO` for the ECN cmsg, so the fallback never kicks in and every `sendmsg` keeps failing.

Closes #2718.