### PR TITLE
Surface non-`WouldBlock` recv errors from `poll_recv`

### DIFF
--- a/quinn/src/runtime/smol.rs
+++ b/quinn/src/runtime/smol.rs
@@ -81,8 +81,10 @@ impl AsyncUdpSocket for UdpSocket {
     ) -> Poll<io::Result<usize>> {
         loop {
             ready!(self.io.poll_readable(cx))?;
-            if let Ok(res) = self.inner.recv((&self.io).into(), bufs, meta) {
-                return Poll::Ready(Ok(res));
+            match self.inner.recv((&self.io).into(), bufs, meta) {
+                Ok(res) => return Poll::Ready(Ok(res)),
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {}
+                Err(e) => return Poll::Ready(Err(e)),
             }
         }
     }

--- a/quinn/src/runtime/tokio.rs
+++ b/quinn/src/runtime/tokio.rs
@@ -82,10 +82,15 @@ impl AsyncUdpSocket for UdpSocket {
     ) -> Poll<io::Result<usize>> {
         loop {
             ready!(self.io.poll_recv_ready(cx))?;
-            if let Ok(res) = self.io.try_io(Interest::READABLE, || {
+            match self.io.try_io(Interest::READABLE, || {
                 self.inner.recv((&self.io).into(), bufs, meta)
             }) {
-                return Poll::Ready(Ok(res));
+                Ok(res) => return Poll::Ready(Ok(res)),
+                // `try_io` clears readiness only for `WouldBlock`. Looping on any other
+                // error would spin: readiness stays asserted, so `poll_recv_ready`
+                // completes at once and the recv fails again, without ever yielding.
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {}
+                Err(e) => return Poll::Ready(Err(e)),
             }
         }
     }


### PR DESCRIPTION
`AsyncUdpSocket::poll_recv` discards every error the socket returns and re-polls. On the tokio runtime this is an unbounded busy loop, and on both bundled runtimes it makes `RecvState::poll_socket`'s error handling unreachable.

## The loop

`quinn/src/runtime/tokio.rs`:

```rust
loop {
    ready!(self.io.poll_recv_ready(cx))?;
    if let Ok(res) = self.io.try_io(Interest::READABLE, || {
        self.inner.recv((&self.io).into(), bufs, meta)
    }) {
        return Poll::Ready(Ok(res));
    }
}
```

tokio's [`try_io`](https://docs.rs/tokio/latest/tokio/net/struct.UdpSocket.html#method.try_io) clears the cached readiness flag **only** when the closure returns `WouldBlock`. Any other `io::Error` is returned with readiness still asserted. The `if let Ok(..)` discards it, the loop re-enters `poll_recv_ready`, which completes immediately because readiness was never cleared, and the recv fails the same way again.

The result is a synchronous loop inside a *single* `poll_recv` call. It never returns, so the endpoint driver task never yields — on a current-thread runtime it starves every other task on that runtime, and it pegs a core until the process is killed.

`quinn-udp`'s `recv` retries `EINTR` internally and returns everything else, so any durable socket error reaches this loop.

## Observed

An iOS app on a QUIC connection whose bound interface went away. Instruments Time Profiler: 97% of process CPU on the endpoint driver's thread, 94.9% inside `<quinn::runtime::tokio::UdpSocket as AsyncUdpSocket>::poll_recv`. A System Trace over the same process, 0.39s window:

| syscall | count | result |
|---|---|---|
| `recvmsg` on the endpoint's fd | 422,117 | `ENOTCONN` (errno 57), every call |
| `recvmsg` on other fds | 14 | normal |

That is ~1.07M failing `recvmsg`/sec. `quinn_proto`'s packet handling accounts for ~1ms out of 16s of samples — no packets are being processed at all. Darwin returns `ENOTCONN` on every `recvmsg` once the socket's flow is invalidated, so the error is latched, not one-shot.

## The error handling that never runs

`RecvState::poll_socket` already matches on the recv result:

```rust
// Ignore ECONNRESET as it's undefined in QUIC and may be injected by an attacker
Poll::Ready(Err(ref e)) if e.kind() == io::ErrorKind::ConnectionReset => { continue; }
Poll::Ready(Err(e)) => { return Err(e); }
```

Neither arm can fire for the bundled runtimes, because neither `poll_recv` ever returns `Ready(Err(_))` from the recv itself. Both arms date to 71927fb8 ("Draft tokio bindings", 2018) and were moved verbatim by 8f4e30bc and 5eae60d4 without their reachability being revisited. So the intended behavior — retry `ECONNRESET`, tear the driver down on anything else — has never been in effect; the actual behavior is to spin.

## The change

Return non-`WouldBlock` errors from `poll_recv` and let `poll_socket` apply the policy it already encodes. Applied to `runtime/tokio.rs` and `runtime/smol.rs`, which share the discard-and-loop shape. No policy is invented here.

## Caveats, stated plainly

- **This does not fix a latched `ECONNRESET`.** That error takes `poll_socket`'s `continue` arm, which re-polls at once, so the spin would move up a layer rather than disappear. It is fine for the case above (`ENOTCONN` takes the teardown arm), and quinn never `connect()`s the endpoint socket, so an unconnected UDP socket does not collect ICMP-derived errors the way a connected one does. But if you want that arm bounded too, it should be a deliberate decision — say so and I will add it.

- **This changes a failure mode from "spin forever" to "driver returns `Err`"** for durable errors. That appears to be the original intent, but it is a behavior change and worth a maintainer's judgement.

- **No regression test.** The seam needs a socket that is epoll-readable while `recvmsg` returns a persistent error. Aliasing a pending-accept TCP listener fd as a `UdpSocket` fails at `UdpSocketState::new`, which sets UDP-only sockopts. I would rather say so than add a test that does not exercise the bug. Suggestions welcome.

## Checks

`cargo fmt --all -- --check` clean. `cargo test --locked -p quinn`: 22 passed, 4 ignored. `cargo clippy --locked --all-targets -- -D warnings` reports one unfulfilled lint expectation at `quinn-udp/src/unix.rs:809` — it reproduces on pristine `main` on macOS and is unrelated to this change.
