### PR TITLE
quinn-proto: add TransportConfig::max_rtt to bound RTT samples

### DIFF
--- a/quinn-proto/src/config/transport.rs
+++ b/quinn-proto/src/config/transport.rs
@@ -36,6 +36,7 @@ pub struct TransportConfig {
     pub(crate) packet_threshold: u32,
     pub(crate) time_threshold: f32,
     pub(crate) initial_rtt: Duration,
+    pub(crate) max_rtt: Duration,
     pub(crate) initial_mtu: u16,
     pub(crate) min_mtu: u16,
     pub(crate) mtu_discovery_config: Option<MtuDiscoveryConfig>,
@@ -171,6 +172,20 @@ impl TransportConfig {
     /// The RTT used before an RTT sample is taken
     pub fn initial_rtt(&mut self, value: Duration) -> &mut Self {
         self.initial_rtt = value;
+        self
+    }
+
+    /// Upper bound applied to individual RTT samples
+    ///
+    /// Each RTT sample is clamped to this value before it is fed into the smoothed RTT estimator.
+    /// Without a bound, a single spuriously large sample -- for example caused by the async
+    /// runtime being starved, or by packets sitting unread in the socket buffer -- poisons the
+    /// estimate. That in turn inflates the PTO, time-based loss detection threshold and idle
+    /// timeout, which can leave a connection unable to recover.
+    ///
+    /// Defaults to 2 seconds, comfortably above any legitimate internet RTT.
+    pub fn max_rtt(&mut self, value: Duration) -> &mut Self {
+        self.max_rtt = value;
         self
     }
 
@@ -380,6 +395,7 @@ impl Default for TransportConfig {
             packet_threshold: 3,
             time_threshold: 9.0 / 8.0,
             initial_rtt: Duration::from_millis(333), // per spec, intentionally distinct from EXPECTED_RTT
+            max_rtt: Duration::from_secs(2),
             initial_mtu: INITIAL_MTU,
             min_mtu: INITIAL_MTU,
             mtu_discovery_config: Some(MtuDiscoveryConfig::default()),
@@ -418,6 +434,7 @@ impl fmt::Debug for TransportConfig {
             packet_threshold,
             time_threshold,
             initial_rtt,
+            max_rtt,
             initial_mtu,
             min_mtu,
             mtu_discovery_config,
@@ -448,6 +465,7 @@ impl fmt::Debug for TransportConfig {
             .field("packet_threshold", packet_threshold)
             .field("time_threshold", time_threshold)
             .field("initial_rtt", initial_rtt)
+            .field("max_rtt", max_rtt)
             .field("initial_mtu", initial_mtu)
             .field("min_mtu", min_mtu)
             .field("mtu_discovery_config", mtu_discovery_config)

--- a/quinn-proto/src/congestion/cubic.rs
+++ b/quinn-proto/src/congestion/cubic.rs
@@ -329,7 +329,7 @@ mod tests {
     #[test]
     fn congestion_avoidance_preserves_excess_cwnd_increment() {
         let now = Instant::now();
-        let rtt = RttEstimator::new(Duration::from_millis(100));
+        let rtt = RttEstimator::new(Duration::from_millis(100), Duration::from_secs(2));
         let config = Arc::new(CubicConfig::default());
         let mut cubic = Cubic::new(config, now, BASE_DATAGRAM_SIZE as u16);
 

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -69,7 +69,7 @@ impl PathData {
             .build(now, config.get_initial_mtu());
         Self {
             remote,
-            rtt: RttEstimator::new(config.initial_rtt),
+            rtt: RttEstimator::new(config.initial_rtt, config.max_rtt),
             sending_ecn: true,
             pacing: Pacer::new(
                 config.initial_rtt,
@@ -147,7 +147,7 @@ impl PathData {
     ///
     /// This is useful when it is known the underlying path has changed.
     pub(super) fn reset(&mut self, now: Instant, config: &TransportConfig) {
-        self.rtt = RttEstimator::new(config.initial_rtt);
+        self.rtt = RttEstimator::new(config.initial_rtt, config.max_rtt);
         self.congestion = config
             .congestion_controller_factory
             .clone()
@@ -308,15 +308,18 @@ pub struct RttEstimator {
     var: Duration,
     /// The minimum RTT seen in the connection, ignoring ack delay.
     min: Duration,
+    /// Upper bound applied to RTT samples, guarding the estimate against processing delays.
+    max: Duration,
 }
 
 impl RttEstimator {
-    pub(crate) fn new(initial_rtt: Duration) -> Self {
+    pub(crate) fn new(initial_rtt: Duration, max_rtt: Duration) -> Self {
         Self {
             latest: initial_rtt,
             smoothed: None,
             var: initial_rtt / 2,
             min: initial_rtt,
+            max: max_rtt,
         }
     }
 
@@ -344,6 +347,9 @@ impl RttEstimator {
     }
 
     pub(crate) fn update(&mut self, ack_delay: Duration, rtt: Duration) {
+        // Clamp the raw sample so that a delayed ack (e.g. from runtime starvation, or packets
+        // left unread in the socket buffer) cannot poison the estimate.
+        let rtt = cmp::min(rtt, self.max);
         self.latest = rtt;
         // min_rtt ignores ack delay.
         self.min = cmp::min(self.min, self.latest);
@@ -465,5 +471,32 @@ impl InFlight {
     fn remove(&mut self, packet: &SentPacket) {
         self.bytes -= u64::from(packet.size);
         self.ack_eliciting -= u64::from(packet.ack_eliciting);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rtt_estimator_clamps_samples_above_max() {
+        let max = Duration::from_millis(500);
+        let mut rtt = RttEstimator::new(Duration::from_millis(100), max);
+
+        // A wildly inflated sample (e.g. from runtime starvation) must not exceed `max`.
+        rtt.update(Duration::ZERO, Duration::from_secs(30));
+
+        assert_eq!(rtt.latest, max);
+        assert_eq!(rtt.get(), max);
+    }
+
+    #[test]
+    fn rtt_estimator_keeps_samples_below_max() {
+        let mut rtt = RttEstimator::new(Duration::from_millis(100), Duration::from_secs(2));
+
+        let sample = Duration::from_millis(250);
+        rtt.update(Duration::ZERO, sample);
+
+        assert_eq!(rtt.latest, sample);
     }
 }


### PR DESCRIPTION
## Motivation
  
Every RTT sample feeds straight into the smoothed RTT estimator with no upper bound. When the host is momentarily unable to process incoming packets in a timely fashion — e.g. an async runtime starved of CPU, or packets sitting unread in the socket receive buffer — an ack can be processed long after it arrived, producing a spuriously large RTT sample. That single sample poisons the smoothed estimate, which inflates the PTO, the time-based loss-detection threshold and the idle timeout, and can leave a connection unable to recover.
  
We observed exactly this under runtime starvation and now configure a 2s bound on both client and server connections. 
  
## Summary
- Add a `TransportConfig::max_rtt` option that clamps each raw RTT sample before it enters the estimator (`RttEstimator` gains a `max` bound).
- Defaults to **2 seconds**, comfortably above any legitimate internet RTT, so existing behavior is unchanged in practice.
- Covered by unit tests (`rtt_estimator_clamps_samples_above_max`, `rtt_estimator_keeps_samples_below_max`).