### PR TITLE
fix(quinn-udp): avoid permanent `EWOULDBLOCK` from macOS `sendmsg` bug

### DIFF
--- a/quinn-udp/src/apple_fast.rs
+++ b/quinn-udp/src/apple_fast.rs
@@ -60,6 +60,7 @@ fn send_via_sendmsg_x(
             state.sendmsg_einval(),
         );
         hdrs[i].msg_datalen = chunk.len();
+        state.check_send_buffer_limit(chunk.len(), &hdrs[i])?;
         cnt += 1;
     }
     let Some(sendmsg_x) = state.resolve_apple_fast_fn(sendmsg_x_fn) else {

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -197,6 +197,15 @@ impl UdpSocketState {
             )?;
         }
 
+        // Enlarge SO_SNDBUF to a safe minimum.
+        #[cfg(apple)]
+        if io
+            .send_buffer_size()
+            .is_ok_and(|cur| cur < Self::MIN_SAFE_SNDBUF)
+        {
+            let _ = io.set_send_buffer_size(Self::MIN_SAFE_SNDBUF);
+        }
+
         let now = Instant::now();
         Ok(Self {
             last_send_error: Mutex::new(now.checked_sub(2 * IO_ERROR_LOG_INTERVAL).unwrap_or(now)),
@@ -331,8 +340,20 @@ impl UdpSocketState {
     }
 
     /// Resize the send buffer of `socket` to `bytes`
+    ///
+    /// On Apple platforms, `bytes` is silently raised to a safe minimum if smaller.
     #[inline]
     pub fn set_send_buffer_size(&self, socket: UdpSockRef<'_>, bytes: usize) -> io::Result<()> {
+        #[cfg(apple)]
+        let bytes = if bytes < Self::MIN_SAFE_SNDBUF {
+            crate::log::debug!(
+                "raising requested SO_SNDBUF from {bytes} to {}",
+                Self::MIN_SAFE_SNDBUF
+            );
+            Self::MIN_SAFE_SNDBUF
+        } else {
+            bytes
+        };
         socket.0.set_send_buffer_size(bytes)
     }
 
@@ -414,6 +435,12 @@ impl UdpSocketState {
         }
         f
     }
+
+    /// Smallest `SO_SNDBUF` that mitigates <https://feedbackassistant.apple.com/feedback/23671230>:
+    /// On macOS, a non-blocking SOCK_DGRAM `sendmsg`/`sendmsg_x` call with ancillary data returns
+    /// `EWOULDBLOCK` when the payload length is at or just under `SO_SNDBUF`.
+    #[cfg(apple)]
+    const MIN_SAFE_SNDBUF: usize = 65535 + cmsg::LEN;
 }
 
 #[cfg(not(any(apple, target_os = "openbsd", target_os = "netbsd")))]

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -48,6 +48,10 @@ pub struct UdpSocketState {
     /// Apple OS versions. Callers must verify availability before enabling.
     #[cfg(apple_fast)]
     apple_fast_path: AtomicBool,
+
+    /// Cached `SO_SNDBUF`.
+    #[cfg(apple)]
+    send_buffer_size: AtomicUsize,
 }
 
 impl UdpSocketState {
@@ -215,6 +219,8 @@ impl UdpSocketState {
             sendmsg_einval: AtomicBool::new(false),
             #[cfg(apple_fast)]
             apple_fast_path: AtomicBool::new(false),
+            #[cfg(apple)]
+            send_buffer_size: AtomicUsize::new(io.send_buffer_size().unwrap_or(usize::MAX)),
         })
     }
 
@@ -354,7 +360,13 @@ impl UdpSocketState {
         } else {
             bytes
         };
-        socket.0.set_send_buffer_size(bytes)
+        socket.0.set_send_buffer_size(bytes)?;
+        #[cfg(apple)]
+        self.send_buffer_size.store(
+            socket.0.send_buffer_size().unwrap_or(bytes),
+            Ordering::Relaxed,
+        );
+        Ok(())
     }
 
     /// Resize the receive buffer of `socket` to `bytes`
@@ -441,6 +453,22 @@ impl UdpSocketState {
     /// `EWOULDBLOCK` when the payload length is at or just under `SO_SNDBUF`.
     #[cfg(apple)]
     const MIN_SAFE_SNDBUF: usize = 65535 + cmsg::LEN;
+
+    /// Safety net returning `EMSGSIZE` for payload sizes in the bug's region.
+    #[cfg(apple)]
+    pub(crate) fn check_send_buffer_limit(
+        &self,
+        resid: usize,
+        hdr: &impl cmsg::MsgHdr,
+    ) -> io::Result<()> {
+        let needed = resid.saturating_add(hdr.control_len());
+        let sndbuf = self.send_buffer_size.load(Ordering::Relaxed);
+        if needed > sndbuf {
+            crate::log::debug!("EMSGSIZE for {needed}-byte send: exceeds SO_SNDBUF ({sndbuf})");
+            return Err(io::Error::from_raw_os_error(libc::EMSGSIZE));
+        }
+        Ok(())
+    }
 }
 
 #[cfg(not(any(apple, target_os = "openbsd", target_os = "netbsd")))]
@@ -553,6 +581,8 @@ pub(crate) fn send_single(
         cfg!(apple) || cfg!(target_os = "openbsd") || cfg!(target_os = "netbsd"),
         state.sendmsg_einval(),
     );
+    #[cfg(apple)]
+    state.check_send_buffer_limit(transmit.contents.len(), &hdr)?;
     retry_if_interrupted(|| unsafe { libc::sendmsg(io.as_raw_fd(), &hdr, 0) })?;
     Ok(())
 }

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -1,5 +1,9 @@
+#[cfg(apple)]
+use std::io::{self, IoSlice};
 #[cfg(not(any(target_os = "openbsd", target_os = "netbsd", solarish)))]
 use std::net::{SocketAddr, SocketAddrV6};
+#[cfg(apple)]
+use std::os::fd::AsRawFd;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::time::Duration;
 use std::{
@@ -9,6 +13,8 @@ use std::{
 };
 
 use quinn_udp::{EcnCodepoint, RecvMeta, Transmit, UdpSocketState};
+#[cfg(apple)]
+use socket2::MsgHdr;
 use socket2::Socket;
 
 #[test]
@@ -483,6 +489,120 @@ fn apple_fast_datapath() {
     }
     assert_eq!(total_received, segments, "should receive all segments");
 }
+
+#[test]
+#[cfg(apple)]
+fn sndbuf_cmsg_boundary() {
+    let send = Socket::from(UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap());
+    let recv = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap();
+    let dst = recv.local_addr().unwrap();
+    send.set_nonblocking(true).unwrap();
+
+    let _ = send.set_send_buffer_size(9216);
+    let sndbuf = send.send_buffer_size().unwrap();
+    let clen = tclass_cmsg_space();
+
+    let payload = vec![0u8; sndbuf];
+    for attempt in 1..=3 {
+        match raw_send_with_tclass_cmsg(&send, dst, &payload) {
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => wait_writable(&send),
+            other => panic!(
+                "expected macOS SO_SNDBUF/cmsg kernel bug to reproduce on attempt {attempt}, got {other:?}"
+            ),
+        }
+    }
+
+    let state = UdpSocketState::new((&send).into()).unwrap();
+    assert_min_sndbuf_enforced(&state, &send, dst, clen);
+}
+
+/// Asserts `UdpSocketState`'s `SO_SNDBUF` floor holds on `sendmsg_x`.
+#[test]
+#[cfg(apple_fast)]
+fn sndbuf_cmsg_boundary_fast_path() {
+    let send = Socket::from(UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap());
+    let recv = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap();
+    let dst = recv.local_addr().unwrap();
+    send.set_nonblocking(true).unwrap();
+
+    let state = UdpSocketState::new((&send).into()).unwrap();
+    // SAFETY: assumes sendmsg_x is available on the macOS test host.
+    unsafe { state.set_apple_fast_path() };
+    assert_min_sndbuf_enforced(&state, &send, dst, tclass_cmsg_space());
+}
+
+/// Asserts `UdpSocketState`'s `SO_SNDBUF` floor holds on `send`.
+#[cfg(apple)]
+fn assert_min_sndbuf_enforced(state: &UdpSocketState, send: &Socket, dst: SocketAddr, clen: usize) {
+    let _ = state.set_send_buffer_size(send.into(), 1);
+    let sndbuf = state.send_buffer_size(send.into()).unwrap();
+    assert!(sndbuf >= 65535 + clen);
+
+    let transmit = Transmit {
+        destination: dst,
+        ecn: Some(EcnCodepoint::Ect0),
+        contents: &vec![0u8; 60_000],
+        segment_size: None,
+        src_ip: None,
+    };
+    match state.try_send(send.into(), &transmit) {
+        Ok(()) => {}
+        Err(e) if e.raw_os_error() == Some(libc::EMSGSIZE) => {}
+        Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+            panic!("regressed: permanently stuck EWOULDBLOCK sending a large datagram")
+        }
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}
+
+/// Sends `payload` with an `IPV6_TCLASS` cmsg attached via `Socket::sendmsg`.
+#[cfg(apple)]
+fn raw_send_with_tclass_cmsg(sock: &Socket, dst: SocketAddr, payload: &[u8]) -> io::Result<()> {
+    let addr = socket2::SockAddr::from(dst);
+    let iov = [IoSlice::new(payload)];
+
+    let mut cbuf = AlignedCmsgBuf([0u8; 32]); // room for one aligned c_int cmsg
+    let mut scratch: libc::msghdr = unsafe { std::mem::zeroed() };
+    scratch.msg_control = cbuf.0.as_mut_ptr() as *mut _;
+    scratch.msg_controllen = tclass_cmsg_space() as _;
+    unsafe {
+        let cmsg = libc::CMSG_FIRSTHDR(&scratch);
+        (*cmsg).cmsg_level = libc::IPPROTO_IPV6;
+        (*cmsg).cmsg_type = libc::IPV6_TCLASS;
+        (*cmsg).cmsg_len = libc::CMSG_LEN(size_of::<libc::c_int>() as _) as _;
+        std::ptr::write(
+            libc::CMSG_DATA(cmsg) as *mut libc::c_int,
+            EcnCodepoint::Ect0 as libc::c_int,
+        );
+    }
+
+    let msg = MsgHdr::new()
+        .with_addr(&addr)
+        .with_buffers(&iov)
+        .with_control(&cbuf.0[..tclass_cmsg_space()]);
+    sock.sendmsg(&msg, 0).map(|_| ())
+}
+
+/// Blocks (via `poll()`) until `sock` reports `POLLOUT`, or panics after 2s.
+#[cfg(apple)]
+fn wait_writable(sock: &Socket) {
+    let mut pfd = libc::pollfd {
+        fd: sock.as_raw_fd(),
+        events: libc::POLLOUT,
+        revents: 0,
+    };
+    let n = unsafe { libc::poll(&mut pfd, 1, 2000) };
+    assert!(n != 0, "poll() itself timed out waiting for POLLOUT");
+}
+
+#[cfg(apple)]
+fn tclass_cmsg_space() -> usize {
+    unsafe { libc::CMSG_SPACE(size_of::<libc::c_int>() as _) as usize }
+}
+
+#[cfg(apple)]
+#[repr(align(8))]
+struct AlignedCmsgBuf([u8; 32]);
 
 #[test]
 #[cfg(any(target_os = "linux", target_os = "android"))]


### PR DESCRIPTION
Non-blocking `sendmsg`/`sendmsg_x` on Apple platforms can permanently return with `EWOULDBLOCK` when a datagram plus its `cmsg` lands just under `SO_SNDBUF`. Enforce a safe `SO_SNDBUF` floor on socket creation and resize, with a per-send `EMSGSIZE` safety net.

See https://feedbackassistant.apple.com/feedback/23671230