### PR TITLE
Implement L4S support and the Prague CCA

### DIFF
--- a/perf/src/client.rs
+++ b/perf/src/client.rs
@@ -165,6 +165,7 @@ pub async fn run(opt: Opt) -> Result<()> {
     let mut stats = Stats::default();
 
     let stats_fut = async {
+        let total_duration = Duration::from_secs(opt.duration);
         let interval_duration = Duration::from_secs(opt.interval);
 
         #[cfg(feature = "json-output")]
@@ -172,9 +173,16 @@ pub async fn run(opt: Opt) -> Result<()> {
         #[cfg(not(feature = "json-output"))]
         let allow_table_output = true;
 
+        // Periodically report statistics.
         loop {
+            let elapsed = stats.elapsed_since_start();
+            let remaining = total_duration.saturating_sub(elapsed);
+            if remaining.is_zero() {
+                break;
+            }
+
             let start = Instant::now();
-            tokio::time::sleep(interval_duration).await;
+            tokio::time::sleep(interval_duration.min(remaining)).await;
             {
                 stats.on_interval(start, &stream_stats);
 
@@ -189,16 +197,15 @@ pub async fn run(opt: Opt) -> Result<()> {
     };
 
     tokio::select! {
-        _ = drive_fut => {}
-        _ = stats_fut => {}
+        _ = drive_fut => {
+            connection.close(0u32.into(), b"finished");
+        }
+        _ = stats_fut => {
+            connection.close(0u32.into(), b"time is up");
+        }
         _ = tokio::signal::ctrl_c() => {
             info!("shutting down");
             connection.close(0u32.into(), b"interrupted");
-        }
-        // Add a small duration so the final interval can be reported
-        _ = tokio::time::sleep(Duration::from_secs(opt.duration) + Duration::from_millis(200)) => {
-            info!("shutting down");
-            connection.close(0u32.into(), b"done");
         }
     }
 
@@ -243,7 +250,8 @@ async fn drain_stream(
             first_byte = false;
         }
         let bytes_received = bufs[..size].iter().map(|b| b.len()).sum();
-        recv_stream_stats.on_bytes(bytes_received);
+        let path_stats = stream.path_stats();
+        recv_stream_stats.on_bytes(bytes_received, path_stats.rtt, path_stats.rttvar);
     }
 
     if first_byte {
@@ -288,40 +296,45 @@ async fn drive_uni(
 async fn request_uni(
     send: quinn::SendStream,
     conn: quinn::Connection,
-    upload: u64,
-    download: u64,
+    upload_size: u64,
+    download_size: u64,
     stream_stats: OpenStreamStats,
 ) -> Result<()> {
-    request(send, upload, download, stream_stats.clone()).await?;
+    request(send, upload_size, download_size, stream_stats.clone()).await?;
     let recv = conn.accept_uni().await?;
-    drain_stream(recv, download, stream_stats).await?;
+    drain_stream(recv, download_size, stream_stats).await?;
     Ok(())
 }
 
 async fn request(
     mut send: quinn::SendStream,
-    mut upload: u64,
-    download: u64,
+    mut upload_size: u64,
+    download_size: u64,
     stream_stats: OpenStreamStats,
 ) -> Result<()> {
     let upload_start = Instant::now();
-    send.write_all(&download.to_be_bytes()).await?;
-    if upload == 0 {
+
+    send.write_all(&download_size.to_be_bytes()).await?;
+    if upload_size == 0 {
         send.finish().unwrap();
         return Ok(());
     }
 
-    let send_stream_stats = stream_stats.new_sender(&send, upload);
+    let send_stream_stats = stream_stats.new_sender(&send, upload_size);
 
     static DATA: [u8; 1024 * 1024] = [42; 1024 * 1024];
-    while upload > 0 {
-        let chunk_len = upload.min(DATA.len() as u64);
+    while upload_size > 0 {
+        let chunk_len = upload_size.min(DATA.len() as u64);
         send.write_chunk(Bytes::from_static(&DATA[..chunk_len as usize]))
             .await
             .context("sending response")?;
-        send_stream_stats.on_bytes(chunk_len as usize);
-        upload -= chunk_len;
+
+        let path_stats = send.path_stats();
+        send_stream_stats.on_bytes(chunk_len as usize, path_stats.rtt, path_stats.rttvar);
+
+        upload_size -= chunk_len;
     }
+
     send.finish().unwrap();
     // Wait for stream to close
     _ = send.stopped().await;
@@ -335,8 +348,8 @@ async fn drive_bi(
     connection: quinn::Connection,
     stream_stats: OpenStreamStats,
     concurrency: u64,
-    upload: u64,
-    download: u64,
+    upload_size: u64,
+    download_size: u64,
 ) -> Result<()> {
     if concurrency == 0 {
         return Ok(());
@@ -351,7 +364,7 @@ async fn drive_bi(
 
         debug!("sending request on {}", send.id());
         tokio::spawn(async move {
-            if let Err(e) = request_bi(send, recv, upload, download, stream_stats).await {
+            if let Err(e) = request_bi(send, recv, upload_size, download_size, stream_stats).await {
                 error!("request failed: {:#}", e);
             }
 
@@ -363,12 +376,12 @@ async fn drive_bi(
 async fn request_bi(
     send: quinn::SendStream,
     recv: quinn::RecvStream,
-    upload: u64,
-    download: u64,
+    upload_size: u64,
+    download_size: u64,
     stream_stats: OpenStreamStats,
 ) -> Result<()> {
-    request(send, upload, download, stream_stats.clone()).await?;
-    drain_stream(recv, download, stream_stats).await?;
+    request(send, upload_size, download_size, stream_stats.clone()).await?;
+    drain_stream(recv, download_size, stream_stats).await?;
     Ok(())
 }
 

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -56,6 +56,12 @@ pub struct CommonOpt {
     /// Ack Frequency mode
     #[clap(long = "ack-frequency")]
     pub ack_frequency: bool,
+    /// ECN mode to use
+    ///
+    /// NOTE: this does not guarantee that ECN will actually be used, as it also depends on
+    /// support from the network path (e.g., network queues in routers) and the remote peer.
+    #[clap(long = "ecn", default_value = "classic")]
+    pub ecn: EcnMode,
     /// Congestion algorithm to use
     #[clap(long = "congestion")]
     pub cong_alg: Option<CongestionAlgorithm>,
@@ -121,6 +127,8 @@ impl CommonOpt {
         if let Some(send_window) = self.send_window {
             transport.send_window(send_window);
         }
+
+        transport.enable_ecn(self.ecn.into());
 
         #[cfg(feature = "qlog")]
         if let Some(qlog_file) = &self.qlog_file {
@@ -197,11 +205,34 @@ pub fn parse_byte_size(s: &str) -> Result<u64, ParseIntError> {
     Ok(u64::from_str(s)? * multiplier)
 }
 
+/// Mode of operation for Explicit Congestion Notification (ECN)
+///
+/// NOTE: all this boilerplate-like code is here to avoid adding a trait
+/// from clap (a library crate for CLI applications -- binary crates) to a
+/// library crate.
+#[derive(Clone, Copy, ValueEnum)]
+pub enum EcnMode {
+    Disabled,
+    Classic,
+    L4S,
+}
+
+impl From<EcnMode> for quinn_proto::EcnMode {
+    fn from(mode: EcnMode) -> Self {
+        match mode {
+            EcnMode::Disabled => Self::Disabled,
+            EcnMode::Classic => Self::Classic,
+            EcnMode::L4S => Self::L4S,
+        }
+    }
+}
+
 #[derive(Clone, Copy, ValueEnum)]
 pub enum CongestionAlgorithm {
     Cubic,
     Bbr,
     NewReno,
+    Prague,
 }
 
 impl CongestionAlgorithm {
@@ -210,6 +241,7 @@ impl CongestionAlgorithm {
             Self::Cubic => Arc::new(congestion::CubicConfig::default()),
             Self::Bbr => Arc::new(congestion::BbrConfig::default()),
             Self::NewReno => Arc::new(congestion::NewRenoConfig::default()),
+            Self::Prague => Arc::new(congestion::PragueConfig::default()),
         }
     }
 }

--- a/perf/src/stats.rs
+++ b/perf/src/stats.rs
@@ -3,6 +3,7 @@ use quinn::StreamId;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime};
+use tracing::info;
 #[cfg(feature = "json-output")]
 use {std::fs::File, std::io, std::path::Path};
 
@@ -44,15 +45,29 @@ impl Default for Stats {
 }
 
 impl Stats {
+    pub fn elapsed_since_start(&self) -> Duration {
+        self.start_instant.elapsed()
+    }
+
     pub fn on_interval(&mut self, start: Instant, stream_stats: &OpenStreamStats) {
         let mut interval = Interval::new(start - self.start_instant, self.start_instant.elapsed());
         let mut guard = stream_stats.0.lock().unwrap();
 
         guard.retain(|stream_stats| {
+            info!(
+                "request_size={}, bytes={}",
+                stream_stats.request_size,
+                stream_stats.bytes.load(Ordering::SeqCst)
+            );
+
+            // Record stats globally.
             self.record(stream_stats.clone());
+            // Record stats local to the interval on which it was measured.
             interval.record_stream_stats(stream_stats.clone());
-            // Retain if not finished yet
-            !stream_stats.finished.load(Ordering::SeqCst)
+
+            let is_finished = stream_stats.finished.load(Ordering::SeqCst);
+            // Retain if not finished yet, otherwise remove the statistics corresponding to the stream from per stream statistics.
+            !is_finished
         });
 
         self.intervals.push(interval);
@@ -144,6 +159,8 @@ impl OpenStreamStats {
             finished: Default::default(),
             duration: Default::default(),
             first_byte_latency: Default::default(),
+            rtt: Default::default(),
+            rttvar: Default::default(),
         };
         let send_stream_stats = Arc::new(send_stream_stats);
         self.push(send_stream_stats.clone());
@@ -159,6 +176,8 @@ impl OpenStreamStats {
             finished: Default::default(),
             duration: Default::default(),
             first_byte_latency: Default::default(),
+            rtt: Default::default(),
+            rttvar: Default::default(),
         };
         let recv_stream_stats = Arc::new(recv_stream_stats);
         self.push(recv_stream_stats.clone());
@@ -178,6 +197,8 @@ pub struct StreamStats {
     finished: AtomicBool,
     duration: AtomicU64,
     first_byte_latency: AtomicU64,
+    rtt: AtomicU64,
+    rttvar: AtomicU64,
 }
 
 impl StreamStats {
@@ -186,8 +207,11 @@ impl StreamStats {
             .store(latency.as_micros() as u64, Ordering::SeqCst);
     }
 
-    pub fn on_bytes(&self, bytes: usize) {
+    pub fn on_bytes(&self, bytes: usize, rtt: Duration, rttvar: Duration) {
         self.bytes.fetch_add(bytes, Ordering::SeqCst);
+        self.rtt.store(rtt.as_micros() as u64, Ordering::SeqCst);
+        self.rttvar
+            .store(rttvar.as_micros() as u64, Ordering::SeqCst);
     }
 
     pub fn finish(&self, duration: Duration) {
@@ -222,6 +246,8 @@ impl Interval {
             id: stream_stats.id,
             bytes,
             sender: stream_stats.sender,
+            rtt: stream_stats.rtt.load(Ordering::SeqCst),
+            rttvar: stream_stats.rttvar.load(Ordering::SeqCst),
         })
     }
 }
@@ -236,6 +262,8 @@ struct StreamIntervalStats {
     id: StreamId,
     bytes: usize,
     sender: bool,
+    rtt: u64,
+    rttvar: u64,
 }
 
 fn throughput_bytes_per_second(duration_in_micros: u64, size: u64) -> f64 {
@@ -351,6 +379,8 @@ mod json {
         bytes: usize,
         bits_per_second: f64,
         sender: bool,
+        rtt: u64,
+        rttvar: u64,
     }
 
     impl Stream {
@@ -368,6 +398,8 @@ mod json {
                 bytes: stats.bytes,
                 bits_per_second,
                 sender: stats.sender,
+                rtt: stats.rtt,
+                rttvar: stats.rttvar,
             }
         }
     }

--- a/quinn-proto/src/config/mod.rs
+++ b/quinn-proto/src/config/mod.rs
@@ -28,7 +28,9 @@ use crate::{
 mod transport;
 #[cfg(feature = "qlog")]
 pub use transport::QlogConfig;
-pub use transport::{AckFrequencyConfig, IdleTimeout, MtuDiscoveryConfig, TransportConfig};
+pub use transport::{
+    AckFrequencyConfig, EcnMode, IdleTimeout, MtuDiscoveryConfig, TransportConfig,
+};
 
 /// Global configuration for the endpoint, affecting all connections
 ///

--- a/quinn-proto/src/config/transport.rs
+++ b/quinn-proto/src/config/transport.rs
@@ -8,9 +8,58 @@ use qlog::streamer::QlogStreamer;
 #[cfg(feature = "qlog")]
 use crate::QlogStream;
 use crate::{
-    Duration, INITIAL_MTU, MAX_UDP_PAYLOAD, VarInt, VarIntBoundsExceeded, congestion,
+    Duration, EcnCodepoint, INITIAL_MTU, MAX_UDP_PAYLOAD, VarInt, VarIntBoundsExceeded,
+    congestion::{self, Controller},
     connection::qlog::QlogSink,
 };
+
+/// Mode of operation for Explicit Congestion Notification (ECN)
+///
+/// Determines how ECN is used (if at all) for outgoing packets, and how it is interpreted for
+/// incoming packets.
+#[derive(Clone, Copy, Debug)]
+pub enum EcnMode {
+    /// Disable ECN completely
+    Disabled,
+    /// Classic ECN based on RFC3168
+    ///
+    /// Causes outgoing packets to be marked with ECT(0).
+    Classic,
+    /// ECN for Low Latency, Low Loss, Scalable throughput based on RFC9331
+    ///
+    /// Causes outgoing packets to be marked with ECT(1).
+    L4S,
+}
+
+impl EcnMode {
+    /// Returns whether the ECN mode indicates an enabled configuration state (ECT(0) or ECT(1)).
+    pub fn is_enabled(&self) -> bool {
+        !matches!(self, Self::Disabled)
+    }
+
+    /// Returns the appropriate ECN mode for the given congestion control algorithm.
+    pub fn supported_mode(&self, controller: &mut Box<dyn Controller>) -> Self {
+        match self {
+            Self::Classic if controller.enable_ect0() => Self::Classic,
+
+            // For L4S, the check for ECT(1) takes priority, and only when it's not
+            // supported by the controller, will it fall back to ECT(0) if supported.
+            Self::L4S if controller.enable_ect1() => Self::L4S,
+            Self::L4S if controller.enable_ect0() => Self::Classic,
+
+            _ => Self::Disabled,
+        }
+    }
+
+    /// Maps the ECN mode to the corresponding ECN codepoint if enabled, `None` otherwise.
+    pub fn codepoint(&self) -> Option<EcnCodepoint> {
+        match self {
+            Self::Disabled => None,
+            Self::Classic => Some(EcnCodepoint::Ect0),
+            Self::L4S => Some(EcnCodepoint::Ect1),
+        }
+    }
+}
 
 /// Parameters governing the core QUIC state machine
 ///
@@ -52,6 +101,7 @@ pub struct TransportConfig {
     #[cfg(test)]
     pub(crate) deterministic_packet_numbers: bool,
 
+    pub(crate) ecn_mode: EcnMode,
     pub(crate) congestion_controller_factory: Arc<dyn congestion::ControllerFactory + Send + Sync>,
 
     pub(crate) enable_segmentation_offload: bool,
@@ -321,6 +371,15 @@ impl TransportConfig {
         self
     }
 
+    /// Whether to enable sending Explicit Congestion Notification (ECN) if remote peer supports it
+    ///
+    /// This allows congestion controllers to rely on ECN-CE marks (echoed by the remote peer
+    /// through ECN counters) instead of drops for detecting congestion on the path.
+    pub fn enable_ecn(&mut self, value: EcnMode) -> &mut Self {
+        self.ecn_mode = value;
+        self
+    }
+
     /// How to construct new `congestion::Controller`s
     ///
     /// Typically the refcounted configuration of a `congestion::Controller`,
@@ -400,6 +459,7 @@ impl Default for TransportConfig {
             #[cfg(test)]
             deterministic_packet_numbers: false,
 
+            ecn_mode: EcnMode::Classic,
             congestion_controller_factory: Arc::new(congestion::CubicConfig::default()),
 
             enable_segmentation_offload: true,
@@ -436,6 +496,7 @@ impl fmt::Debug for TransportConfig {
             datagram_send_buffer_size,
             #[cfg(test)]
                 deterministic_packet_numbers: _,
+            ecn_mode,
             congestion_controller_factory: _,
             enable_segmentation_offload,
             qlog_sink,
@@ -470,6 +531,7 @@ impl fmt::Debug for TransportConfig {
             .field("allow_spin", allow_spin)
             .field("datagram_receive_buffer_size", datagram_receive_buffer_size)
             .field("datagram_send_buffer_size", datagram_send_buffer_size)
+            .field("ecn_mode", ecn_mode)
             // congestion_controller_factory not debug
             .field("enable_segmentation_offload", enable_segmentation_offload);
         if cfg!(feature = "qlog") {
@@ -615,7 +677,7 @@ impl QlogConfig {
             self.description,
             self.start_time,
             trace,
-            qlog::events::EventImportance::Core,
+            qlog::events::EventImportance::Extra,
             // `Instant` should have sub-microsecond precision on most platforms
             qlog::streamer::EventTimePrecision::NanoSeconds,
             writer,

--- a/quinn-proto/src/congestion.rs
+++ b/quinn-proto/src/congestion.rs
@@ -8,10 +8,12 @@ use std::sync::Arc;
 mod bbr;
 mod cubic;
 mod new_reno;
+mod prague;
 
 pub use bbr::{Bbr, BbrConfig};
 pub use cubic::{Cubic, CubicConfig};
 pub use new_reno::{NewReno, NewRenoConfig};
+pub use prague::{Prague, PragueConfig};
 
 /// Common interface for different congestion controllers
 pub trait Controller: Send + Sync {

--- a/quinn-proto/src/congestion.rs
+++ b/quinn-proto/src/congestion.rs
@@ -1,7 +1,7 @@
 //! Logic for controlling the rate at which data is sent
 
-use crate::Instant;
 use crate::connection::RttEstimator;
+use crate::{Instant, frame::EcnCounts};
 use std::any::Any;
 use std::sync::Arc;
 
@@ -60,14 +60,34 @@ pub trait Controller: Send + Sync {
         lost_bytes: u64,
     );
 
+    /// ECN counter increments were observed
+    ///
+    /// `increment` the increment of ECN counters compared to its value prior to the most recent ACK.
+    /// It is assumed that `increment` has at least one non-zero value (for ECT(0), ECT(1) or CE).
+    #[allow(unused_variables)]
+    fn on_ecn_delivery(&mut self, now: Instant, increment: EcnCounts) {}
+
     /// Packets were incorrectly deemed lost
     ///
     /// This function is called when all packets that were deemed lost (for instance because
     /// of packet reordering) are acknowledged after the congestion event was raised.
     fn on_spurious_congestion_event(&mut self) {}
 
+    /// Exit recovery/loss state
+    ///
+    /// This allows a controller to resume normal congestion window growth immediately.
+    #[allow(unused_variables)]
+    fn exit_recovery(&mut self, now: Instant) {}
+
     /// The known MTU for the current network path has been updated
     fn on_mtu_update(&mut self, new_mtu: u16);
+
+    /// Externally set the CWND size
+    fn set_window(&mut self, size: u64);
+
+    /// Externally set the slow start threshold size
+    #[allow(unused_variables)]
+    fn set_ssthresh(&mut self, size: u64) {}
 
     /// Number of ack-eliciting bytes that may be in flight
     fn window(&self) -> u64;
@@ -88,6 +108,18 @@ pub trait Controller: Send + Sync {
 
     /// Initial congestion window
     fn initial_window(&self) -> u64;
+
+    /// Assures the controller that using ECT(0) is supported and enabled by the endpoint.
+    /// Returns whether the controller supports and agrees to handle ECT(0) packets accordingly.
+    fn enable_ect0(&mut self) -> bool {
+        true
+    }
+
+    /// Assures the controller that using ECT(1) is supported and enabled by the endpoint.
+    /// Returns whether the controller supports and agrees to handle ECT(1) packets accordingly.
+    fn enable_ect1(&mut self) -> bool {
+        false
+    }
 
     /// Returns Self for use in down-casting to extract implementation details
     fn into_any(self: Box<Self>) -> Box<dyn Any>;
@@ -110,7 +142,12 @@ pub struct ControllerMetrics {
 /// Constructs controllers on demand
 pub trait ControllerFactory {
     /// Construct a fresh `Controller`
-    fn build(self: Arc<Self>, now: Instant, current_mtu: u16) -> Box<dyn Controller>;
+    fn build(
+        self: Arc<Self>,
+        now: Instant,
+        current_mtu: u16,
+        config: &crate::TransportConfig,
+    ) -> Box<dyn Controller>;
 }
 
 const BASE_DATAGRAM_SIZE: u64 = 1200;

--- a/quinn-proto/src/congestion/bbr/mod.rs
+++ b/quinn-proto/src/congestion/bbr/mod.rs
@@ -483,6 +483,10 @@ impl Controller for Bbr {
         self.cwnd = self.cwnd.max(self.min_cwnd);
     }
 
+    fn set_window(&mut self, size: u64) {
+        self.cwnd = size;
+    }
+
     fn window(&self) -> u64 {
         if self.mode == Mode::ProbeRtt {
             return self.get_probe_rtt_cwnd();
@@ -541,7 +545,12 @@ impl Default for BbrConfig {
 }
 
 impl ControllerFactory for BbrConfig {
-    fn build(self: Arc<Self>, _now: Instant, current_mtu: u16) -> Box<dyn Controller> {
+    fn build(
+        self: Arc<Self>,
+        _now: Instant,
+        current_mtu: u16,
+        _config: &crate::TransportConfig,
+    ) -> Box<dyn Controller> {
         Box::new(Bbr::new(self, current_mtu))
     }
 }

--- a/quinn-proto/src/congestion/cubic.rs
+++ b/quinn-proto/src/congestion/cubic.rs
@@ -40,6 +40,10 @@ pub(super) struct State {
     /// The time when QUIC first detects a loss, causing it to enter recovery. When a packet sent
     /// after this time is acknowledged, QUIC exits recovery.
     recovery_start_time: Option<Instant>,
+
+    /// The time when loss recovery started. Unlike `recovery_start_time`, this can be cleared
+    /// separately (e.g., on ECN events) to avoid blocking window growth for in-flight packets.
+    loss_recovery_start_time: Option<Instant>,
 }
 
 /// CUBIC Functions.
@@ -77,6 +81,8 @@ pub struct Cubic {
     config: Arc<CubicConfig>,
     current_mtu: u64,
     state: State,
+    /// Whether handling of ECN (specifically, ECT(0)) is allowed.
+    allow_ecn: bool,
     /// Copy of the controller state to restore when a spurious congestion event is detected.
     pre_congestion_state: Option<State>,
 }
@@ -90,6 +96,7 @@ impl Cubic {
                 ssthresh: u64::MAX,
                 ..Default::default()
             },
+            allow_ecn: false,
             current_mtu: current_mtu as u64,
             pre_congestion_state: None,
             config,
@@ -113,8 +120,8 @@ impl Controller for Cubic {
         if app_limited
             || self
                 .state
-                .recovery_start_time
-                .map(|recovery_start_time| sent <= recovery_start_time)
+                .loss_recovery_start_time
+                .map(|loss_recovery_start_time| sent <= loss_recovery_start_time)
                 .unwrap_or(false)
         {
             return;
@@ -205,6 +212,7 @@ impl Controller for Cubic {
         }
 
         self.state.recovery_start_time = Some(now);
+        self.state.loss_recovery_start_time = Some(now);
         let window = self.state.window as f64;
 
         // Fast convergence lowers W_max first; the 0.7 loss reduction still
@@ -225,6 +233,7 @@ impl Controller for Cubic {
 
         if is_persistent_congestion {
             self.state.recovery_start_time = None;
+            self.state.loss_recovery_start_time = None;
             self.state.w_max = self.state.window as f64;
 
             // 4.7 Timeout - reduce ssthresh based on BETA_CUBIC
@@ -247,9 +256,25 @@ impl Controller for Cubic {
         }
     }
 
+    fn exit_recovery(&mut self, _now: Instant) {
+        self.state.loss_recovery_start_time = None;
+    }
+
     fn on_mtu_update(&mut self, new_mtu: u16) {
         self.current_mtu = new_mtu as u64;
         self.state.window = self.state.window.max(self.minimum_window());
+    }
+
+    fn set_window(&mut self, size: u64) {
+        if (size as f64) < self.state.w_max {
+            self.state.w_max = size as f64 / BETA_CUBIC;
+            self.state.k = self.state.cubic_k(self.current_mtu);
+        }
+        self.state.window = size;
+    }
+
+    fn set_ssthresh(&mut self, size: u64) {
+        self.state.ssthresh = size;
     }
 
     fn window(&self) -> u64 {
@@ -271,6 +296,11 @@ impl Controller for Cubic {
 
     fn initial_window(&self) -> u64 {
         self.config.initial_window
+    }
+
+    fn enable_ect0(&mut self) -> bool {
+        self.allow_ecn = true;
+        true
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {
@@ -303,7 +333,12 @@ impl Default for CubicConfig {
 }
 
 impl ControllerFactory for CubicConfig {
-    fn build(self: Arc<Self>, now: Instant, current_mtu: u16) -> Box<dyn Controller> {
+    fn build(
+        self: Arc<Self>,
+        now: Instant,
+        current_mtu: u16,
+        _config: &crate::TransportConfig,
+    ) -> Box<dyn Controller> {
         Box::new(Cubic::new(self, now, current_mtu))
     }
 }

--- a/quinn-proto/src/congestion/new_reno.rs
+++ b/quinn-proto/src/congestion/new_reno.rs
@@ -16,19 +16,19 @@ pub struct NewReno {
     /// slow start and the window grows by the number of bytes acknowledged.
     ssthresh: u64,
     /// The time when QUIC first detects a loss, causing it to enter recovery. When a packet sent
-    /// after this time is acknowledged, QUIC exits recovery.
-    recovery_start_time: Instant,
+    /// after this time is acknowledged, QUIC exits recovery. `None` if not currently in recovery.
+    recovery_start_time: Option<Instant>,
     /// Bytes which had been acked by the peer since leaving slow start
     bytes_acked: u64,
 }
 
 impl NewReno {
     /// Construct a state using the given `config` and current time `now`
-    pub fn new(config: Arc<NewRenoConfig>, now: Instant, current_mtu: u16) -> Self {
+    pub fn new(config: Arc<NewRenoConfig>, _now: Instant, current_mtu: u16) -> Self {
         Self {
             window: config.initial_window,
             ssthresh: u64::MAX,
-            recovery_start_time: now,
+            recovery_start_time: None,
             current_mtu: current_mtu as u64,
             config,
             bytes_acked: 0,
@@ -49,7 +49,12 @@ impl Controller for NewReno {
         app_limited: bool,
         _rtt: &RttEstimator,
     ) {
-        if app_limited || sent <= self.recovery_start_time {
+        if app_limited
+            || self
+                .recovery_start_time
+                .map(|recovery_start_time| sent <= recovery_start_time)
+                .unwrap_or(false)
+        {
             return;
         }
 
@@ -90,11 +95,15 @@ impl Controller for NewReno {
         _is_ecn: bool,
         _lost_bytes: u64,
     ) {
-        if sent <= self.recovery_start_time {
+        if self
+            .recovery_start_time
+            .map(|recovery_start_time| sent <= recovery_start_time)
+            .unwrap_or(false)
+        {
             return;
         }
 
-        self.recovery_start_time = now;
+        self.recovery_start_time = Some(now);
         self.window = (self.window as f32 * self.config.loss_reduction_factor) as u64;
         self.window = self.window.max(self.minimum_window());
         self.ssthresh = self.window;
@@ -104,9 +113,21 @@ impl Controller for NewReno {
         }
     }
 
+    fn exit_recovery(&mut self, _now: Instant) {
+        self.recovery_start_time = None;
+    }
+
     fn on_mtu_update(&mut self, new_mtu: u16) {
         self.current_mtu = new_mtu as u64;
         self.window = self.window.max(self.minimum_window());
+    }
+
+    fn set_window(&mut self, size: u64) {
+        self.window = size;
+    }
+
+    fn set_ssthresh(&mut self, size: u64) {
+        self.ssthresh = size;
     }
 
     fn window(&self) -> u64 {
@@ -168,7 +189,12 @@ impl Default for NewRenoConfig {
 }
 
 impl ControllerFactory for NewRenoConfig {
-    fn build(self: Arc<Self>, now: Instant, current_mtu: u16) -> Box<dyn Controller> {
+    fn build(
+        self: Arc<Self>,
+        now: Instant,
+        current_mtu: u16,
+        _config: &crate::TransportConfig,
+    ) -> Box<dyn Controller> {
         Box::new(NewReno::new(self, now, current_mtu))
     }
 }

--- a/quinn-proto/src/congestion/prague.rs
+++ b/quinn-proto/src/congestion/prague.rs
@@ -1,0 +1,289 @@
+use std::any::Any;
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::{Controller, ControllerFactory};
+use crate::congestion::{NewReno, NewRenoConfig};
+use crate::connection::RttEstimator;
+use crate::connection::qlog::QlogSink;
+use crate::frame::EcnCounts;
+use crate::{ConnectionId, Instant};
+
+/// A port of the Prague congestion controller to Quinn
+#[derive(Clone)]
+pub struct Prague {
+    controller: NewReno,
+    ect1_enabled: bool,
+    ect_count: f64,
+    ce_count: f64,
+    last_alpha_update: Instant,
+    alpha: Option<f64>,
+    rtt_virt: Duration,
+    last_ecn_reduction: Option<(Instant, u64)>,
+    in_loss_regime: bool,
+    reduce_rtt_dependence: bool,
+    connection_start_time: Instant,
+    qlog_sink: QlogSink,
+}
+
+impl Prague {
+    /// Following the Linux Prague reference implementation's choice of constants according to
+    /// 2.4.4. Reduced RTT-Dependence (draft-briscoe-iccrg-prague-congestion-control-04)
+    const RTT_VIRT_MIN: Duration = Duration::from_millis(25);
+
+    const EWMA_GAIN: f64 = 1.0 / 16.0;
+
+    /// Construct a state using the given `config` and current time `now`
+    pub fn new(_config: Arc<PragueConfig>, now: Instant, current_mtu: u16) -> Self {
+        let reno_config = Arc::new(NewRenoConfig::default());
+        let reno = NewReno::new(reno_config, now, current_mtu);
+
+        Self {
+            controller: reno,
+            ect1_enabled: false,
+            ect_count: 0.0,
+            ce_count: 0.0,
+            last_alpha_update: now,
+            alpha: None,
+            rtt_virt: Self::RTT_VIRT_MIN,
+            in_loss_regime: false,
+            last_ecn_reduction: None,
+            reduce_rtt_dependence: false,
+            connection_start_time: now,
+            qlog_sink: QlogSink::default(),
+        }
+    }
+}
+
+impl Controller for Prague {
+    fn on_ack(
+        &mut self,
+        now: Instant,
+        sent: Instant,
+        bytes: u64,
+        app_limited: bool,
+        rtt: &RttEstimator,
+    ) {
+        // Use a corrected, virtual RTT by adjusting the smoothed RTT to account for long-running
+        // classic flows with high RTTs, as recommended in A.1.6. Reduce RTT Dependence (RFC9331)
+        self.rtt_virt = rtt.get().max(Self::RTT_VIRT_MIN);
+
+        if !self.ect1_enabled {
+            self.controller.on_ack(now, sent, bytes, app_limited, rtt);
+            return;
+        }
+
+        let original_cwnd = self.controller.window();
+        self.controller.on_ack(now, sent, bytes, app_limited, rtt);
+
+        let new_cwnd = self.controller.window();
+        if new_cwnd > original_cwnd {
+            // Check if we are in slow start.
+            let in_slow_start = self
+                .controller
+                .metrics()
+                .ssthresh
+                .map(|ssthresh| original_cwnd < ssthresh)
+                .unwrap_or(false);
+
+            if !in_slow_start {
+                if !self.reduce_rtt_dependence {
+                    self.reduce_rtt_dependence =
+                        now.saturating_duration_since(self.connection_start_time) > rtt.get() * 500;
+                }
+
+                if self.reduce_rtt_dependence && !self.in_loss_regime {
+                    let srtt = rtt.get();
+                    let ratio = srtt.as_secs_f64() / self.rtt_virt.as_secs_f64();
+                    let deflator = (ratio * ratio).min(1.0);
+                    let cwnd_increase = new_cwnd - original_cwnd;
+                    let scaled_increase = (cwnd_increase as f64 * deflator) as u64;
+                    self.controller.set_window(original_cwnd + scaled_increase);
+                }
+            }
+        }
+
+        // Exit loss regime to re-enable CWND growth deflation.
+        self.in_loss_regime = true;
+    }
+
+    fn on_ecn_delivery(&mut self, now: Instant, increment: EcnCounts) {
+        if !self.ect1_enabled || (increment.ect1 == 0 && increment.ce == 0) {
+            return; // Not an event that concerns an L4S controller such as Prague
+        }
+        if let Some(alpha) = self.alpha {
+            self.ect_count += increment.ect1 as f64;
+            self.ce_count += increment.ce as f64;
+            if now.saturating_duration_since(self.last_alpha_update) > self.rtt_virt {
+                let frac: f64 = self.ce_count / (self.ce_count + self.ect_count);
+                self.alpha = Some((1.0 - Self::EWMA_GAIN) * alpha + Self::EWMA_GAIN * frac);
+                // Emit a log for debugging purposes.
+                self.qlog_sink
+                    .emit_l4s_event(self.alpha.unwrap(), now, ConnectionId::new(&[]));
+                self.last_alpha_update = now;
+                self.ect_count = 0.0;
+                self.ce_count = 0.0;
+            }
+        } else if increment.ce > 0 {
+            // Initialize alpha to 1.0 on the first CE mark, per the Prague spec.
+            self.alpha = Some(1.0);
+            // Emit a log for debugging purposes.
+            self.qlog_sink
+                .emit_l4s_event(self.alpha.unwrap(), now, ConnectionId::new(&[]));
+            self.last_alpha_update = now;
+            self.ect_count = increment.ect1 as f64;
+            self.ce_count = increment.ce as f64;
+        }
+    }
+
+    fn on_congestion_event(
+        &mut self,
+        now: Instant,
+        sent: Instant,
+        is_persistent_congestion: bool,
+        is_ecn: bool,
+        lost_bytes: u64,
+    ) {
+        if !self.ect1_enabled {
+            self.controller.on_congestion_event(
+                now,
+                sent,
+                is_persistent_congestion,
+                is_ecn,
+                lost_bytes,
+            );
+            return;
+        }
+
+        // Handle Loss (loss-only / ECN+loss).
+        if lost_bytes > 0 {
+            // Check if we should account for a recent ECN reduction to avoid double-dipping.
+            if let Some((last_time, last_reduction_size)) = self.last_ecn_reduction {
+                if now.saturating_duration_since(last_time) < self.rtt_virt {
+                    // Undo the ECN reduction in the underlying controller.
+                    let undone_cwnd = self.controller.window() + last_reduction_size;
+                    self.controller.set_window(undone_cwnd);
+                    self.controller.set_ssthresh(undone_cwnd);
+                }
+            }
+
+            // Arm the ECN cooldown from this loss event, instead of clearing it, so that a CE mark
+            // arriving shortly after this loss does not trigger a second, independent
+            // multiplicative decrease on top of the one we are about to apply below.
+            self.last_ecn_reduction = Some((now, 0));
+
+            // Make sure to enter loss regime to disable CWND growth deflation for the next ACK.
+            self.in_loss_regime = true;
+
+            // Delegate loss handling to the underlying controller.
+            self.controller.on_congestion_event(
+                now,
+                sent,
+                is_persistent_congestion,
+                false, // Treat as normal loss event
+                lost_bytes,
+            );
+            return;
+        }
+
+        // Handle pure ECN congestion event.
+        if is_ecn {
+            // Limit ECN window reduction to at most once per virtual RTT.
+            // This is necessary to satisfy 2.4.2. Multiplicative Decrease on ECN Feedback <draft-briscoe-iccrg-prague-congestion-control-04> stating
+            // > the Prague CC [...] only triggers a multiplicative decrease to its congestion window when
+            // > it actually receives an ACK carrying ECN feedback. Then it suppresses any further decreases
+            // > for one round trip, even if it receives further ECN feedback."
+            let in_cooldown = self
+                .last_ecn_reduction
+                .map(|(last_time, _)| now.saturating_duration_since(last_time) < self.rtt_virt)
+                .unwrap_or(false);
+
+            if !in_cooldown {
+                let original_cwnd = self.controller.window();
+
+                // Call the underlying controller's congestion event handler to set up recovery state,
+                // update recovery_start_time, reset the cubic/reno epoch, etc.
+                self.controller
+                    .on_congestion_event(now, sent, is_persistent_congestion, true, 0);
+
+                // Find out how much the underlying controller reduced the window.
+                let cwnd_reduction = original_cwnd.saturating_sub(self.controller.window());
+
+                // Scale the reduction by alpha.
+                let alpha = self.alpha.unwrap_or(0.0);
+                let prague_reduction = (cwnd_reduction as f64 * alpha) as u64;
+
+                // Apply the Prague ECN-scaled reduction.
+                let new_cwnd = original_cwnd.saturating_sub(prague_reduction);
+                self.controller.set_window(new_cwnd);
+                self.controller.set_ssthresh(new_cwnd);
+                self.controller.exit_recovery(now);
+
+                // Record the reduction details.
+                self.last_ecn_reduction = Some((now, prague_reduction));
+            }
+        }
+    }
+
+    fn exit_recovery(&mut self, now: Instant) {
+        self.controller.exit_recovery(now);
+    }
+
+    fn on_mtu_update(&mut self, new_mtu: u16) {
+        self.controller.on_mtu_update(new_mtu);
+    }
+
+    fn set_window(&mut self, size: u64) {
+        self.controller.set_window(size);
+    }
+
+    fn set_ssthresh(&mut self, size: u64) {
+        self.controller.set_ssthresh(size);
+    }
+
+    fn window(&self) -> u64 {
+        self.controller.window()
+    }
+
+    fn metrics(&self) -> super::ControllerMetrics {
+        self.controller.metrics()
+    }
+
+    fn clone_box(&self) -> Box<dyn Controller> {
+        Box::new(self.clone())
+    }
+
+    fn initial_window(&self) -> u64 {
+        self.controller.initial_window()
+    }
+
+    fn enable_ect0(&mut self) -> bool {
+        self.controller.enable_ect0()
+    }
+
+    fn enable_ect1(&mut self) -> bool {
+        self.ect1_enabled = true;
+        true
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+}
+
+/// Configuration for the [`Prague`] congestion controller
+#[derive(Debug, Clone, Default)]
+pub struct PragueConfig {}
+
+impl ControllerFactory for PragueConfig {
+    fn build(
+        self: Arc<Self>,
+        now: Instant,
+        current_mtu: u16,
+        config: &crate::TransportConfig,
+    ) -> Box<dyn Controller> {
+        let mut prague = Prague::new(self.clone(), now, current_mtu);
+        prague.qlog_sink = config.qlog_sink.clone();
+        Box::new(prague)
+    }
+}

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -774,6 +774,7 @@ impl Connection {
                 buf,
                 buf_capacity,
                 datagram_start,
+                None,
                 ack_eliciting,
                 self,
             )?);
@@ -941,6 +942,12 @@ impl Connection {
 
         self.app_limited = buf.is_empty() && !congestion_blocked;
 
+        let ecn = if self.path.using_ecn {
+            self.path.ecn_mode.codepoint()
+        } else {
+            None
+        };
+
         // Send MTU probe if necessary
         if buf.is_empty() && self.state.is_established() {
             let space_id = SpaceId::Data;
@@ -959,6 +966,7 @@ impl Connection {
                 buf,
                 buf_capacity,
                 0,
+                ecn,
                 true,
                 self,
             )?;
@@ -998,11 +1006,7 @@ impl Connection {
         Some(Transmit {
             destination: self.path.remote,
             size: buf.len(),
-            ecn: if self.path.sending_ecn {
-                Some(EcnCodepoint::Ect0)
-            } else {
-                None
-            },
+            ecn,
             segment_size: match num_datagrams {
                 1 => None,
                 _ => Some(segment_size),
@@ -1043,6 +1047,7 @@ impl Connection {
             buf,
             buf_capacity,
             0,
+            None,
             false,
             self,
         )?;
@@ -1267,6 +1272,7 @@ impl Connection {
     pub fn stats(&self) -> ConnectionStats {
         let mut stats = self.stats;
         stats.path.rtt = self.path.rtt.get();
+        stats.path.rttvar = self.path.rtt.var();
         stats.path.cwnd = self.path.congestion.window();
         stats.path.bandwidth_estimate = self.path.congestion.metrics().bandwidth_estimate;
         stats.path.current_mtu = self.path.mtud.current_mtu();
@@ -1464,9 +1470,20 @@ impl Connection {
 
         // Avoid DoS from unreasonably huge ack ranges by filtering out just the new acks.
         let mut newly_acked = ArrayRangeSet::new();
+        let mut newly_acked_ect0 = 0u64;
+        let mut newly_acked_ect1 = 0u64;
         for range in ack.iter() {
             self.packet_number_filter.check_ack(space, range.clone())?;
-            for (pn, _) in self.spaces[space].sent_packets.range(range) {
+            for (pn, pkt_info) in self.spaces[space].sent_packets.range(range) {
+                match pkt_info.ecn {
+                    Some(EcnCodepoint::Ect0) => {
+                        newly_acked_ect0 += 1;
+                    }
+                    Some(EcnCodepoint::Ect1) => {
+                        newly_acked_ect1 += 1;
+                    }
+                    _ => {}
+                }
                 newly_acked.insert_one(pn);
             }
         }
@@ -1535,7 +1552,7 @@ impl Connection {
         }
 
         // Explicit congestion notification
-        if self.path.sending_ecn {
+        if self.path.using_ecn {
             if let Some(ecn) = ack.ecn {
                 // We only examine ECN counters from ACKs that we are certain we received in transmit
                 // order, allowing us to compute an increase in ECN counts to compare against the number
@@ -1543,12 +1560,15 @@ impl Connection {
                 // reordering.
                 if new_largest {
                     let sent = self.spaces[space].largest_acked_packet_sent;
-                    self.process_ecn(now, space, newly_acked.len() as u64, ecn, sent);
+                    self.process_ecn(now, space, newly_acked_ect0, newly_acked_ect1, ecn, sent);
                 }
-            } else {
-                // We always start out sending ECN, so any ack that doesn't acknowledge it disables it.
+            } else if newly_acked_ect0 > 0 || newly_acked_ect1 > 0 {
+                // We sent out packets marked with ECN, so any ack that doesn't acknowledge it disables it.
                 debug!("ECN not acknowledged by peer");
-                self.path.sending_ecn = false;
+                self.path.using_ecn = false;
+                self.config
+                    .qlog_sink
+                    .emit_ecn_state_update(false, now, self.orig_rem_cid);
             }
         }
 
@@ -1598,25 +1618,47 @@ impl Connection {
         &mut self,
         now: Instant,
         space: SpaceId,
-        newly_acked: u64,
+        newly_acked_ect0: u64,
+        newly_acked_ect1: u64,
         ecn: frame::EcnCounts,
         largest_sent_time: Instant,
     ) {
-        match self.spaces[space].detect_ecn(newly_acked, ecn) {
+        match self.spaces[space].detect_ecn(newly_acked_ect0, newly_acked_ect1, ecn) {
             Err(e) => {
                 debug!("halting ECN due to verification failure: {}", e);
-                self.path.sending_ecn = false;
+                // NOTE: negotiation may not be completely necessary, since this and another check
+                // essentially disables the use of ECN in case there's no ECN-echoing or if the
+                // echoing peer is faulty.
+                self.path.using_ecn = false;
+                self.config
+                    .qlog_sink
+                    .emit_ecn_state_update(false, now, self.orig_rem_cid);
+
                 // Wipe out the existing value because it might be garbage and could interfere with
                 // future attempts to use ECN on new paths.
                 self.spaces[space].ecn_feedback = frame::EcnCounts::ZERO;
             }
-            Ok(false) => {}
-            Ok(true) => {
-                self.stats.path.congestion_events += 1;
-                self.path
-                    .congestion
-                    .on_congestion_event(now, largest_sent_time, false, true, 0);
+            Ok(increment) if increment.ect1 > 0 || increment.ect0 > 0 || increment.ce > 0 => {
+                self.path.congestion.on_ecn_delivery(now, increment);
+                if increment.ce > 0 {
+                    debug!(
+                        "ECN counter increments: ECT(1) = {}, CE = {}",
+                        increment.ect1, increment.ce
+                    );
+                    self.stats.path.congestion_events += 1;
+                    self.path.congestion.on_congestion_event(
+                        now,
+                        largest_sent_time,
+                        false,
+                        true,
+                        0,
+                    );
+                    self.config
+                        .qlog_sink
+                        .emit_ecn_event(increment, now, self.orig_rem_cid);
+                }
             }
+            _ => {}
         }
     }
 
@@ -1843,6 +1885,9 @@ impl Connection {
                     false,
                     size_of_lost_packets,
                 );
+                self.config
+                    .qlog_sink
+                    .emit_loss_event(size_of_lost_packets, now, self.orig_rem_cid);
             }
         }
 
@@ -3668,7 +3713,7 @@ impl Connection {
     /// Whether explicit congestion notification is in use on outgoing packets.
     #[cfg(test)]
     pub(crate) fn using_ecn(&self) -> bool {
-        self.path.sending_ecn
+        self.path.using_ecn
     }
 
     /// The number of received bytes in the current path

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -4,7 +4,7 @@ use tracing::{debug, trace, trace_span};
 
 use super::{Connection, SentFrames, spaces::SentPacket};
 use crate::{
-    ConnectionId, Instant, TransportError, TransportErrorCode,
+    ConnectionId, EcnCodepoint, Instant, TransportError, TransportErrorCode,
     connection::ConnectionSide,
     frame::{self, Close},
     packet::{FIXED_BIT, Header, InitialHeader, LongType, PacketNumber, PartialEncode, SpaceId},
@@ -14,6 +14,7 @@ pub(super) struct PacketBuilder {
     pub(super) datagram_start: usize,
     pub(super) space: SpaceId,
     pub(super) partial_encode: PartialEncode,
+    pub(super) ecn: Option<EcnCodepoint>,
     pub(super) ack_eliciting: bool,
     pub(super) exact_number: u64,
     pub(super) short_header: bool,
@@ -39,6 +40,7 @@ impl PacketBuilder {
         buffer: &mut Vec<u8>,
         buffer_capacity: usize,
         datagram_start: usize,
+        ecn: Option<EcnCodepoint>,
         ack_eliciting: bool,
         conn: &mut Connection,
     ) -> Option<Self> {
@@ -164,6 +166,7 @@ impl PacketBuilder {
             min_size,
             max_size,
             tag_len,
+            ecn,
             ack_eliciting,
             _span: span,
         })
@@ -188,6 +191,7 @@ impl PacketBuilder {
         sent: Option<SentFrames>,
         buffer: &mut Vec<u8>,
     ) {
+        let ecn = self.ecn;
         let ack_eliciting = self.ack_eliciting;
         let exact_number = self.exact_number;
         let space_id = self.space;
@@ -206,6 +210,7 @@ impl PacketBuilder {
             largest_acked: sent.largest_acked,
             time_sent: now,
             size,
+            ecn,
             ack_eliciting,
             retransmits: sent.retransmits,
             stream_frames: sent.stream_frames,

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -7,7 +7,9 @@ use super::{
     pacing::Pacer,
     spaces::{PacketSpace, SentPacket},
 };
-use crate::{Duration, Instant, TIMER_GRANULARITY, TransportConfig, congestion, packet::SpaceId};
+use crate::{
+    Duration, EcnMode, Instant, TIMER_GRANULARITY, TransportConfig, congestion, packet::SpaceId,
+};
 
 #[cfg(feature = "qlog")]
 use qlog::events::{ExData, quic::RecoveryMetricsUpdated};
@@ -16,8 +18,16 @@ use qlog::events::{ExData, quic::RecoveryMetricsUpdated};
 pub(super) struct PathData {
     pub(super) remote: SocketAddr,
     pub(super) rtt: RttEstimator,
-    /// Whether we're enabling ECN on outgoing packets
-    pub(super) sending_ecn: bool,
+    /// Configured ECN mode
+    ///
+    /// NOTE: this is a configuration value, not an operational status. It indicates what the user
+    /// wants to do, not what the path is actually doing.
+    pub(super) ecn_mode: EcnMode,
+    /// Whether we're currently marking outgoing packets with ECT and checking received ECN counts
+    ///
+    /// NOTE: this is an operational status, a simple bool flag indicating if ECN is enabled on
+    /// this path
+    pub(super) using_ecn: bool,
     /// Congestion controller state
     pub(super) congestion: Box<dyn congestion::Controller>,
     /// Pacing state
@@ -63,14 +73,17 @@ impl PathData {
         now: Instant,
         config: &TransportConfig,
     ) -> Self {
-        let congestion = config
-            .congestion_controller_factory
-            .clone()
-            .build(now, config.get_initial_mtu());
+        let mut congestion = config.congestion_controller_factory.clone().build(
+            now,
+            config.get_initial_mtu(),
+            config,
+        );
+        let ecn_mode = config.ecn_mode.supported_mode(&mut congestion);
         Self {
             remote,
             rtt: RttEstimator::new(config.initial_rtt),
-            sending_ecn: true,
+            ecn_mode,
+            using_ecn: ecn_mode.is_enabled(),
             pacing: Pacer::new(
                 config.initial_rtt,
                 congestion.initial_window(),
@@ -115,18 +128,21 @@ impl PathData {
         now: Instant,
     ) -> Self {
         let congestion = prev.congestion.clone_box();
-        let smoothed_rtt = prev.rtt.get();
         Self {
             remote,
             rtt: prev.rtt,
             pacing: Pacer::new(
-                smoothed_rtt,
+                prev.rtt.get(),
                 congestion.window(),
                 prev.current_mtu(),
                 prev.pacing.max_bytes_per_second(),
                 now,
             ),
-            sending_ecn: true,
+            ecn_mode: prev.ecn_mode,
+            // Note that we can't rely on the previous path's `using_ecn` value here, as it may
+            // have been disabled due to ECN failure. We should re-enable it on the new path should
+            // the configuration allow it.
+            using_ecn: prev.ecn_mode.is_enabled(),
             congestion,
             challenge: None,
             challenge_pending: false,
@@ -148,10 +164,11 @@ impl PathData {
     /// This is useful when it is known the underlying path has changed.
     pub(super) fn reset(&mut self, now: Instant, config: &TransportConfig) {
         self.rtt = RttEstimator::new(config.initial_rtt);
-        self.congestion = config
-            .congestion_controller_factory
-            .clone()
-            .build(now, config.get_initial_mtu());
+        self.congestion = config.congestion_controller_factory.clone().build(
+            now,
+            config.get_initial_mtu(),
+            config,
+        );
         self.mtud.reset(config.get_initial_mtu(), config.min_mtu);
     }
 
@@ -323,6 +340,11 @@ impl RttEstimator {
     /// The current best RTT estimation.
     pub fn get(&self) -> Duration {
         self.smoothed.unwrap_or(self.latest)
+    }
+
+    /// The current best jitter estimation
+    pub fn var(&self) -> Duration {
+        self.var
     }
 
     /// Conservative estimate of RTT

--- a/quinn-proto/src/connection/qlog.rs
+++ b/quinn-proto/src/connection/qlog.rs
@@ -19,7 +19,7 @@ use qlog::{
 use tracing::warn;
 
 use crate::{
-    ConnectionId, Instant,
+    ConnectionId, EcnCounts, Instant,
     connection::{PathData, SentPacket},
     packet::SpaceId,
 };
@@ -172,6 +172,116 @@ impl QlogSink {
             };
 
             stream.emit_event(orig_rem_cid, EventData::QuicPacketReceived(event), now);
+        }
+    }
+
+    pub(super) fn emit_loss_event(
+        &self,
+        size_of_lost_packets: u64,
+        now: Instant,
+        orig_rem_cid: ConnectionId,
+    ) {
+        #[cfg(feature = "qlog")]
+        {
+            use qlog::events::quic::{CongestionStateUpdated, CongestionStateUpdatedTrigger};
+
+            let Some(stream) = self.stream.as_ref() else {
+                return;
+            };
+
+            let event = CongestionStateUpdated {
+                old: None,
+                new: format!("LOSS:size_of_lost_packets={}", size_of_lost_packets),
+                trigger: Some(CongestionStateUpdatedTrigger::Unknown),
+            };
+
+            stream.emit_event(
+                orig_rem_cid,
+                EventData::QuicCongestionStateUpdated(event),
+                now,
+            );
+        }
+    }
+
+    pub(super) fn emit_ecn_event(
+        &self,
+        increment: EcnCounts,
+        now: Instant,
+        orig_rem_cid: ConnectionId,
+    ) {
+        #[cfg(feature = "qlog")]
+        {
+            use qlog::events::quic::{CongestionStateUpdated, CongestionStateUpdatedTrigger};
+
+            let Some(stream) = self.stream.as_ref() else {
+                return;
+            };
+
+            let event = CongestionStateUpdated {
+                old: None,
+                new: format!(
+                    "ECN:ect0+={},ect1+={},ce+={}",
+                    increment.ect0, increment.ect1, increment.ce
+                ),
+                trigger: Some(CongestionStateUpdatedTrigger::Ecn),
+            };
+
+            stream.emit_event(
+                orig_rem_cid,
+                EventData::QuicCongestionStateUpdated(event),
+                now,
+            );
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn emit_l4s_event(&self, alpha: f64, now: Instant, orig_rem_cid: ConnectionId) {
+        #[cfg(feature = "qlog")]
+        {
+            use qlog::events::quic::{CongestionStateUpdated, CongestionStateUpdatedTrigger};
+
+            let Some(stream) = self.stream.as_ref() else {
+                return;
+            };
+
+            let event = CongestionStateUpdated {
+                old: None,
+                new: format!("ALPHA:alpha={:?}", alpha),
+                trigger: Some(CongestionStateUpdatedTrigger::Ecn),
+            };
+
+            stream.emit_event(
+                orig_rem_cid,
+                EventData::QuicCongestionStateUpdated(event),
+                now,
+            );
+        }
+    }
+
+    pub(super) fn emit_ecn_state_update(
+        &self,
+        ecn_capable: bool,
+        now: Instant,
+        orig_rem_cid: ConnectionId,
+    ) {
+        #[cfg(feature = "qlog")]
+        {
+            use qlog::events::quic::{EcnState, EcnStateUpdated};
+
+            let Some(stream) = self.stream.as_ref() else {
+                return;
+            };
+
+            let event = EcnStateUpdated {
+                old: None,
+                new: if ecn_capable {
+                    EcnState::Capable
+                } else {
+                    EcnState::Failed
+                },
+            };
+
+            stream.emit_event(orig_rem_cid, EventData::QuicEcnStateUpdated(event), now);
         }
     }
 }

--- a/quinn-proto/src/connection/sent_packets.rs
+++ b/quinn-proto/src/connection/sent_packets.rs
@@ -248,6 +248,7 @@ mod tests {
             path_generation: 0,
             time_sent: Instant::now(),
             size,
+            ecn: None,
             ack_eliciting: false,
             largest_acked: None,
             retransmits: Default::default(),

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -12,9 +12,9 @@ use tracing::trace;
 use super::assembler::Assembler;
 use super::sent_packets::SentPackets;
 use crate::{
-    Dir, Duration, Instant, SocketAddr, StreamId, TransportError, VarInt, cid_queue::CidQueue,
-    connection::StreamsState, crypto::Keys, frame, packet::SpaceId, range_set::ArrayRangeSet,
-    shared::IssuedCid,
+    Dir, Duration, EcnCodepoint, Instant, SocketAddr, StreamId, TransportError, VarInt,
+    cid_queue::CidQueue, connection::StreamsState, crypto::Keys, frame, packet::SpaceId,
+    range_set::ArrayRangeSet, shared::IssuedCid,
 };
 
 pub(super) struct PacketSpace {
@@ -175,12 +175,13 @@ impl PacketSpace {
         SendableFrames { acks, other }
     }
 
-    /// Verifies sanity of an ECN block and returns whether congestion was encountered.
+    /// Verifies sanity of an ECN block and returns the increase in each counter.
     pub(super) fn detect_ecn(
         &mut self,
-        newly_acked: u64,
+        newly_acked_ect0: u64,
+        newly_acked_ect1: u64,
         ecn: frame::EcnCounts,
-    ) -> Result<bool, &'static str> {
+    ) -> Result<frame::EcnCounts, &'static str> {
         let ect0_increase = ecn
             .ect0
             .checked_sub(self.ecn_feedback.ect0)
@@ -193,19 +194,25 @@ impl PacketSpace {
             .ce
             .checked_sub(self.ecn_feedback.ce)
             .ok_or("peer CE count regression")?;
-        let total_increase = ect0_increase + ect1_increase + ce_increase;
-        if total_increase < newly_acked {
+
+        if ect0_increase + ce_increase < newly_acked_ect0
+            || ect1_increase + ce_increase < newly_acked_ect1
+            || ect0_increase + ect1_increase + ce_increase < newly_acked_ect0 + newly_acked_ect1
+        {
             return Err("ECN bleaching");
         }
-        if (ect0_increase + ce_increase) < newly_acked || ect1_increase != 0 {
-            return Err("ECN corruption");
-        }
-        // If total_increase > newly_acked (which happens when ACKs are lost), this is required by
+
+        // It is okay, if increase > newly_acked (which happens when ACKs are lost), as per
         // the draft so that long-term drift does not occur. If =, then the only question is whether
         // to count CE packets as CE or ECT0. Recording them as CE is more consistent and keeps the
         // congestion check obvious.
+
         self.ecn_feedback = ecn;
-        Ok(ce_increase != 0)
+        Ok(frame::EcnCounts {
+            ect0: ect0_increase,
+            ect1: ect1_increase,
+            ce: ce_increase,
+        })
     }
 
     /// Stop tracking sent packet `number`, and return what we knew about it
@@ -290,6 +297,8 @@ pub(super) struct SentPacket {
     /// framing overhead. Zero if this packet is not counted towards congestion control, i.e. not an
     /// "in flight" packet.
     pub(super) size: u16,
+    /// The ECN bits set on the packet.
+    pub(super) ecn: Option<EcnCodepoint>,
     /// Whether an acknowledgement is expected directly in response to this packet.
     pub(super) ack_eliciting: bool,
     /// The largest packet number acknowledged by this packet

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -136,6 +136,8 @@ impl std::fmt::Debug for FrameStats {
 pub struct PathStats {
     /// Current best estimate of this connection's latency (round-trip-time)
     pub rtt: Duration,
+    /// Current best estimate of this connection's latency variation (jitter)
+    pub rttvar: Duration,
     /// Current congestion window of the connection
     pub cwnd: u64,
     /// Congestion controller's estimate of sustainable path bandwidth, in bits per second
@@ -143,7 +145,8 @@ pub struct PathStats {
     /// `None` when the congestion controller does not provide an estimate.
     pub bandwidth_estimate: Option<u64>,
     /// Congestion events on the connection
-    pub congestion_events: u64,
+    pub congestion_events: u64, // TODO: consider replacing this with a more fine-grade
+    // counter that distinguishes between drop and mark events
     /// Spurious congestion events on the connection
     pub spurious_congestion_events: u64,
     /// The amount of packets lost on this path

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -414,10 +414,14 @@ impl Ack {
     }
 }
 
+/// Encapsulates the number of ECT(0), ECT(1) and CE marked packets in a certain context.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub(crate) struct EcnCounts {
+pub struct EcnCounts {
+    /// The number of ECT(0) packets
     pub ect0: u64,
+    /// The number of ECT(1) packets
     pub ect1: u64,
+    /// The number of CE packets
     pub ce: u64,
 }
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -59,15 +59,16 @@ mod config;
 #[cfg(feature = "qlog")]
 pub use config::QlogConfig;
 pub use config::{
-    AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig,
-    ServerConfig, StdSystemTime, TimeSource, TransportConfig, ValidationTokenConfig,
+    AckFrequencyConfig, ClientConfig, ConfigError, EcnMode, EndpointConfig, IdleTimeout,
+    MtuDiscoveryConfig, ServerConfig, StdSystemTime, TimeSource, TransportConfig,
+    ValidationTokenConfig,
 };
 
 pub mod crypto;
 
 mod frame;
 use crate::frame::Frame;
-pub use crate::frame::{ApplicationClose, ConnectionClose, Datagram, FrameType};
+pub use crate::frame::{ApplicationClose, ConnectionClose, Datagram, EcnCounts, FrameType};
 
 mod endpoint;
 pub use crate::endpoint::{

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -189,6 +189,10 @@ fn stats_include_congestion_controller_bandwidth_estimate() {
         fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
             self
         }
+
+        fn set_window(&mut self, _size: u64) {
+            // ignore
+        }
     }
 
     struct TestControllerFactory;
@@ -198,6 +202,7 @@ fn stats_include_congestion_controller_bandwidth_estimate() {
             self: Arc<Self>,
             _now: Instant,
             _current_mtu: u16,
+            _config: &TransportConfig,
         ) -> Box<dyn congestion::Controller> {
             Box::new(TestController)
         }

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -60,11 +60,11 @@ pub use proto::BloomTokenLog;
 pub use proto::{
     AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ClosedStream, ConfigError,
     ConnectError, ConnectionClose, ConnectionError, ConnectionId, ConnectionIdGenerator,
-    ConnectionStats, Dir, EcnCodepoint, EndpointConfig, FrameStats, FrameType, IdleTimeout,
-    InvalidCid, MtuDiscoveryConfig, NoneTokenLog, NoneTokenStore, PathStats, ServerConfig, Side,
-    StdSystemTime, StreamId, TimeSource, TokenLog, TokenMemoryCache, TokenReuseError, TokenStore,
-    Transmit, TransportConfig, TransportErrorCode, UdpStats, ValidationTokenConfig, VarInt,
-    VarIntBoundsExceeded, Written, congestion, crypto,
+    ConnectionStats, Dir, EcnCodepoint, EcnMode, EndpointConfig, FrameStats, FrameType,
+    IdleTimeout, InvalidCid, MtuDiscoveryConfig, NoneTokenLog, NoneTokenStore, PathStats,
+    ServerConfig, Side, StdSystemTime, StreamId, TimeSource, TokenLog, TokenMemoryCache,
+    TokenReuseError, TokenStore, Transmit, TransportConfig, TransportErrorCode, UdpStats,
+    ValidationTokenConfig, VarInt, VarIntBoundsExceeded, Written, congestion, crypto,
 };
 #[cfg(feature = "qlog")]
 pub use proto::{QlogConfig, QlogStream};

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use proto::{Chunk, Chunks, ClosedStream, ConnectionError, ReadableError, StreamId};
+use proto::{Chunk, Chunks, ClosedStream, ConnectionError, PathStats, ReadableError, StreamId};
 use thiserror::Error;
 use tokio::io::ReadBuf;
 
@@ -416,6 +416,11 @@ impl RecvStream {
                 }
             },
         }
+    }
+
+    /// Returns the path statistics of the underlying connection.
+    pub fn path_stats(&self) -> PathStats {
+        self.conn.state.lock("path_stats").inner.stats().path
     }
 }
 

--- a/quinn/src/send_stream.rs
+++ b/quinn/src/send_stream.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use proto::{ClosedStream, ConnectionError, FinishError, StreamId, Written};
+use proto::{ClosedStream, ConnectionError, FinishError, PathStats, StreamId, Written};
 use thiserror::Error;
 
 use crate::{
@@ -293,6 +293,11 @@ impl SendStream {
         buf: &[u8],
     ) -> Poll<Result<usize, WriteError>> {
         pin!(self.get_mut().write(buf)).as_mut().poll(cx)
+    }
+
+    /// Returns the path statistics of the underlying connection.
+    pub fn path_stats(&self) -> PathStats {
+        self.conn.state.lock("path_stats").inner.stats().path
     }
 }
 


### PR DESCRIPTION
## Summary

This change set introduces support for the **Low Latency, Low Loss, and Scalable Throughput (L4S)** architecture (RFC 9330) by exposing ECN configuration and implementing the Prague scalable congestion control algorithm.

## Changes

The changes made are three-fold:

1. **ECN Configuration**: Adds configurable ECN modes (`Classic`, `L4S`, or `Disabled`) to `TransportConfig` and enables `ECT(1)` markings.
2. **TCP Prague**: Implements the Prague congestion control algorithm with EWMA-based $\alpha$ (CE-fraction) estimation, virtual RTT scaling to reduce RTT dependence, and loss/ECN event double-reduction cooldowns.
3. **`quinn-perf` Support**: Updates `quinn-perf` to support Prague and configured ECN, tracks stream RTT/RTTvar, and optimizes client shutdown logic.

## Testing & Verification

To verify the implementation, I created a Mininet-based testbed (available [here](https://github.com/Zotyamester/l4s-bench), though unfortunately, not everything is documented as of yet), the topology of which is seen in the figure below.

<img width="3312" height="1204" alt="env" src="https://github.com/user-attachments/assets/68dee038-d2f5-473f-ba33-061e7b56c4d5" />

I measured six metrics in time (four endpoint-based, and one network-based).
Namely, one-way delay, RTT, CWND, network queue length, Prague's alpha value,
and the estimated throughput. The endpoint-based metrics were gathered and/or
derived from qlog entries (e.g., for calculating the one-way delay estimates,
the script paired up corresponding 1RTT packets -- assuming most packets were
not dropped). On the other hand, the queue length was monitored by a short
script running on the host taking the role of the router (configured with a
DualPI2 queue on its outbound interface facing the quinn-perf server host).

During the measurement scenario here, the quinn-perf client (on host h1) ran
for 60 seconds, continuously sending data to the quinn-perf server (on host h2)
through the network, with each round-trip experiencing a total delay of 24 ms,
and the network bandwidth being limited to 32 Mbps (with HTB).

The results of this run are depicted in the figure below.

<img width="5721" height="3771" alt="plot" src="https://github.com/user-attachments/assets/51699cfa-3fe2-484a-9efe-05b695f0423c" />

## Referenced Issues

Fixes #1498 #2487.