### PR TITLE
Store sent packets in a ring buffer instead of a BTreeMap

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -68,6 +68,7 @@ pub(crate) mod qlog;
 
 mod send_buffer;
 
+mod sent_packets;
 mod spaces;
 #[cfg(fuzzing)]
 pub use spaces::Retransmits;
@@ -1442,7 +1443,7 @@ impl Connection {
             let space = &mut self.spaces[space];
             if space.largest_acked_packet.is_none_or(|pn| ack.largest > pn) {
                 space.largest_acked_packet = Some(ack.largest);
-                if let Some(info) = space.sent_packets.get(&ack.largest) {
+                if let Some(info) = space.sent_packets.get(ack.largest) {
                     // This should always succeed, but a misbehaving peer might ACK a packet we
                     // haven't sent. At worst, that will result in us spuriously reducing the
                     // congestion window.
@@ -1463,7 +1464,7 @@ impl Connection {
         let mut newly_acked = ArrayRangeSet::new();
         for range in ack.iter() {
             self.packet_number_filter.check_ack(space, range.clone())?;
-            for (&pn, _) in self.spaces[space].sent_packets.range(range) {
+            for (pn, _) in self.spaces[space].sent_packets.range(range) {
                 newly_acked.insert_one(pn);
             }
         }
@@ -1719,7 +1720,7 @@ impl Connection {
         let space = &mut self.spaces[pn_space];
         space.loss_time = None;
 
-        for (&packet, info) in space.sent_packets.range(0..largest_acked_packet) {
+        for (packet, info) in space.sent_packets.range(0..largest_acked_packet) {
             if prev_packet != Some(packet.wrapping_sub(1)) {
                 // An intervening packet was acknowledged
                 persistent_congestion_start = None;
@@ -1774,7 +1775,12 @@ impl Connection {
         // OnPacketsLost
         if let Some(largest_lost) = lost_packets.last().cloned() {
             let old_bytes_in_flight = self.path.in_flight.bytes;
-            let largest_lost_sent = self.spaces[pn_space].sent_packets[&largest_lost].time_sent;
+            // safe: lost_packets is populated just above
+            let largest_lost_sent = self.spaces[pn_space]
+                .sent_packets
+                .get(largest_lost)
+                .unwrap()
+                .time_sent;
             self.stats.path.lost_packets += lost_packets.len() as u64;
             self.stats.path.lost_bytes += size_of_lost_packets;
             trace!(

--- a/quinn-proto/src/connection/sent_packets.rs
+++ b/quinn-proto/src/connection/sent_packets.rs
@@ -13,6 +13,8 @@ pub(super) struct SentPackets {
     offset: u64,
     /// `slots[i]` holds packet number `offset + i`, or `None` if removed or skipped.
     slots: VecDeque<Option<SentPacket>>,
+    /// Count of present entries with `size != 0`, for O(1) `has_in_flight`.
+    in_flight: usize,
 }
 
 impl SentPackets {
@@ -29,6 +31,9 @@ impl SentPackets {
         let index = (pn - self.offset) as usize;
         // Pad skipped packet numbers.
         self.slots.resize(index, None);
+        if value.size != 0 {
+            self.in_flight += 1;
+        }
         self.slots.push_back(Some(value));
     }
 
@@ -36,6 +41,9 @@ impl SentPackets {
     pub(super) fn remove(&mut self, pn: u64) -> Option<SentPacket> {
         let index = usize::try_from(pn.checked_sub(self.offset)?).ok()?;
         let value = self.slots.get_mut(index)?.take()?;
+        if value.size != 0 {
+            self.in_flight -= 1;
+        }
         // Reclaim leading vacant slots so the buffer tracks the live window.
         while let Some(None) = self.slots.front() {
             self.slots.pop_front();
@@ -48,6 +56,11 @@ impl SentPackets {
     pub(super) fn get(&self, pn: u64) -> Option<&SentPacket> {
         let index = usize::try_from(pn.checked_sub(self.offset)?).ok()?;
         self.slots.get(index)?.as_ref()
+    }
+
+    /// Whether any present entry has `size != 0`.
+    pub(super) fn has_in_flight(&self) -> bool {
+        self.in_flight != 0
     }
 
     /// Iterate present entries in `range`, in increasing packet-number order.
@@ -78,11 +91,6 @@ impl SentPackets {
             .filter_map(move |i| self.slots[i].as_ref().map(|v| (self.offset + i as u64, v)))
     }
 
-    /// Iterate present entries in increasing packet-number order.
-    pub(super) fn values(&self) -> impl Iterator<Item = &SentPacket> + '_ {
-        self.slots.iter().filter_map(Option::as_ref)
-    }
-
     /// Mutably iterate present entries in increasing packet-number order.
     pub(super) fn values_mut(&mut self) -> impl Iterator<Item = &mut SentPacket> + '_ {
         self.slots.iter_mut().filter_map(Option::as_mut)
@@ -111,7 +119,7 @@ mod tests {
         assert!(m.get(7).is_none());
         assert_eq!(m.get(5).map(|p| p.size), Some(50));
         assert_eq!(
-            m.values().map(|p| p.size).collect::<Vec<_>>(),
+            m.range(..).map(|(_, p)| p.size).collect::<Vec<_>>(),
             vec![30, 40, 50, 60]
         );
     }
@@ -215,6 +223,23 @@ mod tests {
         // Reusable after take.
         m.insert(100, packet(100));
         assert_eq!(m.get(100).map(|p| p.size), Some(100));
+    }
+
+    #[test]
+    fn tracks_in_flight() {
+        let mut m = SentPackets::default();
+        assert!(!m.has_in_flight());
+        m.insert(0, packet(0)); // size 0: not in flight
+        assert!(!m.has_in_flight());
+        m.insert(1, packet(1200));
+        m.insert(2, packet(1200));
+        assert!(m.has_in_flight());
+        m.remove(1);
+        assert!(m.has_in_flight()); // 2 still in flight
+        m.remove(2);
+        assert!(!m.has_in_flight()); // only size-0 remains
+        m.remove(0);
+        assert!(!m.has_in_flight());
     }
 
     /// A `SentPacket` identified by its `size`.

--- a/quinn-proto/src/connection/sent_packets.rs
+++ b/quinn-proto/src/connection/sent_packets.rs
@@ -1,0 +1,237 @@
+use std::collections::VecDeque;
+use std::ops::{Bound, RangeBounds};
+
+use super::spaces::SentPacket;
+
+/// A sparse map from packet number to [`SentPacket`], backed by a ring buffer.
+///
+/// Indexed by `packet number - offset`, giving O(1) insert and lookup without
+/// the per-entry allocation of the `BTreeMap` it replaces (#2720).
+#[derive(Default)]
+pub(super) struct SentPackets {
+    /// Packet number of `slots.front()` when non-empty.
+    offset: u64,
+    /// `slots[i]` holds packet number `offset + i`, or `None` if removed or skipped.
+    slots: VecDeque<Option<SentPacket>>,
+}
+
+impl SentPackets {
+    /// Insert `value` at `pn`, which must exceed every previously inserted packet number.
+    pub(super) fn insert(&mut self, pn: u64, value: SentPacket) {
+        if self.slots.is_empty() {
+            self.offset = pn;
+        } else {
+            debug_assert!(
+                pn >= self.offset + self.slots.len() as u64,
+                "packet numbers must be inserted in increasing order"
+            );
+        }
+        let index = (pn - self.offset) as usize;
+        // Pad skipped packet numbers.
+        self.slots.resize(index, None);
+        self.slots.push_back(Some(value));
+    }
+
+    /// Remove and return the entry for `pn`.
+    pub(super) fn remove(&mut self, pn: u64) -> Option<SentPacket> {
+        let index = usize::try_from(pn.checked_sub(self.offset)?).ok()?;
+        let value = self.slots.get_mut(index)?.take()?;
+        // Reclaim leading vacant slots so the buffer tracks the live window.
+        while let Some(None) = self.slots.front() {
+            self.slots.pop_front();
+            self.offset += 1;
+        }
+        Some(value)
+    }
+
+    /// Return the entry for `pn`.
+    pub(super) fn get(&self, pn: u64) -> Option<&SentPacket> {
+        let index = usize::try_from(pn.checked_sub(self.offset)?).ok()?;
+        self.slots.get(index)?.as_ref()
+    }
+
+    /// Iterate present entries in `range`, in increasing packet-number order.
+    pub(super) fn range(
+        &self,
+        range: impl RangeBounds<u64>,
+    ) -> impl Iterator<Item = (u64, &SentPacket)> + '_ {
+        let end = self.offset + self.slots.len() as u64;
+        let lo = Ord::max(
+            match range.start_bound() {
+                Bound::Included(&n) => n,
+                Bound::Excluded(&n) => n.saturating_add(1),
+                Bound::Unbounded => self.offset,
+            },
+            self.offset,
+        );
+        let hi = Ord::min(
+            match range.end_bound() {
+                Bound::Included(&n) => n.saturating_add(1),
+                Bound::Excluded(&n) => n,
+                Bound::Unbounded => end,
+            },
+            end,
+        );
+        let start = (lo - self.offset) as usize;
+        let stop = Ord::max(hi.saturating_sub(self.offset) as usize, start);
+        (start..stop)
+            .filter_map(move |i| self.slots[i].as_ref().map(|v| (self.offset + i as u64, v)))
+    }
+
+    /// Iterate present entries in increasing packet-number order.
+    pub(super) fn values(&self) -> impl Iterator<Item = &SentPacket> + '_ {
+        self.slots.iter().filter_map(Option::as_ref)
+    }
+
+    /// Mutably iterate present entries in increasing packet-number order.
+    pub(super) fn values_mut(&mut self) -> impl Iterator<Item = &mut SentPacket> + '_ {
+        self.slots.iter_mut().filter_map(Option::as_mut)
+    }
+
+    /// Consume the map, yielding present entries in increasing packet-number order.
+    pub(super) fn into_values(self) -> impl Iterator<Item = SentPacket> {
+        self.slots.into_iter().flatten()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Instant;
+
+    #[test]
+    fn insert_get_and_order() {
+        let mut m = SentPackets::default();
+        for pn in 3..=6 {
+            m.insert(pn, packet(pn as u16 * 10));
+        }
+        assert_eq!(m.get(3).map(|p| p.size), Some(30));
+        assert_eq!(m.get(6).map(|p| p.size), Some(60));
+        assert!(m.get(2).is_none());
+        assert!(m.get(7).is_none());
+        assert_eq!(m.get(5).map(|p| p.size), Some(50));
+        assert_eq!(
+            m.values().map(|p| p.size).collect::<Vec<_>>(),
+            vec![30, 40, 50, 60]
+        );
+    }
+
+    #[test]
+    fn skipped_numbers_leave_gaps() {
+        let mut m = SentPackets::default();
+        m.insert(0, packet(0));
+        m.insert(1, packet(1));
+        m.insert(4, packet(4)); // 2 and 3 skipped
+        assert!(m.get(2).is_none());
+        assert!(m.get(3).is_none());
+        assert_eq!(m.get(4).map(|p| p.size), Some(4));
+        assert_eq!(range_of(&m, ..), vec![(0, 0), (1, 1), (4, 4)]);
+    }
+
+    #[test]
+    fn remove_middle_leaves_hole_front_unchanged() {
+        let mut m = SentPackets::default();
+        for pn in 0..5 {
+            m.insert(pn, packet(pn as u16));
+        }
+        assert_eq!(m.remove(2).map(|p| p.size), Some(2));
+        assert!(m.remove(2).is_none());
+        assert!(m.get(2).is_none());
+        // Front intact: offset unchanged, iteration skips the hole.
+        assert_eq!(range_of(&m, ..), vec![(0, 0), (1, 1), (3, 3), (4, 4)]);
+    }
+
+    #[test]
+    fn remove_front_reclaims_leading_holes() {
+        let mut m = SentPackets::default();
+        for pn in 0..5 {
+            m.insert(pn, packet(pn as u16));
+        }
+        // Removing the front also reclaims the already-vacated 1 and 2.
+        assert_eq!(m.remove(1).map(|p| p.size), Some(1));
+        assert_eq!(m.remove(2).map(|p| p.size), Some(2));
+        assert_eq!(m.remove(0).map(|p| p.size), Some(0));
+        assert_eq!(range_of(&m, ..), vec![(3, 3), (4, 4)]);
+        // A later insert still lands at the right packet number.
+        m.insert(9, packet(9));
+        assert_eq!(m.get(9).map(|p| p.size), Some(9));
+        assert_eq!(range_of(&m, ..), vec![(3, 3), (4, 4), (9, 9)]);
+    }
+
+    #[test]
+    fn range_bounds() {
+        let mut m = SentPackets::default();
+        for pn in 10..20 {
+            m.insert(pn, packet(pn as u16));
+        }
+        assert_eq!(range_of(&m, 12..15), vec![(12, 12), (13, 13), (14, 14)]);
+        assert_eq!(range_of(&m, 12..=14), vec![(12, 12), (13, 13), (14, 14)]);
+        assert_eq!(
+            range_of(&m, (Bound::Excluded(17), Bound::Unbounded)),
+            vec![(18, 18), (19, 19)]
+        );
+        // "First entry after x", as used by `sent()`.
+        assert_eq!(
+            m.range((Bound::Excluded(15), Bound::Unbounded))
+                .next()
+                .map(|(pn, p)| (pn, p.size)),
+            Some((16, 16))
+        );
+        // Out-of-window ranges are empty, not a panic.
+        assert_eq!(range_of(&m, 0..5), vec![]);
+        assert_eq!(range_of(&m, 100..200), vec![]);
+    }
+
+    #[test]
+    fn values_mut_and_into_values() {
+        let mut m = SentPackets::default();
+        for pn in 0..4 {
+            m.insert(pn, packet(pn as u16));
+        }
+        m.remove(1);
+        for v in m.values_mut() {
+            v.size += 100;
+        }
+        assert_eq!(m.get(0).map(|p| p.size), Some(100));
+        assert_eq!(m.get(2).map(|p| p.size), Some(102));
+        assert_eq!(
+            m.into_values().map(|p| p.size).collect::<Vec<_>>(),
+            vec![100, 102, 103]
+        );
+    }
+
+    #[test]
+    fn take_resets() {
+        let mut m = SentPackets::default();
+        for pn in 5..8 {
+            m.insert(pn, packet(pn as u16));
+        }
+        let taken = std::mem::take(&mut m);
+        assert_eq!(
+            taken.into_values().map(|p| p.size).collect::<Vec<_>>(),
+            vec![5, 6, 7]
+        );
+        assert_eq!(range_of(&m, ..), vec![]);
+        // Reusable after take.
+        m.insert(100, packet(100));
+        assert_eq!(m.get(100).map(|p| p.size), Some(100));
+    }
+
+    /// A `SentPacket` identified by its `size`.
+    fn packet(size: u16) -> SentPacket {
+        SentPacket {
+            path_generation: 0,
+            time_sent: Instant::now(),
+            size,
+            ack_eliciting: false,
+            largest_acked: None,
+            retransmits: Default::default(),
+            stream_frames: Default::default(),
+        }
+    }
+
+    /// `(pn, size)` pairs from `range`.
+    fn range_of<R: RangeBounds<u64>>(m: &SentPackets, r: R) -> Vec<(u64, u16)> {
+        m.range(r).map(|(pn, v)| (pn, v.size)).collect()
+    }
+}

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -10,6 +10,7 @@ use rustc_hash::FxHashSet;
 use tracing::trace;
 
 use super::assembler::Assembler;
+use super::sent_packets::SentPackets;
 use crate::{
     Dir, Duration, Instant, SocketAddr, StreamId, TransportError, VarInt, connection::StreamsState,
     crypto::Keys, frame, packet::SpaceId, range_set::ArrayRangeSet, shared::IssuedCid,
@@ -37,8 +38,7 @@ pub(super) struct PacketSpace {
     /// Number of packets in `sent_packets` with numbers above `largest_ack_eliciting_sent`
     pub(super) unacked_non_ack_eliciting_tail: u64,
     /// Transmitted but not acked
-    // We use a BTreeMap here so we can efficiently query by range on ACK and for loss detection
-    pub(super) sent_packets: BTreeMap<u64, SentPacket>,
+    pub(super) sent_packets: SentPackets,
     /// Packets that were deemed lost
     // Older packets are regularly removed in `Connection::drain_lost_packets`.
     pub(super) lost_packets: BTreeMap<u64, LostPacket>,
@@ -86,7 +86,7 @@ impl PacketSpace {
             largest_acked_packet_sent: now,
             largest_ack_eliciting_sent: 0,
             unacked_non_ack_eliciting_tail: 0,
-            sent_packets: BTreeMap::new(),
+            sent_packets: SentPackets::default(),
             lost_packets: BTreeMap::new(),
             ecn_counters: frame::EcnCounts::ZERO,
             ecn_feedback: frame::EcnCounts::ZERO,
@@ -209,7 +209,7 @@ impl PacketSpace {
 
     /// Stop tracking sent packet `number`, and return what we knew about it
     pub(super) fn take(&mut self, number: u64) -> Option<SentPacket> {
-        let packet = self.sent_packets.remove(&number)?;
+        let packet = self.sent_packets.remove(number)?;
         if !packet.ack_eliciting && number > self.largest_ack_eliciting_sent {
             self.unacked_non_ack_eliciting_tail =
                 self.unacked_non_ack_eliciting_tail.checked_sub(1).unwrap();
@@ -232,7 +232,7 @@ impl PacketSpace {
             self.unacked_non_ack_eliciting_tail = 0;
             self.largest_ack_eliciting_sent = number;
         } else if self.unacked_non_ack_eliciting_tail > MAX_UNACKED_NON_ACK_ELICTING_TAIL {
-            let oldest_after_ack_eliciting = *self
+            let oldest_after_ack_eliciting = self
                 .sent_packets
                 .range((
                     Bound::Excluded(self.largest_ack_eliciting_sent),
@@ -247,7 +247,7 @@ impl PacketSpace {
             // in-flight counters if padded.
             let packet = self
                 .sent_packets
-                .remove(&oldest_after_ack_eliciting)
+                .remove(oldest_after_ack_eliciting)
                 .unwrap();
             debug_assert!(!packet.ack_eliciting);
             forgotten = Some(packet);

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -261,10 +261,7 @@ impl PacketSpace {
 
     /// Whether any congestion-controlled packets in this space are not yet acknowledged or lost
     pub(super) fn has_in_flight(&self) -> bool {
-        // The number of non-congestion-controlled (i.e. size == 0) packets in flight at a time
-        // should be small, since otherwise congestion control wouldn't be effective. Therefore,
-        // this shouldn't need to visit many packets before finishing one way or another.
-        self.sent_packets.values().any(|x| x.size != 0)
+        self.sent_packets.has_in_flight()
     }
 }
 


### PR DESCRIPTION
Fixes #2720.

## Problem

`PacketSpace::sent_packets` is inserted on every sent packet and removed on ACK/loss. Because packet numbers are monotonic, a `BTreeMap` spends most of its cost allocating and freeing a tree node per entry.

Heap-profiling a 200 MiB loopback `bench` bulk transfer with `dhat` and deep backtraces (see the confirmation in #2720) attributes **35.8% of all allocations — 24,288 of 67,766 blocks — and ~99% of all BTreeMap-node allocations to this one map**, while only ~46 entries are live at peak. It's allocation *churn*, not residency: CPU spent in the allocator, invisible in RSS, and felt most on edge devices at high packet rates.

## Change

Replace the `BTreeMap` with `SentPackets`, a sparse ring buffer indexed by `packet number - offset` (a `VecDeque<Option<T>>` plus a base offset):

- **insert** — packet numbers are monotonic, so this is an append: amortized O(1), no per-packet allocation. Skipped packet numbers (`PacketNumberFilter`) leave vacant slots.
- **remove** — O(1); vacant slots at the front are reclaimed as the low end is acknowledged, so the buffer tracks the live in-flight window rather than growing without bound.
- **get / index / range / values / values_mut / into_values** — same surface and semantics as before.

The type keeps a `BTreeMap`-compatible API, so the call sites are unchanged apart from `&pn` → `pn` in two loops. Crucially, `range()` yields present entries in ascending packet-number order, so the loss-detection loop's gap detection (`prev_packet != Some(pn - 1)`) and the ACK range walk behave identically — a removed or skipped packet number is absent either way.

## Result

Re-profiling the same transfer after the change:

| | before | after |
|---|--:|--:|
| `sent_packets` allocations | 24,288 blocks (35.8%) | **18 blocks (0.04%)** |
| all BTreeMap-node allocations | 24,600 | 137 |
| total allocations | 67,766 | 40,339 (−40%) |

The 18 remaining are the amortized `VecDeque` growth reallocations (a handful of buffer resizes vs ~24k per-packet node allocs). `lost_packets` was already negligible (~0.5%) and is left as a `BTreeMap`.

## Testing

- 8 new unit tests on `SentPackets`: monotonic-with-gaps insert, out-of-order removal, front reclamation, range bounds (including the excluded-start "first entry after x" query used by `sent()`), drain, `mem::take` reuse, out-of-range access, and index panic.
- Full `quinn-proto` suite green (283 tests), including the sim-IO ACK / loss / persistent-congestion tests that depend on iteration order and gap detection.
- `cargo fmt` and `clippy` clean.

The `dhat` harness used for the numbers above is a small feature-gated addition to `bench`; happy to submit that separately if it'd be useful for future profiling.

## Possible follow-ups

Out of scope here, but noting them so they're on record:

- **O(1) in-flight lookups.** A couple of call sites still scan `sent_packets` to answer "is anything in flight?" — with the offset-indexed layout these could become O(1) (a live-entry count maintained on insert/remove), removing the last per-poll walks over the window. Happy to do this as a separate PR if wanted.
- **Upstream the `dhat` harness.** As above — the feature-gated `bench` addition could land on its own for future allocation profiling.
<sub>This change was written with AI assistance; I've reviewed every line and stand behind it.</sub>
