### PR TITLE
Reduce receive-path allocations by reusing one buffer per batch

### DIFF
--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -863,6 +863,14 @@ impl RecvState {
             match socket.poll_recv(cx, &mut iovs, &mut metas) {
                 Poll::Ready(Ok(msgs)) => {
                     self.recv_limiter.record_work(msgs);
+                    // Copy the received batch into `datagrams` and split each datagram off as
+                    // an owned slice. We can't read directly into `datagrams` and drop
+                    // `recv_buf`: once a slice has been handed to a connection the allocation
+                    // is shared, so the next `reserve` must allocate fresh backing memory.
+                    // Reading in place would therefore mean reserving the worst-case iovec
+                    // envelope before every poll and reallocating it whenever a prior datagram
+                    // is still in flight. `recv_buf` stays an allocate-once scratch buffer, and
+                    // we reserve only the bytes actually received.
                     let batch_len = metas.iter().take(msgs).map(|meta| meta.len).sum();
                     self.datagrams.reserve(batch_len);
                     for (meta, buf) in metas.iter().zip(iovs.iter()).take(msgs) {

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -809,6 +809,8 @@ struct RecvState {
     incoming: VecDeque<proto::Incoming>,
     connections: ConnectionSet,
     recv_buf: Box<[u8]>,
+    /// Reused buffer that received datagrams are copied into and split into owned slices.
+    datagrams: BytesMut,
     recv_limiter: WorkLimiter,
 }
 
@@ -818,12 +820,10 @@ impl RecvState {
         max_receive_segments: usize,
         endpoint: &proto::Endpoint,
     ) -> Self {
-        let recv_buf = vec![
-            0;
-            endpoint.config().get_max_udp_payload_size().min(64 * 1024) as usize
-                * max_receive_segments
-                * BATCH_SIZE
-        ];
+        let datagram_capacity = endpoint.config().get_max_udp_payload_size().min(64 * 1024)
+            as usize
+            * max_receive_segments;
+        let recv_buf = vec![0; datagram_capacity * BATCH_SIZE];
         Self {
             connections: ConnectionSet {
                 senders: FxHashMap::default(),
@@ -832,6 +832,7 @@ impl RecvState {
             },
             incoming: VecDeque::new(),
             recv_buf: recv_buf.into(),
+            datagrams: BytesMut::with_capacity(datagram_capacity),
             recv_limiter: WorkLimiter::new(RECV_TIME_BOUND),
         }
     }
@@ -862,8 +863,13 @@ impl RecvState {
             match socket.poll_recv(cx, &mut iovs, &mut metas) {
                 Poll::Ready(Ok(msgs)) => {
                     self.recv_limiter.record_work(msgs);
+                    let batch_len = metas.iter().take(msgs).map(|meta| meta.len).sum();
+                    self.datagrams.reserve(batch_len);
                     for (meta, buf) in metas.iter().zip(iovs.iter()).take(msgs) {
-                        let mut data: BytesMut = buf[0..meta.len].into();
+                        self.datagrams.extend_from_slice(&buf[..meta.len]);
+                    }
+                    for meta in metas.iter().take(msgs) {
+                        let mut data = self.datagrams.split_to(meta.len);
                         while !data.is_empty() {
                             let buf = data.split_to(meta.stride.min(data.len()));
                             let mut response_buffer = Vec::new();


### PR DESCRIPTION
RecvState::poll_socket allocated a fresh BytesMut for every received datagram, copying it out of recv_buf, and the following split_to promoted it to shared. This keeps one reusable BytesMut, copies each batch into it, and splits every datagram off as an owned slice sharing that allocation. reserve reclaims the buffer once the previous batch's slices have been dropped, so it only reallocates while some datagrams are still in flight, and empty polls don't allocate at all. The rest of the receive path stays zero-copy.

This uses the reserve approach @EileenGalvin suggested on #2734.

Allocations:
- dhat, 200 MiB loopback bulk transfer: receive-path allocations drop from ~38.6k blocks to ~6.7k.
- Counting allocator in the perf client, 4 GiB loopback download: whole-process allocations drop from ~207k to ~57k per GiB (-72%).

Throughput and CPU:
- No throughput change within noise, on loopback and across a netem veth pair (no delay, 10 and 40 ms RTT, 0.1% loss). No regression anywhere.
- Client CPU per GiB is unchanged on x86: an alloc+free of these small buffers is about 25 ns here, so cutting ~65k allocs/s at 450 MiB/s is under 1% of CPU. The benefit grows where allocation is a larger share of the budget: @EileenGalvin reported that this plus #2720 took an edge device from 100% to 60% peak CPU at the same throughput.

Fixes #2734
