### PR TITLE
Ignore EMSGSIZE error triggered by ICMP Frag Needed (Path To Big)

### DIFF
--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -28,13 +28,18 @@
 #![warn(clippy::use_self)]
 
 use core::time::Duration;
-use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 #[cfg(unix)]
 use std::os::unix::io::AsFd;
 #[cfg(windows)]
 use std::os::windows::io::AsSocket;
+use std::{
+    io,
+    net::{IpAddr, Ipv6Addr, SocketAddr},
+};
 #[cfg(not(wasm_browser))]
 use std::{sync::Mutex, time::Instant};
+#[cfg(windows)]
+use windows_sys::Win32::Networking::WinSock;
 
 #[cfg(apple_fast)]
 mod apple_fast;
@@ -222,6 +227,32 @@ pub enum TransportErrorPayload {
     },
     /// Other transport-layer or kernel-reported error
     Other,
+}
+
+/// Returns true if the given I/O error corresponds to a message size error
+///
+/// Useful, for example, after invoking [`io::Error::last_os_error()`]
+/// to check if the last OS error was a message size error
+/// (EMSGSIZE on Unix, WSAEMSGSIZE on Windows).
+///
+/// Note: EMSGSIZE's value is not standardized across OSes (90 on Linux,
+/// 40 on macOS/iOS/BSD; on Windows, `io::Error::raw_os_error()` returns
+/// the Winsock error WSAEMSGSIZE (10040) via `GetLastError()`, which is
+/// distinct from the MSVCRT `errno.h` EMSGSIZE value of 115, which is
+/// never actually populated by socket operations).
+pub fn is_msg_size_err(err: &io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        err.raw_os_error() == Some(libc::EMSGSIZE)
+    }
+    #[cfg(windows)]
+    {
+        err.raw_os_error() == Some(WinSock::WSAEMSGSIZE)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        false
+    }
 }
 
 /// Log at most 1 IO error per minute

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -40,7 +40,7 @@ use rustc_hash::FxHashMap;
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::sync::{Notify, futures::Notified, mpsc};
 use tracing::{Instrument, Span};
-use udp::{BATCH_SIZE, RecvMeta};
+use udp::{BATCH_SIZE, RecvMeta, is_msg_size_err};
 
 use crate::{
     ConnectionEvent, EndpointConfig, IO_LOOP_BOUND, RECV_TIME_BOUND, VarInt,
@@ -911,6 +911,13 @@ impl RecvState {
                 // Ignore ECONNRESET as it's undefined in QUIC and may be injected by an
                 // attacker
                 Poll::Ready(Err(ref e)) if e.kind() == io::ErrorKind::ConnectionReset => {
+                    continue;
+                }
+                // Ignore EMSGSIZE as we're currently not handling ICMPv4 Fragmentation Needed
+                // and ICMPv6 Packet Too Big (PTB) messages since they cannot be authenticated,
+                // and Datagram Packetization Layer Path MTU Discovery (DPLPMTUD) works without
+                // it anyways.
+                Poll::Ready(Err(ref e)) if is_msg_size_err(e) => {
                     continue;
                 }
                 Poll::Ready(Err(e)) => {


### PR DESCRIPTION
We're currently not handling ICMPv4 Fragmentation Needed and ICMPv6 Packet Too Big (PTB) messages since they cannot be authenticated, and Datagram Packetization Layer Path MTU Discovery (DPLPMTUD) works without it anyways.

A dedicated check for this type became necessary due to a recent change in how internal errors originating from recvmsg are exposed to the caller as errors (rather than letting the runtime silently retry the read).

Fixes #2733.