### PR TITLE
feat(udp): support partial sends

### DIFF
--- a/quinn-udp/benches/throughput.rs
+++ b/quinn-udp/benches/throughput.rs
@@ -57,7 +57,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             1
         };
         let msg = vec![0xAB; min(MAX_DATAGRAM_SIZE, SEGMENT_SIZE * gso_segments)];
-        let transmit = Transmit {
+        let make_transmit = || Transmit {
             destination: dst_addr,
             ecn: None,
             contents: &msg,
@@ -82,14 +82,25 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
                 let mut sent: usize = 0;
                 let mut received: usize = 0;
+                let mut pending = make_transmit();
                 while sent < TOTAL_BYTES {
                     send_socket.writable().await.unwrap();
-                    send_socket
+                    let sent_datagrams = send_socket
                         .try_io(Interest::WRITABLE, || {
-                            send_state.send((&send_socket).into(), &transmit)
+                            send_state.send((&send_socket).into(), &pending)
                         })
                         .unwrap();
-                    sent += transmit.contents.len();
+                    let previous_len = pending.contents.len();
+                    match pending.advance(sent_datagrams) {
+                        Some(remainder) => {
+                            sent += previous_len - remainder.contents.len();
+                            pending = remainder;
+                        }
+                        None => {
+                            sent += previous_len;
+                            pending = make_transmit();
+                        }
+                    }
 
                     while received < sent {
                         recv_socket.readable().await.unwrap();

--- a/quinn-udp/benches/throughput.rs
+++ b/quinn-udp/benches/throughput.rs
@@ -57,7 +57,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             1
         };
         let msg = vec![0xAB; min(MAX_DATAGRAM_SIZE, SEGMENT_SIZE * gso_segments)];
-        let transmit = Transmit {
+        let make_transmit = || Transmit {
             destination: dst_addr,
             ecn: None,
             contents: &msg,
@@ -82,14 +82,25 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
                 let mut sent: usize = 0;
                 let mut received: usize = 0;
+                let mut pending = make_transmit();
                 while sent < TOTAL_BYTES {
                     send_socket.writable().await.unwrap();
-                    send_socket
+                    let sent_datagrams = send_socket
                         .try_io(Interest::WRITABLE, || {
-                            send_state.try_send((&send_socket).into(), &transmit)
+                            send_state.try_send((&send_socket).into(), &pending)
                         })
                         .unwrap();
-                    sent += transmit.contents.len();
+                    let previous_len = pending.contents.len();
+                    match pending.advance(sent_datagrams) {
+                        Some(remainder) => {
+                            sent += previous_len - remainder.contents.len();
+                            pending = remainder;
+                        }
+                        None => {
+                            sent += previous_len;
+                            pending = make_transmit();
+                        }
+                    }
 
                     while received < sent {
                         recv_socket.readable().await.unwrap();

--- a/quinn-udp/src/apple_fast.rs
+++ b/quinn-udp/src/apple_fast.rs
@@ -16,12 +16,12 @@ use crate::{
 pub(crate) fn send(
     state: &UdpSocketState,
     io: SockRef<'_>,
-    transmit: &Transmit<'_>,
-) -> io::Result<()> {
+    transmit: Transmit<'_>,
+) -> io::Result<usize> {
     if state.is_apple_fast_path_enabled() {
         send_via_sendmsg_x(state, io, transmit)
     } else {
-        send_single(state, io, transmit)
+        send_single(state, io, &transmit.limit(1))
     }
 }
 
@@ -29,29 +29,23 @@ pub(crate) fn send(
 fn send_via_sendmsg_x(
     state: &UdpSocketState,
     io: SockRef<'_>,
-    transmit: &Transmit<'_>,
-) -> io::Result<()> {
+    transmit: Transmit<'_>,
+) -> io::Result<usize> {
     let mut hdrs = unsafe { mem::zeroed::<[msghdr_x; BATCH_SIZE]>() };
     let mut iovs = unsafe { mem::zeroed::<[libc::iovec; BATCH_SIZE]>() };
     let mut ctrls = [cmsg::Aligned([0u8; cmsg::LEN]); BATCH_SIZE];
     let addr = socket2::SockAddr::from(transmit.destination);
-    let segment_size = transmit.segment_size.unwrap_or(transmit.contents.len());
-    let mut cnt = 0;
-    debug_assert!(transmit.contents.len().div_ceil(segment_size) <= BATCH_SIZE);
-    for (i, chunk) in transmit
-        .contents
-        .chunks(segment_size)
-        .enumerate()
-        .take(BATCH_SIZE)
-    {
+
+    let mut prepare = |i: usize, chunk: &[u8]| -> io::Result<()> {
+        let segment = Transmit {
+            destination: transmit.destination,
+            ecn: transmit.ecn,
+            contents: chunk,
+            segment_size: None,
+            src_ip: transmit.src_ip,
+        };
         prepare_msg_x(
-            &Transmit {
-                destination: transmit.destination,
-                ecn: transmit.ecn,
-                contents: chunk,
-                segment_size: Some(chunk.len()),
-                src_ip: transmit.src_ip,
-            },
+            &segment,
             &addr,
             &mut hdrs[i],
             &mut iovs[i],
@@ -61,13 +55,45 @@ fn send_via_sendmsg_x(
         );
         hdrs[i].msg_datalen = chunk.len();
         state.check_send_buffer_limit(chunk.len(), &hdrs[i])?;
-        cnt += 1;
-    }
-    let Some(sendmsg_x) = state.resolve_apple_fast_fn(sendmsg_x_fn) else {
-        return send_single(state, io, transmit);
+
+        Ok(())
     };
-    retry_if_interrupted(|| unsafe { sendmsg_x(io.as_raw_fd(), hdrs.as_ptr(), cnt as u32, 0) })?;
-    Ok(())
+
+    debug_assert!(transmit.datagram_count() <= BATCH_SIZE);
+    let cnt = if transmit.contents.is_empty() {
+        prepare(0, &[])?;
+        1
+    } else {
+        let segment_size = transmit.segment_size.unwrap_or(transmit.contents.len());
+        let mut cnt = 0;
+
+        for (i, chunk) in transmit
+            .contents
+            .chunks(segment_size)
+            .enumerate()
+            .take(BATCH_SIZE)
+        {
+            prepare(i, chunk)?;
+            cnt += 1;
+        }
+
+        cnt
+    };
+
+    let Some(sendmsg_x) = state.resolve_apple_fast_fn(sendmsg_x_fn) else {
+        return send_single(state, io, &transmit.limit(1));
+    };
+
+    let sent = retry_if_interrupted(|| unsafe {
+        sendmsg_x(io.as_raw_fd(), hdrs.as_ptr(), cnt as u32, 0)
+    })? as usize;
+
+    if sent == 0 {
+        return Err(io::ErrorKind::WriteZero.into());
+    }
+    debug_assert!(sent <= cnt);
+
+    Ok(sent)
 }
 
 /// Prepares an `msghdr_x` for use with `sendmsg_x`

--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -4,7 +4,7 @@ use std::{
     time::Instant,
 };
 
-use super::{IO_ERROR_LOG_INTERVAL, RecvMeta, Transmit, UdpSockRef, log_sendmsg_error};
+use super::{IO_ERROR_LOG_INTERVAL, RecvMeta, SendCount, Transmit, UdpSockRef, log_sendmsg_error};
 
 /// Fallback UDP socket interface that stubs out all special functionality
 ///
@@ -35,21 +35,30 @@ impl UdpSocketState {
     ///
     /// If you would like to handle these errors yourself, use [`UdpSocketState::try_send`]
     /// instead.
-    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
-        match send(socket, transmit) {
-            Ok(()) => Ok(()),
+    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<SendCount> {
+        let transmit = transmit.limit(1);
+
+        match send(socket, &transmit) {
+            Ok(sent) => Ok(SendCount::from_datagram_count(sent)),
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => Err(e),
             Err(e) => {
-                log_sendmsg_error(&self.last_send_error, e, transmit);
+                log_sendmsg_error(&self.last_send_error, e, &transmit);
 
-                Ok(())
+                Ok(SendCount::from_datagram_count(1))
             }
         }
     }
 
-    /// Sends a [`Transmit`] on the given socket without any additional error handling.
-    pub fn try_send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
-        send(socket, transmit)
+    /// Sends the first datagram of a [`Transmit`] without any additional error handling.
+    pub fn try_send(
+        &self,
+        socket: UdpSockRef<'_>,
+        transmit: &Transmit<'_>,
+    ) -> io::Result<SendCount> {
+        let transmit = transmit.limit(1);
+        let sent = send(socket, &transmit)?;
+
+        Ok(SendCount::from_datagram_count(sent))
     }
 
     pub fn recv(
@@ -117,11 +126,13 @@ impl UdpSocketState {
     }
 }
 
-fn send(socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
+fn send(socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<usize> {
     socket.0.send_to(
         transmit.contents,
         &socket2::SockAddr::from(transmit.destination),
-    )
+    )?;
+
+    Ok(transmit.datagram_count())
 }
 
 pub(crate) const BATCH_SIZE: usize = 1;

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -35,6 +35,7 @@ use std::os::windows::io::AsSocket;
 use std::{
     io,
     net::{IpAddr, Ipv6Addr, SocketAddr},
+    num::NonZeroUsize,
 };
 #[cfg(not(wasm_browser))]
 use std::{sync::Mutex, time::Instant};
@@ -158,13 +159,80 @@ pub struct Transmit<'a> {
     /// Contents of the datagram
     pub contents: &'a [u8],
     /// The segment size if this transmission contains multiple datagrams.
-    /// This is `None` if the transmit only contains a single datagram
+    ///
+    /// This is `None` if the transmit only contains a single datagram.
+    /// A value of zero is treated like `None`.
     pub segment_size: Option<usize>,
     /// Optional source IP address for the datagram
     pub src_ip: Option<IpAddr>,
 }
 
-impl Transmit<'_> {
+impl<'a> Transmit<'a> {
+    /// Returns the number of datagrams encoded by this transmit.
+    ///
+    /// A transmit without a `segment_size` always represents one datagram, including when its
+    /// contents are empty.
+    pub fn datagram_count(&self) -> usize {
+        match self.segment_size {
+            Some(size) if size != 0 && size < self.contents.len() => {
+                self.contents.len().div_ceil(size)
+            }
+            Some(_) | None => 1,
+        }
+    }
+
+    /// Advances this transmit by `sent` datagrams.
+    ///
+    /// Returns the unsent remainder, or `None` if the entire transmit was consumed. The returned
+    /// transmit borrows a suffix of the same payload; packet data is never copied.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::{io, net::UdpSocket};
+    ///
+    /// use quinn_udp::{Transmit, UdpSocketState};
+    ///
+    /// fn send_pending<'a>(
+    ///     state: &UdpSocketState,
+    ///     socket: &UdpSocket,
+    ///     pending: &mut Option<Transmit<'a>>,
+    /// ) -> io::Result<()> {
+    ///     while let Some(transmit) = pending.take() {
+    ///         match state.send(socket.into(), &transmit) {
+    ///             Ok(sent) => *pending = transmit.advance(sent),
+    ///             Err(error) => {
+    ///                 *pending = Some(transmit);
+    ///                 return Err(error);
+    ///             }
+    ///         }
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn advance(mut self, sent: SendCount) -> Option<Self> {
+        let sent = sent.get();
+        let segment_size = match self.segment_size {
+            Some(size) if size != 0 && size < self.contents.len() => size,
+            Some(_) | None => {
+                debug_assert_eq!(sent, 1, "a single-datagram transmit must consume once");
+                return None;
+            }
+        };
+
+        debug_assert!(sent <= self.contents.len().div_ceil(segment_size));
+
+        let offset = sent.saturating_mul(segment_size);
+        if offset >= self.contents.len() {
+            return None;
+        }
+
+        self.contents = &self.contents[offset..];
+
+        Some(self)
+    }
+
     /// Computes the effective segment-size of the packet.
     ///
     /// Some (older) network drivers don't like being told to do GSO even if
@@ -178,9 +246,61 @@ impl Transmit<'_> {
     #[cfg_attr(apple_fast, allow(dead_code))] // Used by prepare_msg, which is unused when apple_fast
     fn effective_segment_size(&self) -> Option<usize> {
         match self.segment_size? {
+            0 => None,
             size if size >= self.contents.len() => None,
             size => Some(size),
         }
+    }
+
+    /// Returns a transmit containing at most `max_datagrams.max(1)` leading datagrams.
+    #[cfg(not(wasm_browser))]
+    fn limit(&self, max_datagrams: usize) -> Self {
+        let max_datagrams = max_datagrams.max(1);
+
+        let segment_size = self.effective_segment_size();
+
+        let contents = match segment_size {
+            Some(size) => {
+                &self.contents[..self.contents.len().min(size.saturating_mul(max_datagrams))]
+            }
+            None => self.contents,
+        };
+
+        let segment_size = segment_size.filter(|&size| size < contents.len());
+
+        Self {
+            destination: self.destination,
+            ecn: self.ecn,
+            contents,
+            segment_size,
+            src_ip: self.src_ip,
+        }
+    }
+}
+
+/// Number of leading datagrams consumed by a send operation.
+///
+/// Pass this to [`Transmit::advance`] on the transmit supplied to the send operation. This consumes
+/// the previous transmit and returns its unsent remainder, if any.
+#[must_use = "send progress must be used to advance the transmitted packet"]
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+pub struct SendCount(NonZeroUsize);
+
+impl SendCount {
+    /// Constructs a send count, or returns `None` if `value` is zero.
+    pub fn new(value: usize) -> Option<Self> {
+        Some(Self(NonZeroUsize::new(value)?))
+    }
+
+    #[cfg(not(wasm_browser))]
+    fn from_datagram_count(value: usize) -> Self {
+        Self::new(value).expect("a send operation must consume at least one datagram")
+    }
+
+    /// Returns the number of consumed datagrams.
+    pub const fn get(self) -> usize {
+        self.0.get()
     }
 }
 
@@ -372,6 +492,100 @@ mod tests {
             Some(5),
             "segment_size < content_len should yield effective segment_size"
         );
+        assert_eq!(
+            make_transmit(&[0u8; 10], Some(0)).effective_segment_size(),
+            None,
+            "zero is not a valid segment size"
+        );
+    }
+
+    #[test]
+    fn datagram_count() {
+        let contents = [0u8; 11];
+        let transmit = make_transmit(&contents, Some(5));
+
+        assert!(SendCount::new(0).is_none());
+
+        assert_eq!(transmit.datagram_count(), 3);
+        let sent = SendCount::new(1).unwrap();
+        assert_eq!(sent.get(), 1);
+
+        assert_eq!(make_transmit(&[], None).datagram_count(), 1);
+        assert_eq!(make_transmit(&contents, None).datagram_count(), 1);
+        assert_eq!(make_transmit(&contents, Some(0)).datagram_count(), 1);
+        assert_eq!(make_transmit(&contents, Some(20)).datagram_count(), 1);
+    }
+
+    #[test]
+    fn advance_returns_the_unsent_remainder() {
+        let contents = [0u8; 11];
+        let transmit = make_transmit(&contents, Some(5));
+
+        let transmit = transmit.advance(SendCount::new(1).unwrap()).unwrap();
+        assert_eq!(transmit.contents.len(), 6);
+        assert_eq!(transmit.datagram_count(), 2);
+
+        let transmit = transmit.advance(SendCount::new(1).unwrap()).unwrap();
+        assert_eq!(transmit.contents.len(), 1);
+        assert_eq!(transmit.datagram_count(), 1);
+        assert!(transmit.advance(SendCount::new(1).unwrap()).is_none());
+
+        assert!(
+            make_transmit(&[], None)
+                .advance(SendCount::new(1).unwrap())
+                .is_none()
+        );
+        assert!(
+            make_transmit(&contents, Some(0))
+                .advance(SendCount::new(1).unwrap())
+                .is_none()
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic]
+    fn advancing_by_too_large_a_send_count_triggers_debug_assertion() {
+        let contents = [0u8; 1];
+        let _ = make_transmit(&contents, None).advance(SendCount::new(2).unwrap());
+    }
+
+    #[test]
+    fn limit_is_infallible_for_degenerate_limits_and_segment_sizes() {
+        let contents = [0u8; 11];
+
+        for segment_size in [None, Some(0)] {
+            let transmit = make_transmit(&contents, segment_size);
+            let transmit = transmit.limit(0);
+
+            assert_eq!(transmit.contents, contents);
+            assert_eq!(transmit.datagram_count(), 1);
+            assert_eq!(transmit.segment_size, None);
+        }
+    }
+
+    #[test]
+    fn limit_preserves_a_datagram_prefix() {
+        let contents = [0u8; 11];
+        let transmit = make_transmit(&contents, Some(5));
+
+        let prefix = transmit.limit(2);
+        assert_eq!(prefix.contents.len(), 10);
+        assert_eq!(prefix.datagram_count(), 2);
+        assert_eq!(prefix.segment_size, Some(5));
+        assert_eq!(prefix.destination, transmit.destination);
+        assert_eq!(prefix.ecn, transmit.ecn);
+        assert_eq!(prefix.src_ip, transmit.src_ip);
+
+        let complete = transmit.limit(3);
+        assert_eq!(complete.contents.len(), 11);
+        assert_eq!(complete.datagram_count(), 3);
+        assert_eq!(complete.segment_size, Some(5));
+
+        let single = prefix.limit(1);
+        assert_eq!(single.contents.len(), 5);
+        assert_eq!(single.datagram_count(), 1);
+        assert_eq!(single.segment_size, None);
     }
 
     fn make_transmit(contents: &[u8], segment_size: Option<usize>) -> Transmit<'_> {

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -35,6 +35,7 @@ use std::os::windows::io::AsSocket;
 use std::{
     io,
     net::{IpAddr, Ipv6Addr, SocketAddr},
+    num::NonZeroUsize,
 };
 #[cfg(target_os = "wasi")]
 use std::{
@@ -161,13 +162,80 @@ pub struct Transmit<'a> {
     /// Contents of the datagram
     pub contents: &'a [u8],
     /// The segment size if this transmission contains multiple datagrams.
-    /// This is `None` if the transmit only contains a single datagram
+    ///
+    /// This is `None` if the transmit only contains a single datagram.
+    /// A value of zero is treated like `None`.
     pub segment_size: Option<usize>,
     /// Optional source IP address for the datagram
     pub src_ip: Option<IpAddr>,
 }
 
-impl Transmit<'_> {
+impl<'a> Transmit<'a> {
+    /// Returns the number of datagrams encoded by this transmit.
+    ///
+    /// A transmit without a `segment_size` always represents one datagram, including when its
+    /// contents are empty.
+    pub fn datagram_count(&self) -> usize {
+        match self.segment_size {
+            Some(size) if size != 0 && size < self.contents.len() => {
+                self.contents.len().div_ceil(size)
+            }
+            Some(_) | None => 1,
+        }
+    }
+
+    /// Advances this transmit by `sent` datagrams.
+    ///
+    /// Returns the unsent remainder, or `None` if the entire transmit was consumed. The returned
+    /// transmit borrows a suffix of the same payload; packet data is never copied.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::{io, net::UdpSocket};
+    ///
+    /// use quinn_udp::{Transmit, UdpSocketState};
+    ///
+    /// fn send_pending<'a>(
+    ///     state: &UdpSocketState,
+    ///     socket: &UdpSocket,
+    ///     pending: &mut Option<Transmit<'a>>,
+    /// ) -> io::Result<()> {
+    ///     while let Some(transmit) = pending.take() {
+    ///         match state.try_send(socket.into(), &transmit) {
+    ///             Ok(sent) => *pending = transmit.advance(sent),
+    ///             Err(error) => {
+    ///                 *pending = Some(transmit);
+    ///                 return Err(error);
+    ///             }
+    ///         }
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn advance(mut self, sent: SendCount) -> Option<Self> {
+        let sent = sent.get();
+        let segment_size = match self.segment_size {
+            Some(size) if size != 0 && size < self.contents.len() => size,
+            Some(_) | None => {
+                debug_assert_eq!(sent, 1, "a single-datagram transmit must consume once");
+                return None;
+            }
+        };
+
+        debug_assert!(sent <= self.contents.len().div_ceil(segment_size));
+
+        let offset = sent.saturating_mul(segment_size);
+        if offset >= self.contents.len() {
+            return None;
+        }
+
+        self.contents = &self.contents[offset..];
+
+        Some(self)
+    }
+
     /// Computes the effective segment-size of the packet.
     ///
     /// Some (older) network drivers don't like being told to do GSO even if
@@ -181,9 +249,61 @@ impl Transmit<'_> {
     #[cfg_attr(apple_fast, allow(dead_code))] // Used by prepare_msg, which is unused when apple_fast
     fn effective_segment_size(&self) -> Option<usize> {
         match self.segment_size? {
+            0 => None,
             size if size >= self.contents.len() => None,
             size => Some(size),
         }
+    }
+
+    /// Returns a transmit containing at most `max_datagrams.max(1)` leading datagrams.
+    #[cfg(not(wasm_browser))]
+    fn limit(&self, max_datagrams: usize) -> Self {
+        let max_datagrams = max_datagrams.max(1);
+
+        let segment_size = self.effective_segment_size();
+
+        let contents = match segment_size {
+            Some(size) => {
+                &self.contents[..self.contents.len().min(size.saturating_mul(max_datagrams))]
+            }
+            None => self.contents,
+        };
+
+        let segment_size = segment_size.filter(|&size| size < contents.len());
+
+        Self {
+            destination: self.destination,
+            ecn: self.ecn,
+            contents,
+            segment_size,
+            src_ip: self.src_ip,
+        }
+    }
+}
+
+/// Number of leading datagrams consumed by a send operation.
+///
+/// Pass this to [`Transmit::advance`] on the transmit supplied to the send operation. This consumes
+/// the previous transmit and returns its unsent remainder, if any.
+#[must_use = "send progress must be used to advance the transmitted packet"]
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+pub struct SendCount(NonZeroUsize);
+
+impl SendCount {
+    /// Constructs a send count, or returns `None` if `value` is zero.
+    pub fn new(value: usize) -> Option<Self> {
+        Some(Self(NonZeroUsize::new(value)?))
+    }
+
+    #[cfg(not(wasm_browser))]
+    fn from_datagram_count(value: usize) -> Self {
+        Self::new(value).expect("a send operation must consume at least one datagram")
+    }
+
+    /// Returns the number of consumed datagrams.
+    pub const fn get(self) -> usize {
+        self.0.get()
     }
 }
 
@@ -360,6 +480,100 @@ mod tests {
             Some(5),
             "segment_size < content_len should yield effective segment_size"
         );
+        assert_eq!(
+            make_transmit(&[0u8; 10], Some(0)).effective_segment_size(),
+            None,
+            "zero is not a valid segment size"
+        );
+    }
+
+    #[test]
+    fn datagram_count() {
+        let contents = [0u8; 11];
+        let transmit = make_transmit(&contents, Some(5));
+
+        assert!(SendCount::new(0).is_none());
+
+        assert_eq!(transmit.datagram_count(), 3);
+        let sent = SendCount::new(1).unwrap();
+        assert_eq!(sent.get(), 1);
+
+        assert_eq!(make_transmit(&[], None).datagram_count(), 1);
+        assert_eq!(make_transmit(&contents, None).datagram_count(), 1);
+        assert_eq!(make_transmit(&contents, Some(0)).datagram_count(), 1);
+        assert_eq!(make_transmit(&contents, Some(20)).datagram_count(), 1);
+    }
+
+    #[test]
+    fn advance_returns_the_unsent_remainder() {
+        let contents = [0u8; 11];
+        let transmit = make_transmit(&contents, Some(5));
+
+        let transmit = transmit.advance(SendCount::new(1).unwrap()).unwrap();
+        assert_eq!(transmit.contents.len(), 6);
+        assert_eq!(transmit.datagram_count(), 2);
+
+        let transmit = transmit.advance(SendCount::new(1).unwrap()).unwrap();
+        assert_eq!(transmit.contents.len(), 1);
+        assert_eq!(transmit.datagram_count(), 1);
+        assert!(transmit.advance(SendCount::new(1).unwrap()).is_none());
+
+        assert!(
+            make_transmit(&[], None)
+                .advance(SendCount::new(1).unwrap())
+                .is_none()
+        );
+        assert!(
+            make_transmit(&contents, Some(0))
+                .advance(SendCount::new(1).unwrap())
+                .is_none()
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic]
+    fn advancing_by_too_large_a_send_count_triggers_debug_assertion() {
+        let contents = [0u8; 1];
+        let _ = make_transmit(&contents, None).advance(SendCount::new(2).unwrap());
+    }
+
+    #[test]
+    fn limit_is_infallible_for_degenerate_limits_and_segment_sizes() {
+        let contents = [0u8; 11];
+
+        for segment_size in [None, Some(0)] {
+            let transmit = make_transmit(&contents, segment_size);
+            let transmit = transmit.limit(0);
+
+            assert_eq!(transmit.contents, contents);
+            assert_eq!(transmit.datagram_count(), 1);
+            assert_eq!(transmit.segment_size, None);
+        }
+    }
+
+    #[test]
+    fn limit_preserves_a_datagram_prefix() {
+        let contents = [0u8; 11];
+        let transmit = make_transmit(&contents, Some(5));
+
+        let prefix = transmit.limit(2);
+        assert_eq!(prefix.contents.len(), 10);
+        assert_eq!(prefix.datagram_count(), 2);
+        assert_eq!(prefix.segment_size, Some(5));
+        assert_eq!(prefix.destination, transmit.destination);
+        assert_eq!(prefix.ecn, transmit.ecn);
+        assert_eq!(prefix.src_ip, transmit.src_ip);
+
+        let complete = transmit.limit(3);
+        assert_eq!(complete.contents.len(), 11);
+        assert_eq!(complete.datagram_count(), 3);
+        assert_eq!(complete.segment_size, Some(5));
+
+        let single = prefix.limit(1);
+        assert_eq!(single.contents.len(), 5);
+        assert_eq!(single.datagram_count(), 1);
+        assert_eq!(single.segment_size, None);
     }
 
     fn make_transmit(contents: &[u8], segment_size: Option<usize>) -> Transmit<'_> {

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -42,8 +42,6 @@ use std::{
     net::UdpSocket,
     os::fd::{AsRawFd, FromRawFd},
 };
-#[cfg(not(wasm_browser))]
-use std::{sync::Mutex, time::Instant};
 #[cfg(windows)]
 use windows_sys::Win32::Networking::WinSock;
 
@@ -259,40 +257,6 @@ pub fn is_msg_size_err(err: &io::Error) -> bool {
         false
     }
 }
-
-/// Log at most 1 IO error per minute
-#[cfg(not(wasm_browser))]
-const IO_ERROR_LOG_INTERVAL: Duration = Duration::from_secs(60);
-
-/// Logs a warning message when sendmsg fails
-///
-/// Logging will only be performed if at least [`IO_ERROR_LOG_INTERVAL`]
-/// has elapsed since the last error was logged.
-#[cfg(all(not(wasm_browser), any(feature = "tracing-log", feature = "log")))]
-fn log_sendmsg_error(
-    last_send_error: &Mutex<Instant>,
-    err: impl core::fmt::Debug,
-    transmit: &Transmit<'_>,
-) {
-    let now = Instant::now();
-    let last_send_error = &mut *last_send_error.lock().expect("poisend lock");
-    if now.saturating_duration_since(*last_send_error) > IO_ERROR_LOG_INTERVAL {
-        *last_send_error = now;
-        log::warn!(
-            "sendmsg error: {:?}, Transmit: {{ destination: {:?}, src_ip: {:?}, ecn: {:?}, len: {:?}, segment_size: {:?} }}",
-            err,
-            transmit.destination,
-            transmit.src_ip,
-            transmit.ecn,
-            transmit.contents.len(),
-            transmit.segment_size
-        );
-    }
-}
-
-// No-op
-#[cfg(not(any(wasm_browser, feature = "tracing-log", feature = "log")))]
-fn log_sendmsg_error(_: &Mutex<Instant>, _: impl core::fmt::Debug, _: &Transmit<'_>) {}
 
 /// A borrowed UDP socket
 ///

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -15,8 +15,8 @@ use std::{
 use socket2::SockRef;
 
 use super::{
-    EcnCodepoint, IO_ERROR_LOG_INTERVAL, RecvMeta, Transmit, TransportError, UdpSockRef, cmsg,
-    log_sendmsg_error,
+    EcnCodepoint, IO_ERROR_LOG_INTERVAL, RecvMeta, SendCount, Transmit, TransportError, UdpSockRef,
+    cmsg, log_sendmsg_error,
 };
 
 #[cfg(apple_fast)]
@@ -235,24 +235,39 @@ impl UdpSocketState {
     ///
     /// If you would like to handle these errors yourself, use [`UdpSocketState::try_send`]
     /// instead.
-    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
-        match send(self, socket.0, transmit) {
-            Ok(()) => Ok(()),
+    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<SendCount> {
+        let attempted = transmit.limit(self.max_gso_segments());
+        let attempted_datagrams = attempted.datagram_count();
+
+        match send(self, socket.0, attempted) {
+            Ok(sent) => Ok(SendCount::from_datagram_count(sent)),
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => Err(e),
             // - EMSGSIZE is expected for MTU probes. Future work might be able to avoid
             //   these by automatically clamping the MTUD upper bound to the interface MTU.
-            Err(e) if e.raw_os_error() == Some(libc::EMSGSIZE) => Ok(()),
+            Err(e) if e.raw_os_error() == Some(libc::EMSGSIZE) => {
+                Ok(SendCount::from_datagram_count(attempted_datagrams))
+            }
             Err(e) => {
                 log_sendmsg_error(&self.last_send_error, e, transmit);
 
-                Ok(())
+                Ok(SendCount::from_datagram_count(attempted_datagrams))
             }
         }
     }
 
-    /// Sends a [`Transmit`] on the given socket without any additional error handling
-    pub fn try_send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
-        send(self, socket.0, transmit)
+    /// Sends a prefix of a [`Transmit`] without any additional error handling.
+    ///
+    /// Returns the number of leading datagrams accepted by the kernel. The prefix is limited to
+    /// the platform's current segmentation capacity. Use [`Transmit::advance`] with the return
+    /// value and retry any returned remainder.
+    pub fn try_send(
+        &self,
+        socket: UdpSockRef<'_>,
+        transmit: &Transmit<'_>,
+    ) -> io::Result<SendCount> {
+        let sent = send(self, socket.0, transmit.limit(self.max_gso_segments()))?;
+
+        Ok(SendCount::from_datagram_count(sent))
     }
 
     #[cfg(not(any(
@@ -471,13 +486,59 @@ impl UdpSocketState {
     }
 }
 
-#[cfg(not(any(apple, target_os = "openbsd", target_os = "netbsd")))]
-fn send(
-    #[allow(unused_variables)] // only used on Linux
-    state: &UdpSocketState,
-    io: SockRef<'_>,
-    transmit: &Transmit<'_>,
-) -> io::Result<()> {
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn send(state: &UdpSocketState, io: SockRef<'_>, mut transmit: Transmit<'_>) -> io::Result<usize> {
+    let dst_addr = socket2::SockAddr::from(transmit.destination);
+
+    loop {
+        let mut msg_hdr: libc::msghdr = unsafe { mem::zeroed() };
+        let mut iovec: libc::iovec = unsafe { mem::zeroed() };
+        let mut cmsgs = cmsg::Aligned([0u8; cmsg::LEN]);
+        prepare_msg(
+            &transmit,
+            &dst_addr,
+            &mut msg_hdr,
+            &mut iovec,
+            &mut cmsgs,
+            true,
+            state.sendmsg_einval(),
+        );
+
+        match retry_if_interrupted(|| unsafe { libc::sendmsg(io.as_raw_fd(), &msg_hdr, 0) }) {
+            Ok(_) => return Ok(transmit.datagram_count()),
+            Err(e)
+                if matches!(e.raw_os_error(), Some(libc::EINVAL) | Some(libc::EIO))
+                    && transmit.datagram_count() > 1 =>
+            {
+                if state.max_gso_segments.swap(1, Ordering::Relaxed) > 1 {
+                    crate::log::info!(
+                        "`libc::sendmsg` failed with {e}; halting segmentation offload"
+                    );
+                }
+
+                transmit = transmit.limit(1);
+                continue;
+            }
+            Err(e)
+                if matches!(e.raw_os_error(), Some(libc::EINVAL) | Some(libc::EIO))
+                    && !state.sendmsg_einval() =>
+            {
+                state.set_sendmsg_einval();
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[cfg(not(any(
+    apple,
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "linux",
+    target_os = "android"
+)))]
+fn send(state: &UdpSocketState, io: SockRef<'_>, transmit: Transmit<'_>) -> io::Result<usize> {
     #[allow(unused_mut)] // only mutable on FreeBSD
     let mut encode_src_ip = true;
     #[cfg(target_os = "freebsd")]
@@ -490,75 +551,39 @@ fn send(
             }
         }
     }
-    let mut msg_hdr: libc::msghdr = unsafe { mem::zeroed() };
-    let mut iovec: libc::iovec = unsafe { mem::zeroed() };
-    let mut cmsgs = cmsg::Aligned([0u8; cmsg::LEN]);
     let dst_addr = socket2::SockAddr::from(transmit.destination);
-    prepare_msg(
-        transmit,
-        &dst_addr,
-        &mut msg_hdr,
-        &mut iovec,
-        &mut cmsgs,
-        encode_src_ip,
-        state.sendmsg_einval(),
-    );
 
     loop {
-        let n = unsafe { libc::sendmsg(io.as_raw_fd(), &msg_hdr, 0) };
+        let mut msg_hdr: libc::msghdr = unsafe { mem::zeroed() };
+        let mut iovec: libc::iovec = unsafe { mem::zeroed() };
+        let mut cmsgs = cmsg::Aligned([0u8; cmsg::LEN]);
+        prepare_msg(
+            &transmit,
+            &dst_addr,
+            &mut msg_hdr,
+            &mut iovec,
+            &mut cmsgs,
+            encode_src_ip,
+            state.sendmsg_einval(),
+        );
 
-        if n >= 0 {
-            return Ok(());
-        }
-
-        let e = io::Error::last_os_error();
-        match e.kind() {
-            // Retry the transmission
-            io::ErrorKind::Interrupted => continue,
-            io::ErrorKind::WouldBlock => return Err(e),
-            _ => {
-                // Some network adapters and drivers do not support GSO. Unfortunately, Linux
-                // offers no easy way for us to detect this short of an EIO or sometimes EINVAL
-                // when we try to actually send datagrams using it.
-                #[cfg(any(target_os = "linux", target_os = "android"))]
-                if let Some(libc::EIO) | Some(libc::EINVAL) = e.raw_os_error() {
-                    // Prevent new transmits from being scheduled using GSO. Existing GSO transmits
-                    // may already be in the pipeline, so we need to tolerate additional failures.
-                    if state.max_gso_segments() > 1 {
-                        crate::log::info!(
-                            "`libc::sendmsg` failed with {e}; halting segmentation offload"
-                        );
-                        state.max_gso_segments.store(1, Ordering::Relaxed);
-                    }
-                }
-
-                // Some arguments to `sendmsg` are not supported. Switch to
-                // fallback mode and retry if we haven't already.
+        match retry_if_interrupted(|| unsafe { libc::sendmsg(io.as_raw_fd(), &msg_hdr, 0) }) {
+            Ok(_) => return Ok(transmit.datagram_count()),
+            Err(e)
                 if matches!(e.raw_os_error(), Some(libc::EINVAL) | Some(libc::EIO))
-                    && !state.sendmsg_einval()
-                {
-                    state.set_sendmsg_einval();
-                    prepare_msg(
-                        transmit,
-                        &dst_addr,
-                        &mut msg_hdr,
-                        &mut iovec,
-                        &mut cmsgs,
-                        encode_src_ip,
-                        state.sendmsg_einval(),
-                    );
-                    continue;
-                }
-
-                return Err(e);
+                    && !state.sendmsg_einval() =>
+            {
+                state.set_sendmsg_einval();
+                continue;
             }
+            Err(e) => return Err(e),
         }
     }
 }
 
 #[cfg(any(target_os = "openbsd", target_os = "netbsd", apple_slow))]
-fn send(state: &UdpSocketState, io: SockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
-    send_single(state, io, transmit)
+fn send(state: &UdpSocketState, io: SockRef<'_>, transmit: Transmit<'_>) -> io::Result<usize> {
+    send_single(state, io, &transmit)
 }
 
 #[cfg(any(target_os = "openbsd", target_os = "netbsd", apple))]
@@ -567,11 +592,12 @@ pub(crate) fn send_single(
     state: &UdpSocketState,
     io: SockRef<'_>,
     transmit: &Transmit<'_>,
-) -> io::Result<()> {
+) -> io::Result<usize> {
     let mut hdr: libc::msghdr = unsafe { mem::zeroed() };
     let mut iov: libc::iovec = unsafe { mem::zeroed() };
     let mut ctrl = cmsg::Aligned([0u8; cmsg::LEN]);
     let addr = socket2::SockAddr::from(transmit.destination);
+
     prepare_msg(
         transmit,
         &addr,
@@ -584,7 +610,8 @@ pub(crate) fn send_single(
     #[cfg(apple)]
     state.check_send_buffer_limit(transmit.contents.len(), &hdr)?;
     retry_if_interrupted(|| unsafe { libc::sendmsg(io.as_raw_fd(), &hdr, 0) })?;
-    Ok(())
+
+    Ok(transmit.datagram_count())
 }
 
 /// Receive using the batched `recvmmsg` syscall

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -11,7 +11,7 @@ use std::{
 
 use socket2::SockRef;
 
-use super::{EcnCodepoint, RecvMeta, Transmit, TransportError, UdpSockRef, cmsg};
+use super::{EcnCodepoint, RecvMeta, SendCount, Transmit, TransportError, UdpSockRef, cmsg};
 
 #[cfg(apple_fast)]
 use super::apple_fast::{msghdr_x, recv_via_recvmsg_x, send};
@@ -201,9 +201,19 @@ impl UdpSocketState {
         })
     }
 
-    /// Sends a [`Transmit`] on the given socket without any additional error handling
-    pub fn try_send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
-        send(self, socket.0, transmit)
+    /// Sends a prefix of a [`Transmit`] without any additional error handling.
+    ///
+    /// Returns the number of leading datagrams accepted by the kernel. The prefix is limited to
+    /// the platform's current segmentation capacity. Use [`Transmit::advance`] with the return
+    /// value and retry any returned remainder.
+    pub fn try_send(
+        &self,
+        socket: UdpSockRef<'_>,
+        transmit: &Transmit<'_>,
+    ) -> io::Result<SendCount> {
+        let sent = send(self, socket.0, transmit.limit(self.max_gso_segments()))?;
+
+        Ok(SendCount::from_datagram_count(sent))
     }
 
     #[cfg(not(any(
@@ -467,13 +477,59 @@ impl UdpSocketState {
     }
 }
 
-#[cfg(not(any(apple, target_os = "openbsd", target_os = "netbsd")))]
-fn send(
-    #[allow(unused_variables)] // only used on Linux
-    state: &UdpSocketState,
-    io: SockRef<'_>,
-    transmit: &Transmit<'_>,
-) -> io::Result<()> {
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn send(state: &UdpSocketState, io: SockRef<'_>, mut transmit: Transmit<'_>) -> io::Result<usize> {
+    let dst_addr = socket2::SockAddr::from(transmit.destination);
+
+    loop {
+        let mut msg_hdr: libc::msghdr = unsafe { mem::zeroed() };
+        let mut iovec: libc::iovec = unsafe { mem::zeroed() };
+        let mut cmsgs = cmsg::Aligned([0u8; cmsg::LEN]);
+        prepare_msg(
+            &transmit,
+            &dst_addr,
+            &mut msg_hdr,
+            &mut iovec,
+            &mut cmsgs,
+            true,
+            state.sendmsg_einval(),
+        );
+
+        match retry_if_interrupted(|| unsafe { libc::sendmsg(io.as_raw_fd(), &msg_hdr, 0) }) {
+            Ok(_) => return Ok(transmit.datagram_count()),
+            Err(e)
+                if matches!(e.raw_os_error(), Some(libc::EINVAL) | Some(libc::EIO))
+                    && transmit.datagram_count() > 1 =>
+            {
+                if state.max_gso_segments.swap(1, Ordering::Relaxed) > 1 {
+                    crate::log::info!(
+                        "`libc::sendmsg` failed with {e}; halting segmentation offload"
+                    );
+                }
+
+                transmit = transmit.limit(1);
+                continue;
+            }
+            Err(e)
+                if matches!(e.raw_os_error(), Some(libc::EINVAL) | Some(libc::EIO))
+                    && !state.sendmsg_einval() =>
+            {
+                state.set_sendmsg_einval();
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[cfg(not(any(
+    apple,
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "linux",
+    target_os = "android"
+)))]
+fn send(state: &UdpSocketState, io: SockRef<'_>, transmit: Transmit<'_>) -> io::Result<usize> {
     #[allow(unused_mut)] // only mutable on FreeBSD
     let mut encode_src_ip = true;
     #[cfg(target_os = "freebsd")]
@@ -486,75 +542,39 @@ fn send(
             }
         }
     }
-    let mut msg_hdr: libc::msghdr = unsafe { mem::zeroed() };
-    let mut iovec: libc::iovec = unsafe { mem::zeroed() };
-    let mut cmsgs = cmsg::Aligned([0u8; cmsg::LEN]);
     let dst_addr = socket2::SockAddr::from(transmit.destination);
-    prepare_msg(
-        transmit,
-        &dst_addr,
-        &mut msg_hdr,
-        &mut iovec,
-        &mut cmsgs,
-        encode_src_ip,
-        state.sendmsg_einval(),
-    );
 
     loop {
-        let n = unsafe { libc::sendmsg(io.as_raw_fd(), &msg_hdr, 0) };
+        let mut msg_hdr: libc::msghdr = unsafe { mem::zeroed() };
+        let mut iovec: libc::iovec = unsafe { mem::zeroed() };
+        let mut cmsgs = cmsg::Aligned([0u8; cmsg::LEN]);
+        prepare_msg(
+            &transmit,
+            &dst_addr,
+            &mut msg_hdr,
+            &mut iovec,
+            &mut cmsgs,
+            encode_src_ip,
+            state.sendmsg_einval(),
+        );
 
-        if n >= 0 {
-            return Ok(());
-        }
-
-        let e = io::Error::last_os_error();
-        match e.kind() {
-            // Retry the transmission
-            io::ErrorKind::Interrupted => continue,
-            io::ErrorKind::WouldBlock => return Err(e),
-            _ => {
-                // Some network adapters and drivers do not support GSO. Unfortunately, Linux
-                // offers no easy way for us to detect this short of an EIO or sometimes EINVAL
-                // when we try to actually send datagrams using it.
-                #[cfg(any(target_os = "linux", target_os = "android"))]
-                if let Some(libc::EIO) | Some(libc::EINVAL) = e.raw_os_error() {
-                    // Prevent new transmits from being scheduled using GSO. Existing GSO transmits
-                    // may already be in the pipeline, so we need to tolerate additional failures.
-                    if state.max_gso_segments() > 1 {
-                        crate::log::info!(
-                            "`libc::sendmsg` failed with {e}; halting segmentation offload"
-                        );
-                        state.max_gso_segments.store(1, Ordering::Relaxed);
-                    }
-                }
-
-                // Some arguments to `sendmsg` are not supported. Switch to
-                // fallback mode and retry if we haven't already.
+        match retry_if_interrupted(|| unsafe { libc::sendmsg(io.as_raw_fd(), &msg_hdr, 0) }) {
+            Ok(_) => return Ok(transmit.datagram_count()),
+            Err(e)
                 if matches!(e.raw_os_error(), Some(libc::EINVAL) | Some(libc::EIO))
-                    && !state.sendmsg_einval()
-                {
-                    state.set_sendmsg_einval();
-                    prepare_msg(
-                        transmit,
-                        &dst_addr,
-                        &mut msg_hdr,
-                        &mut iovec,
-                        &mut cmsgs,
-                        encode_src_ip,
-                        state.sendmsg_einval(),
-                    );
-                    continue;
-                }
-
-                return Err(e);
+                    && !state.sendmsg_einval() =>
+            {
+                state.set_sendmsg_einval();
+                continue;
             }
+            Err(e) => return Err(e),
         }
     }
 }
 
 #[cfg(any(target_os = "openbsd", target_os = "netbsd", apple_slow))]
-fn send(state: &UdpSocketState, io: SockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
-    send_single(state, io, transmit)
+fn send(state: &UdpSocketState, io: SockRef<'_>, transmit: Transmit<'_>) -> io::Result<usize> {
+    send_single(state, io, &transmit)
 }
 
 #[cfg(any(target_os = "openbsd", target_os = "netbsd", apple))]
@@ -563,11 +583,12 @@ pub(crate) fn send_single(
     state: &UdpSocketState,
     io: SockRef<'_>,
     transmit: &Transmit<'_>,
-) -> io::Result<()> {
+) -> io::Result<usize> {
     let mut hdr: libc::msghdr = unsafe { mem::zeroed() };
     let mut iov: libc::iovec = unsafe { mem::zeroed() };
     let mut ctrl = cmsg::Aligned([0u8; cmsg::LEN]);
     let addr = socket2::SockAddr::from(transmit.destination);
+
     prepare_msg(
         transmit,
         &addr,
@@ -580,7 +601,8 @@ pub(crate) fn send_single(
     #[cfg(apple)]
     state.check_send_buffer_limit(transmit.contents.len(), &hdr)?;
     retry_if_interrupted(|| unsafe { libc::sendmsg(io.as_raw_fd(), &hdr, 0) })?;
-    Ok(())
+
+    Ok(transmit.datagram_count())
 }
 
 /// Receive using the batched `recvmmsg` syscall

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -5,19 +5,13 @@ use std::{
     mem::{self, MaybeUninit},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     os::fd::AsRawFd,
-    sync::{
-        Mutex,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
-    },
-    time::{Duration, Instant},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    time::Duration,
 };
 
 use socket2::SockRef;
 
-use super::{
-    EcnCodepoint, IO_ERROR_LOG_INTERVAL, RecvMeta, Transmit, TransportError, UdpSockRef, cmsg,
-    log_sendmsg_error,
-};
+use super::{EcnCodepoint, RecvMeta, Transmit, TransportError, UdpSockRef, cmsg};
 
 #[cfg(apple_fast)]
 use super::apple_fast::{msghdr_x, recv_via_recvmsg_x, send};
@@ -30,7 +24,6 @@ use super::linux::{LinuxError, gso};
 /// platforms.
 #[derive(Debug)]
 pub struct UdpSocketState {
-    last_send_error: Mutex<Instant>,
     max_gso_segments: AtomicUsize,
     gro_segments: usize,
     may_fragment: bool,
@@ -196,9 +189,7 @@ impl UdpSocketState {
             let _ = io.set_send_buffer_size(Self::MIN_SAFE_SNDBUF);
         }
 
-        let now = Instant::now();
         Ok(Self {
-            last_send_error: Mutex::new(now.checked_sub(2 * IO_ERROR_LOG_INTERVAL).unwrap_or(now)),
             max_gso_segments: AtomicUsize::new(gso::max_gso_segments(&*io)),
             gro_segments,
             may_fragment,
@@ -208,33 +199,6 @@ impl UdpSocketState {
             #[cfg(apple)]
             send_buffer_size: AtomicUsize::new(io.send_buffer_size().unwrap_or(usize::MAX)),
         })
-    }
-
-    /// Sends a [`Transmit`] on the given socket
-    ///
-    /// This function will only ever return errors of kind [`io::ErrorKind::WouldBlock`].
-    /// All other errors will be logged and converted to `Ok`.
-    ///
-    /// UDP transmission errors are considered non-fatal because higher-level protocols must
-    /// employ retransmits and timeouts anyway in order to deal with UDP's unreliable nature.
-    /// Thus, logging is most likely the only thing you can do with these errors.
-    ///
-    /// If you would like to handle these errors yourself, use [`UdpSocketState::try_send`]
-    /// instead.
-    #[deprecated(note = "silences I/O errors; use `UdpSocketState::try_send() instead")]
-    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
-        match send(self, socket.0, transmit) {
-            Ok(()) => Ok(()),
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock => Err(e),
-            // - EMSGSIZE is expected for MTU probes. Future work might be able to avoid
-            //   these by automatically clamping the MTUD upper bound to the interface MTU.
-            Err(e) if e.raw_os_error() == Some(libc::EMSGSIZE) => Ok(()),
-            Err(e) => {
-                log_sendmsg_error(&self.last_send_error, e, transmit);
-
-                Ok(())
-            }
-        }
     }
 
     /// Sends a [`Transmit`] on the given socket without any additional error handling

--- a/quinn-udp/src/wasi.rs
+++ b/quinn-udp/src/wasi.rs
@@ -1,52 +1,22 @@
 use std::{
     io::{self, IoSliceMut},
     mem::MaybeUninit,
-    sync::Mutex,
-    time::Instant,
 };
 
-use super::{IO_ERROR_LOG_INTERVAL, RecvMeta, Transmit, UdpSockRef, log_sendmsg_error};
+use super::{RecvMeta, Transmit, UdpSockRef};
 
 /// UDP socket interface for WASI
 ///
 /// `wasi:sockets` exposes none of this crate's advanced features, so they are stubbed out.
 #[derive(Debug)]
 pub struct UdpSocketState {
-    last_send_error: Mutex<Instant>,
+    _private: (),
 }
 
 impl UdpSocketState {
     pub fn new(socket: UdpSockRef<'_>) -> io::Result<Self> {
         socket.set_nonblocking(true)?;
-
-        let now = Instant::now();
-        Ok(Self {
-            last_send_error: Mutex::new(now.checked_sub(2 * IO_ERROR_LOG_INTERVAL).unwrap_or(now)),
-        })
-    }
-
-    /// Sends a [`Transmit`] on the given socket.
-    ///
-    /// This function will only ever return errors of kind [`io::ErrorKind::WouldBlock`].
-    /// All other errors will be logged and converted to `Ok`.
-    ///
-    /// UDP transmission errors are considered non-fatal because higher-level protocols must
-    /// employ retransmits and timeouts anyway in order to deal with UDP's unreliable nature.
-    /// Thus, logging is most likely the only thing you can do with these errors.
-    ///
-    /// If you would like to handle these errors yourself, use [`UdpSocketState::try_send`]
-    /// instead.
-    #[deprecated(note = "silences I/O errors; use `UdpSocketState::try_send() instead")]
-    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
-        match send(socket, transmit) {
-            Ok(()) => Ok(()),
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock => Err(e),
-            Err(e) => {
-                log_sendmsg_error(&self.last_send_error, e, transmit);
-
-                Ok(())
-            }
-        }
+        Ok(Self { _private: () })
     }
 
     /// Sends a [`Transmit`] on the given socket without any additional error handling.

--- a/quinn-udp/src/wasi.rs
+++ b/quinn-udp/src/wasi.rs
@@ -3,7 +3,7 @@ use std::{
     mem::MaybeUninit,
 };
 
-use super::{RecvMeta, Transmit, UdpSockRef};
+use super::{RecvMeta, SendCount, Transmit, UdpSockRef};
 
 /// UDP socket interface for WASI
 ///
@@ -19,9 +19,16 @@ impl UdpSocketState {
         Ok(Self { _private: () })
     }
 
-    /// Sends a [`Transmit`] on the given socket without any additional error handling.
-    pub fn try_send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
-        send(socket, transmit)
+    /// Sends the first datagram of a [`Transmit`] without any additional error handling.
+    pub fn try_send(
+        &self,
+        socket: UdpSockRef<'_>,
+        transmit: &Transmit<'_>,
+    ) -> io::Result<SendCount> {
+        let transmit = transmit.limit(1);
+        let sent = send(socket, &transmit)?;
+
+        Ok(SendCount::from_datagram_count(sent))
     }
 
     pub fn recv(
@@ -87,12 +94,13 @@ impl UdpSocketState {
     }
 }
 
-fn send(socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
+fn send(socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<usize> {
     socket.0.send_to(
         transmit.contents,
         &socket2::SockAddr::from(transmit.destination),
     )?;
-    Ok(())
+
+    Ok(transmit.datagram_count())
 }
 
 pub(crate) const BATCH_SIZE: usize = 1;

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -15,7 +15,7 @@ use libc::{c_int, c_uint};
 use windows_sys::Win32::Networking::WinSock;
 
 use crate::{
-    EcnCodepoint, IO_ERROR_LOG_INTERVAL, RecvMeta, Transmit, UdpSockRef,
+    EcnCodepoint, IO_ERROR_LOG_INTERVAL, RecvMeta, SendCount, Transmit, UdpSockRef,
     cmsg::{self, CMsgHdr},
     log::debug,
     log_sendmsg_error,
@@ -196,31 +196,41 @@ impl UdpSocketState {
     ///
     /// If you would like to handle these errors yourself, use [`UdpSocketState::try_send`]
     /// instead.
-    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
+    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<SendCount> {
+        let transmit = transmit.limit(self.max_gso_segments());
+        let attempted = transmit.datagram_count();
+
         match send(
             socket,
-            transmit,
+            &transmit,
             self.ecn_v4_supported,
             self.ecn_v6_supported,
         ) {
-            Ok(()) => Ok(()),
+            Ok(sent) => Ok(SendCount::from_datagram_count(sent)),
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => Err(e),
             Err(e) => {
-                log_sendmsg_error(&self.last_send_error, e, transmit);
+                log_sendmsg_error(&self.last_send_error, e, &transmit);
 
-                Ok(())
+                Ok(SendCount::from_datagram_count(attempted))
             }
         }
     }
 
-    /// Sends a [`Transmit`] on the given socket without any additional error handling.
-    pub fn try_send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
-        send(
+    /// Sends a prefix of a [`Transmit`] without any additional error handling.
+    pub fn try_send(
+        &self,
+        socket: UdpSockRef<'_>,
+        transmit: &Transmit<'_>,
+    ) -> io::Result<SendCount> {
+        let transmit = transmit.limit(self.max_gso_segments());
+        let sent = send(
             socket,
-            transmit,
+            &transmit,
             self.ecn_v4_supported,
             self.ecn_v6_supported,
-        )
+        )?;
+
+        Ok(SendCount::from_datagram_count(sent))
     }
 
     pub fn recv(
@@ -386,7 +396,7 @@ fn send(
     transmit: &Transmit<'_>,
     ecn_v4_supported: bool,
     ecn_v6_supported: bool,
-) -> io::Result<()> {
+) -> io::Result<usize> {
     // we cannot use [`socket2::sendmsg()`] and [`socket2::MsgHdr`] as we do not have access
     // to the inner field which holds the WSAMSG
     let mut ctrl_buf = cmsg::Aligned([0; CMSG_LEN]);
@@ -455,7 +465,7 @@ fn send(
     }
 
     // Segment size is a u32 https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-wsasetudpsendmessagesize
-    if let Some(segment_size) = transmit.effective_segment_size() {
+    if let Some(segment_size) = transmit.segment_size {
         encoder.push(
             WinSock::IPPROTO_UDP,
             WinSock::UDP_SEND_MSG_SIZE,
@@ -478,7 +488,7 @@ fn send(
     };
 
     match rc {
-        0 => Ok(()),
+        0 => Ok(transmit.datagram_count()),
         _ => Err(io::Error::last_os_error()),
     }
 }

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -11,7 +11,7 @@ use libc::{c_int, c_uint};
 use windows_sys::Win32::Networking::WinSock;
 
 use crate::{
-    EcnCodepoint, RecvMeta, Transmit, UdpSockRef,
+    EcnCodepoint, RecvMeta, SendCount, Transmit, UdpSockRef,
     cmsg::{self, CMsgHdr},
     log::debug,
 };
@@ -176,14 +176,21 @@ impl UdpSocketState {
         )
     }
 
-    /// Sends a [`Transmit`] on the given socket without any additional error handling.
-    pub fn try_send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
-        send(
+    /// Sends a prefix of a [`Transmit`] without any additional error handling.
+    pub fn try_send(
+        &self,
+        socket: UdpSockRef<'_>,
+        transmit: &Transmit<'_>,
+    ) -> io::Result<SendCount> {
+        let transmit = transmit.limit(self.max_gso_segments());
+        let sent = send(
             socket,
-            transmit,
+            &transmit,
             self.ecn_v4_supported,
             self.ecn_v6_supported,
-        )
+        )?;
+
+        Ok(SendCount::from_datagram_count(sent))
     }
 
     pub fn recv(
@@ -347,7 +354,7 @@ fn send(
     transmit: &Transmit<'_>,
     ecn_v4_supported: bool,
     ecn_v6_supported: bool,
-) -> io::Result<()> {
+) -> io::Result<usize> {
     // we cannot use [`socket2::sendmsg()`] and [`socket2::MsgHdr`] as we do not have access
     // to the inner field which holds the WSAMSG
     let mut ctrl_buf = cmsg::Aligned([0; CMSG_LEN]);
@@ -416,7 +423,7 @@ fn send(
     }
 
     // Segment size is a u32 https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-wsasetudpsendmessagesize
-    if let Some(segment_size) = transmit.effective_segment_size() {
+    if let Some(segment_size) = transmit.segment_size {
         encoder.push(
             WinSock::IPPROTO_UDP,
             WinSock::UDP_SEND_MSG_SIZE,
@@ -439,7 +446,7 @@ fn send(
     };
 
     match rc {
-        0 => Ok(()),
+        0 => Ok(transmit.datagram_count()),
         _ => Err(io::Error::last_os_error()),
     }
 }

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -4,21 +4,16 @@ use std::{
     net::{IpAddr, Ipv4Addr},
     os::windows::io::AsRawSocket,
     ptr,
-    sync::{
-        Mutex,
-        atomic::{AtomicUsize, Ordering},
-    },
-    time::Instant,
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 use libc::{c_int, c_uint};
 use windows_sys::Win32::Networking::WinSock;
 
 use crate::{
-    EcnCodepoint, IO_ERROR_LOG_INTERVAL, RecvMeta, Transmit, UdpSockRef,
+    EcnCodepoint, RecvMeta, Transmit, UdpSockRef,
     cmsg::{self, CMsgHdr},
     log::debug,
-    log_sendmsg_error,
 };
 
 /// QUIC-friendly UDP socket for Windows
@@ -26,7 +21,6 @@ use crate::{
 /// Unlike a standard Windows UDP socket, this allows ECN bits to be read and written.
 #[derive(Debug)]
 pub struct UdpSocketState {
-    last_send_error: Mutex<Instant>,
     max_gso_segments: AtomicUsize,
 
     /// Whether the underlying Winsock provider supports IPv4 ECN socket options/control messages.
@@ -152,9 +146,7 @@ impl UdpSocketState {
             }
         }
 
-        let now = Instant::now();
         Ok(Self {
-            last_send_error: Mutex::new(now.checked_sub(2 * IO_ERROR_LOG_INTERVAL).unwrap_or(now)),
             max_gso_segments: AtomicUsize::new(max_gso_segments(&*socket.0)),
             ecn_v4_supported,
             ecn_v6_supported,
@@ -182,35 +174,6 @@ impl UdpSocketState {
                 false => 0,
             },
         )
-    }
-
-    /// Sends a [`Transmit`] on the given socket.
-    ///
-    /// This function will only ever return errors of kind [`io::ErrorKind::WouldBlock`].
-    /// All other errors will be logged and converted to `Ok`.
-    ///
-    /// UDP transmission errors are considered non-fatal because higher-level protocols must
-    /// employ retransmits and timeouts anyway in order to deal with UDP's unreliable nature.
-    /// Thus, logging is most likely the only thing you can do with these errors.
-    ///
-    /// If you would like to handle these errors yourself, use [`UdpSocketState::try_send`]
-    /// instead.
-    #[deprecated(note = "silences I/O errors; use `UdpSocketState::try_send() instead")]
-    pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
-        match send(
-            socket,
-            transmit,
-            self.ecn_v4_supported,
-            self.ecn_v6_supported,
-        ) {
-            Ok(()) => Ok(()),
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock => Err(e),
-            Err(e) => {
-                log_sendmsg_error(&self.last_send_error, e, transmit);
-
-                Ok(())
-            }
-        }
     }
 
     /// Sends a [`Transmit`] on the given socket without any additional error handling.

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -4,12 +4,11 @@ use std::io::{self, IoSlice};
 use std::net::{SocketAddr, SocketAddrV6};
 #[cfg(apple)]
 use std::os::fd::AsRawFd;
-#[cfg(any(target_os = "linux", target_os = "android"))]
-use std::time::Duration;
 use std::{
     io::IoSliceMut,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, UdpSocket},
     slice,
+    time::Duration,
 };
 
 use quinn_udp::{EcnCodepoint, RecvMeta, Transmit, UdpSocketState};
@@ -218,6 +217,36 @@ fn gso() {
 }
 
 #[test]
+fn send_reports_platform_limited_prefix() {
+    let send = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let recv = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    recv.set_read_timeout(Some(Duration::from_secs(1))).unwrap();
+
+    let state = UdpSocketState::new((&send).into()).unwrap();
+    let max_segments = state.max_gso_segments();
+    const SEGMENT_SIZE: usize = 128;
+    let contents = vec![0xAB; SEGMENT_SIZE * (max_segments + 1)];
+    let transmit = Transmit {
+        destination: recv.local_addr().unwrap(),
+        ecn: None,
+        contents: &contents,
+        segment_size: Some(SEGMENT_SIZE),
+        src_ip: None,
+    };
+
+    let sent = state.try_send((&send).into(), &transmit).unwrap();
+    assert_eq!(sent.get(), state.max_gso_segments());
+    assert!(sent.get() <= max_segments);
+
+    let mut buf = [0; SEGMENT_SIZE];
+    for _ in 0..sent.get() {
+        let received = recv.recv(&mut buf).unwrap();
+        assert_eq!(received, SEGMENT_SIZE);
+        assert_eq!(buf, [0xAB; SEGMENT_SIZE]);
+    }
+}
+
+#[test]
 fn socket_buffers() {
     const BUFFER_SIZE: usize = 123456;
     const FACTOR: usize = if cfg!(any(target_os = "linux", target_os = "android")) {
@@ -297,12 +326,13 @@ fn test_send_recv(send: &Socket, recv: &Socket, transmit: Transmit<'_>) {
     // Reverse non-blocking flag set by `UdpSocketState` to make the test non-racy
     recv.set_nonblocking(false).unwrap();
 
-    send_state.try_send(send.into(), &transmit).unwrap();
+    let sent = send_state.try_send(send.into(), &transmit).unwrap();
 
     let mut buf = [0; u16::MAX as usize];
     let mut meta = RecvMeta::default();
     let segment_size = transmit.segment_size.unwrap_or(transmit.contents.len());
-    let expected_datagrams = transmit.contents.len() / segment_size;
+    let expected_datagrams = transmit.datagram_count();
+    assert_eq!(sent.get(), expected_datagrams);
     let mut datagrams = 0;
     while datagrams < expected_datagrams {
         let n = recv_state
@@ -450,7 +480,7 @@ fn apple_fast_datapath() {
     let segments = send_state.max_gso_segments();
     let msg = vec![0xAB; SEGMENT_SIZE * segments];
 
-    send_state
+    let sent = send_state
         .try_send(
             (&send).into(),
             &Transmit {
@@ -462,6 +492,7 @@ fn apple_fast_datapath() {
             },
         )
         .unwrap();
+    assert_eq!(sent.get(), segments);
 
     // Receive all segments
     let mut buf = [0u8; u16::MAX as usize];
@@ -546,7 +577,7 @@ fn assert_min_sndbuf_enforced(state: &UdpSocketState, send: &Socket, dst: Socket
         src_ip: None,
     };
     match state.try_send(send.into(), &transmit) {
-        Ok(()) => {}
+        Ok(_) => {}
         Err(e) if e.raw_os_error() == Some(libc::EMSGSIZE) => {}
         Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
             panic!("regressed: permanently stuck EWOULDBLOCK sending a large datagram")
@@ -619,7 +650,7 @@ fn recv_transport_error() {
 
     let dst = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, unused_port));
 
-    state
+    let sent = state
         .try_send(
             (&sock).into(),
             &Transmit {
@@ -631,6 +662,7 @@ fn recv_transport_error() {
             },
         )
         .unwrap();
+    assert_eq!(sent.get(), 1);
 
     let mut received = None;
     for _ in 0..100 {
@@ -680,7 +712,7 @@ fn recv_transport_error_ipv6() {
 
     let dst = SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, unused_port, 0, 0));
 
-    state
+    let sent = state
         .try_send(
             (&sock).into(),
             &Transmit {
@@ -692,6 +724,7 @@ fn recv_transport_error_ipv6() {
             },
         )
         .unwrap();
+    assert_eq!(sent.get(), 1);
 
     let mut received = None;
 

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -274,6 +274,35 @@ fn large_single_datagram_is_not_segmented() {
 }
 
 #[test]
+fn send_reports_platform_limited_prefix() {
+    let send = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let recv = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+
+    let state = UdpSocketState::new((&send).into()).unwrap();
+    let max_segments = state.max_gso_segments();
+    const SEGMENT_SIZE: usize = 128;
+    let contents = vec![0xAB; SEGMENT_SIZE * (max_segments + 1)];
+    let transmit = Transmit {
+        destination: recv.local_addr().unwrap(),
+        ecn: None,
+        contents: &contents,
+        segment_size: Some(SEGMENT_SIZE),
+        src_ip: None,
+    };
+
+    let sent = state.try_send((&send).into(), &transmit).unwrap();
+    assert_eq!(sent.get(), state.max_gso_segments());
+    assert!(sent.get() <= max_segments);
+
+    let mut buf = [0; SEGMENT_SIZE];
+    for _ in 0..sent.get() {
+        let received = recv.recv(&mut buf).unwrap();
+        assert_eq!(received, SEGMENT_SIZE);
+        assert_eq!(buf, [0xAB; SEGMENT_SIZE]);
+    }
+}
+
+#[test]
 fn socket_buffers() {
     const BUFFER_SIZE: usize = 123456;
     const FACTOR: usize = if cfg!(any(target_os = "linux", target_os = "android")) {
@@ -354,12 +383,13 @@ fn test_send_recv(send: &Socket, recv: &Socket, transmit: Transmit<'_>) {
     UdpSockRef::from(send).set_nonblocking(false).unwrap();
     UdpSockRef::from(recv).set_nonblocking(false).unwrap();
 
-    send_state.try_send(send.into(), &transmit).unwrap();
+    let sent = send_state.try_send(send.into(), &transmit).unwrap();
 
     let mut buf = [0; u16::MAX as usize];
     let mut meta = RecvMeta::default();
     let segment_size = transmit.segment_size.unwrap_or(transmit.contents.len());
-    let expected_datagrams = transmit.contents.len() / segment_size;
+    let expected_datagrams = transmit.datagram_count();
+    assert_eq!(sent.get(), expected_datagrams);
     let mut datagrams = 0;
     while datagrams < expected_datagrams {
         let n = recv_state
@@ -507,7 +537,7 @@ fn apple_fast_datapath() {
     let segments = send_state.max_gso_segments();
     let msg = vec![0xAB; SEGMENT_SIZE * segments];
 
-    send_state
+    let sent = send_state
         .try_send(
             (&send).into(),
             &Transmit {
@@ -519,6 +549,7 @@ fn apple_fast_datapath() {
             },
         )
         .unwrap();
+    assert_eq!(sent.get(), segments);
 
     // Receive all segments
     let mut buf = [0u8; u16::MAX as usize];
@@ -603,7 +634,7 @@ fn assert_min_sndbuf_enforced(state: &UdpSocketState, send: &Socket, dst: Socket
         src_ip: None,
     };
     match state.try_send(send.into(), &transmit) {
-        Ok(()) => {}
+        Ok(_) => {}
         Err(e) if e.raw_os_error() == Some(libc::EMSGSIZE) => {}
         Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
             panic!("regressed: permanently stuck EWOULDBLOCK sending a large datagram")
@@ -679,7 +710,7 @@ fn recv_transport_error() {
 
     let dst = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, unused_port));
 
-    state
+    let sent = state
         .try_send(
             (&sock).into(),
             &Transmit {
@@ -691,6 +722,7 @@ fn recv_transport_error() {
             },
         )
         .unwrap();
+    assert_eq!(sent.get(), 1);
 
     let mut received = None;
     for _ in 0..100 {
@@ -743,7 +775,7 @@ fn recv_transport_error_ipv6() {
 
     let dst = SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, unused_port, 0, 0));
 
-    state
+    let sent = state
         .try_send(
             (&sock).into(),
             &Transmit {
@@ -755,6 +787,7 @@ fn recv_transport_error_ipv6() {
             },
         )
         .unwrap();
+    assert_eq!(sent.get(), 1);
 
     let mut received = None;
 
@@ -803,7 +836,7 @@ fn draining_error_queue_before_send_prevents_absorption() {
 
     // Enqueue an ICMP port-unreachable error
     let dst = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, unused_port));
-    state
+    let sent = state
         .try_send(
             (&sock).into(),
             &Transmit {
@@ -815,6 +848,7 @@ fn draining_error_queue_before_send_prevents_absorption() {
             },
         )
         .unwrap();
+    assert_eq!(sent.get(), 1);
 
     std::thread::sleep(Duration::from_millis(20));
 
@@ -834,7 +868,7 @@ fn draining_error_queue_before_send_prevents_absorption() {
     let receiver = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     receiver.set_nonblocking(true).unwrap();
 
-    state
+    let sent = state
         .try_send(
             (&sock).into(),
             &Transmit {
@@ -846,6 +880,7 @@ fn draining_error_queue_before_send_prevents_absorption() {
             },
         )
         .expect("send failed after draining the error queue");
+    assert_eq!(sent.get(), 1);
 
     std::thread::sleep(Duration::from_millis(20));
 

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -1014,8 +1014,9 @@ pub(crate) struct State {
     sender: Pin<Box<dyn UdpSender>>,
     runtime: Arc<dyn Runtime>,
     send_buffer: Vec<u8>,
-    /// We buffer a transmit when the underlying I/O would block
-    buffered_transmit: Option<proto::Transmit>,
+    /// A transmit buffered when I/O blocks or accepts only a prefix, and the byte offset of its
+    /// first unsent datagram.
+    buffered_transmit: Option<(proto::Transmit, usize)>,
 }
 
 impl State {
@@ -1062,7 +1063,7 @@ impl State {
 
         loop {
             // Retry the last transmit, or get a new one.
-            let t = match self.buffered_transmit.take() {
+            let (proto_transmit, mut offset) = match self.buffered_transmit.take() {
                 Some(t) => t,
                 None => {
                     self.send_buffer.clear();
@@ -1076,25 +1077,31 @@ impl State {
                                 None => 1,
                                 Some(s) => t.size.div_ceil(s), // round up
                             };
-                            t
+
+                            (t, 0)
                         }
                         None => break,
                     }
                 }
             };
 
-            let len = t.size;
-            match self
-                .sender
-                .as_mut()
-                .poll_send(&udp_transmit(&t, &self.send_buffer[..len]), cx)
-            {
+            let len = proto_transmit.size;
+            let transmit = udp_transmit(&proto_transmit, &self.send_buffer[offset..len]);
+            let previous_len = transmit.contents.len();
+
+            match self.sender.as_mut().poll_send(&transmit, cx) {
                 Poll::Pending => {
-                    self.buffered_transmit = Some(t);
+                    self.buffered_transmit = Some((proto_transmit, offset));
                     return Ok(false);
                 }
                 Poll::Ready(Err(e)) => return Err(e),
-                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Ok(sent)) => {
+                    if let Some(remainder) = transmit.advance(sent) {
+                        offset += previous_len - remainder.contents.len();
+                        self.buffered_transmit = Some((proto_transmit, offset));
+                        continue;
+                    }
+                }
             }
 
             if transmits >= MAX_TRANSMIT_DATAGRAMS {

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -1065,8 +1065,9 @@ pub(crate) struct State {
     sender: Pin<Box<dyn UdpSender>>,
     runtime: Arc<dyn Runtime>,
     send_buffer: Vec<u8>,
-    /// We buffer a transmit when the underlying I/O would block
-    buffered_transmit: Option<proto::Transmit>,
+    /// A transmit buffered when I/O blocks or accepts only a prefix, and the byte offset of its
+    /// first unsent datagram.
+    buffered_transmit: Option<(proto::Transmit, usize)>,
     remote_address: watch::Sender<SocketAddr>,
 }
 
@@ -1117,7 +1118,7 @@ impl State {
 
         loop {
             // Retry the last transmit, or get a new one.
-            let t = match self.buffered_transmit.take() {
+            let (proto_transmit, mut offset) = match self.buffered_transmit.take() {
                 Some(t) => t,
                 None => {
                     self.send_buffer.clear();
@@ -1131,25 +1132,31 @@ impl State {
                                 None => 1,
                                 Some(s) => t.size.div_ceil(s), // round up
                             };
-                            t
+
+                            (t, 0)
                         }
                         None => break,
                     }
                 }
             };
 
-            let len = t.size;
-            match self
-                .sender
-                .as_mut()
-                .poll_send(&udp_transmit(&t, &self.send_buffer[..len]), cx)
-            {
+            let len = proto_transmit.size;
+            let transmit = udp_transmit(&proto_transmit, &self.send_buffer[offset..len]);
+            let previous_len = transmit.contents.len();
+
+            match self.sender.as_mut().poll_send(&transmit, cx) {
                 Poll::Pending => {
-                    self.buffered_transmit = Some(t);
+                    self.buffered_transmit = Some((proto_transmit, offset));
                     return Ok(false);
                 }
                 Poll::Ready(Err(e)) => return Err(e),
-                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Ok(sent)) => {
+                    if let Some(remainder) = transmit.advance(sent) {
+                        offset += previous_len - remainder.contents.len();
+                        self.buffered_transmit = Some((proto_transmit, offset));
+                        continue;
+                    }
+                }
             }
 
             if transmits >= MAX_TRANSMIT_DATAGRAMS {

--- a/quinn/src/runtime/mod.rs
+++ b/quinn/src/runtime/mod.rs
@@ -9,7 +9,7 @@ use std::{
     task::{self, Context, Poll},
 };
 
-use udp::{RecvMeta, Transmit};
+use udp::{RecvMeta, SendCount, Transmit};
 
 use crate::Instant;
 
@@ -93,11 +93,14 @@ pub trait UdpSender: Send + Sync + Debug + 'static {
     ///
     /// A single [`UdpSender`] will be re-used, even if `poll_send` returns `Poll::Ready` once,
     /// unlike [`Future::poll`], so calling it again after readiness should not panic.
+    ///
+    /// On success, returns the non-zero number of leading datagrams accepted from `transmit`. This
+    /// can be smaller than the number offered, in which case the caller will retry the remainder.
     fn poll_send(
         self: Pin<&mut Self>,
         transmit: &Transmit<'_>,
         cx: &mut Context<'_>,
-    ) -> Poll<io::Result<()>>;
+    ) -> Poll<io::Result<SendCount>>;
 
     /// Maximum number of datagrams that a [`Transmit`] may encode.
     fn max_transmit_segments(&self) -> usize {
@@ -162,7 +165,7 @@ where
         self: Pin<&mut Self>,
         transmit: &Transmit<'_>,
         cx: &mut Context<'_>,
-    ) -> Poll<io::Result<()>> {
+    ) -> Poll<io::Result<SendCount>> {
         let mut this = self.project();
         loop {
             if this.writable_fut.is_none() {
@@ -208,7 +211,7 @@ trait UdpSenderHelperSocket: Send + Sync + 'static {
     /// If not write-ready, this is allowed to return [`std::io::ErrorKind::WouldBlock`].
     ///
     /// The [`UdpSenderHelper`] will use this to implement [`UdpSender::poll_send`].
-    fn try_send(&self, transmit: &Transmit<'_>) -> io::Result<()>;
+    fn try_send(&self, transmit: &Transmit<'_>) -> io::Result<SendCount>;
 
     /// See [`UdpSender::max_transmit_segments`].
     fn max_transmit_segments(&self) -> usize;

--- a/quinn/src/runtime/mod.rs
+++ b/quinn/src/runtime/mod.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-use udp::{RecvMeta, Transmit};
+use udp::{RecvMeta, SendCount, Transmit};
 
 use crate::Instant;
 
@@ -94,11 +94,14 @@ pub trait UdpSender: Send + Sync + Debug + 'static {
     ///
     /// A single [`UdpSender`] will be re-used, even if `poll_send` returns `Poll::Ready` once,
     /// unlike [`Future::poll`], so calling it again after readiness should not panic.
+    ///
+    /// On success, returns the non-zero number of leading datagrams accepted from `transmit`. This
+    /// can be smaller than the number offered, in which case the caller will retry the remainder.
     fn poll_send(
         self: Pin<&mut Self>,
         transmit: &Transmit<'_>,
         cx: &mut Context<'_>,
-    ) -> Poll<io::Result<()>>;
+    ) -> Poll<io::Result<SendCount>>;
 
     /// Maximum number of datagrams that a [`Transmit`] may encode.
     fn max_transmit_segments(&self) -> usize {
@@ -165,7 +168,7 @@ where
         self: Pin<&mut Self>,
         transmit: &Transmit<'_>,
         cx: &mut Context<'_>,
-    ) -> Poll<io::Result<()>> {
+    ) -> Poll<io::Result<SendCount>> {
         let mut this = self.project();
         loop {
             if this.writable_fut.is_none() {
@@ -193,9 +196,12 @@ where
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
                 Err(e) => {
                     log_sendmsg_error(this.last_send_error, &e, transmit);
-                    return Poll::Ready(Ok(()));
+                    let sent = SendCount::new(transmit.datagram_count())
+                        .expect("a transmit contains at least one datagram");
+
+                    return Poll::Ready(Ok(sent));
                 }
-                Ok(()) => return Poll::Ready(Ok(())),
+                Ok(sent) => return Poll::Ready(Ok(sent)),
             }
         }
     }
@@ -247,7 +253,7 @@ trait UdpSenderHelperSocket: Send + Sync + 'static {
     /// If not write-ready, this is allowed to return [`std::io::ErrorKind::WouldBlock`].
     ///
     /// The [`UdpSenderHelper`] will use this to implement [`UdpSender::poll_send`].
-    fn try_send(&self, transmit: &Transmit<'_>) -> io::Result<()>;
+    fn try_send(&self, transmit: &Transmit<'_>) -> io::Result<SendCount>;
 
     /// See [`UdpSender::max_transmit_segments`].
     fn max_transmit_segments(&self) -> usize;
@@ -307,7 +313,10 @@ mod tests {
 
         let result = sender.as_mut().poll_send(&transmit, &mut cx);
 
-        assert!(matches!(result, Poll::Ready(Ok(()))));
+        let Poll::Ready(Ok(sent)) = result else {
+            panic!("send error should be ignored");
+        };
+        assert_eq!(sent.get(), 1);
         assert!(sender.last_send_error.is_some());
     }
 
@@ -315,7 +324,7 @@ mod tests {
     struct TestSocket;
 
     impl UdpSenderHelperSocket for TestSocket {
-        fn try_send(&self, _transmit: &Transmit<'_>) -> io::Result<()> {
+        fn try_send(&self, _transmit: &Transmit<'_>) -> io::Result<SendCount> {
             Err(io::ErrorKind::PermissionDenied.into())
         }
 

--- a/quinn/src/runtime/smol.rs
+++ b/quinn/src/runtime/smol.rs
@@ -60,7 +60,7 @@ impl UdpSenderHelperSocket for UdpSocket {
         self.inner.max_gso_segments()
     }
 
-    fn try_send(&self, transmit: &udp::Transmit<'_>) -> io::Result<()> {
+    fn try_send(&self, transmit: &udp::Transmit<'_>) -> io::Result<udp::SendCount> {
         self.inner.send((&self.io).into(), transmit)
     }
 }

--- a/quinn/src/runtime/smol.rs
+++ b/quinn/src/runtime/smol.rs
@@ -60,10 +60,8 @@ impl UdpSenderHelperSocket for UdpSocket {
         self.inner.max_gso_segments()
     }
 
-    fn try_send(&self, transmit: &udp::Transmit<'_>) -> io::Result<()> {
-        self.inner.try_send((&self.io).into(), transmit)?;
-
-        Ok(())
+    fn try_send(&self, transmit: &udp::Transmit<'_>) -> io::Result<udp::SendCount> {
+        self.inner.try_send((&self.io).into(), transmit)
     }
 }
 

--- a/quinn/src/runtime/tokio.rs
+++ b/quinn/src/runtime/tokio.rs
@@ -59,7 +59,7 @@ impl UdpSenderHelperSocket for UdpSocket {
         self.inner.max_gso_segments()
     }
 
-    fn try_send(&self, transmit: &udp::Transmit<'_>) -> io::Result<()> {
+    fn try_send(&self, transmit: &udp::Transmit<'_>) -> io::Result<udp::SendCount> {
         self.io.try_io(Interest::WRITABLE, || {
             self.inner.send((&self.io).into(), transmit)
         })

--- a/quinn/src/runtime/tokio.rs
+++ b/quinn/src/runtime/tokio.rs
@@ -59,12 +59,10 @@ impl UdpSenderHelperSocket for UdpSocket {
         self.inner.max_gso_segments()
     }
 
-    fn try_send(&self, transmit: &udp::Transmit<'_>) -> io::Result<()> {
+    fn try_send(&self, transmit: &udp::Transmit<'_>) -> io::Result<udp::SendCount> {
         self.io.try_io(Interest::WRITABLE, || {
             self.inner.try_send((&self.io).into(), transmit)
-        })?;
-
-        Ok(())
+        })
     }
 }
 


### PR DESCRIPTION
This PR offers an alternative to #2672 that doesn't require buffering. For a detailed description, see the commit message.

Primarily, this fixes silent packet drops on the apple fast data path but it is also useful for other platforms to report only partial progress of the passed in `Transmit`.