### PR TITLE
congestion: saturate CUBIC window increment to avoid overflow

### DIFF
--- a/quinn-proto/src/congestion/cubic.rs
+++ b/quinn-proto/src/congestion/cubic.rs
@@ -158,7 +158,9 @@ impl Controller for Cubic {
                 let cubic_inc =
                     (w_cubic - cubic_cwnd as f64) / cubic_cwnd as f64 * self.current_mtu as f64;
 
-                cubic_cwnd += cubic_inc as u64;
+                // w_cubic grows cubically with the time since the last congestion
+                // event and can exceed `u64::MAX` after a long lossless period.
+                cubic_cwnd = cubic_cwnd.saturating_add(cubic_inc as u64);
             }
 
             // Update the increment and increase cwnd by MSS.
@@ -355,5 +357,25 @@ mod tests {
         // reset to zero.
         assert_eq!(cubic.state.window, window + BASE_DATAGRAM_SIZE);
         assert_eq!(cubic.state.cwnd_inc, BASE_DATAGRAM_SIZE + 1);
+    }
+
+    #[test]
+    fn congestion_avoidance_does_not_overflow_after_long_lossless_period() {
+        let now = Instant::now();
+        let rtt = RttEstimator::new(Duration::from_millis(100));
+        let config = Arc::new(CubicConfig::default());
+        let mut cubic = Cubic::new(config, now, BASE_DATAGRAM_SIZE as u16);
+
+        // Put CUBIC directly into congestion avoidance.
+        cubic.state.ssthresh = cubic.state.window;
+        cubic.state.recovery_start_time = Some(now);
+        let window = cubic.state.window;
+
+        // After ten days without a congestion event, w_cubic exceeds u64::MAX.
+        // Before this fix, computing the window increment overflowed.
+        let later = now + Duration::from_secs(10 * 24 * 60 * 60);
+        cubic.on_ack(later, later, BASE_DATAGRAM_SIZE, false, &rtt);
+
+        assert_eq!(cubic.state.window, window + BASE_DATAGRAM_SIZE);
     }
 }


### PR DESCRIPTION
Resolves a panic:
```
`thread 'tokio-rt-worker' (2693719) panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/quinn-proto-0.11.16/src/congestion/cubic.rs:149:17:
  attempt to add with overflow
```

`Cubic::on_ack` computes `cubic_cwnd += cubic_inc as u64` (`congestion/cubic.rs:161`). `w_cubic` grows cubically with the time since the last congestion event, so on a long-lived connection with no loss for roughly a week, `cubic_inc` exceeds `u64::MAX` and the addition overflows; a panic in builds with `overflow-checks = true`, a silent wrap otherwise.

Kind of along the lines of the ones below: https://github.com/quinn-rs/quinn/blob/fec2f8960df489767bfccef5b08b72013f1b992a/quinn-proto/src/congestion/cubic.rs#L164-L169