### PR TITLE
Fix quinn-udp compile errors and assertions on musl

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,6 +82,21 @@ jobs:
             . "$HOME/.cargo/env"
             cargo build --locked --all-targets && cargo test --locked && cargo test --locked -- --ignored stress && cargo test --locked --manifest-path fuzz/Cargo.toml && cargo test --locked -p quinn-udp --benches
 
+  test-musl:
+    name: test on musl
+    runs-on: ubuntu-latest
+    env:
+      # `cc` looks for a target-prefixed compiler; point it at the one `musl-tools` installs.
+      CC_x86_64_unknown_linux_musl: musl-gcc
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: x86_64-unknown-linux-musl
+      - run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --locked -p quinn-udp --target x86_64-unknown-linux-musl
+
   test:
     strategy:
       matrix:

--- a/quinn-udp/src/cmsg/mod.rs
+++ b/quinn-udp/src/cmsg/mod.rs
@@ -78,9 +78,10 @@ impl<M: MsgHdr> Drop for Encoder<'_, M> {
 ///
 /// `cmsg` must refer to a native cmsg containing a payload of type `T`
 pub(crate) unsafe fn decode<T: Copy, C: CMsgHdr>(cmsg: &impl CMsgHdr) -> T {
-    assert!(align_of::<T>() <= align_of::<C>());
     debug_assert_eq!(cmsg.len(), C::cmsg_len(size_of::<T>()));
-    ptr::read(cmsg.cmsg_data() as *const T)
+    // The payload is only aligned for `C`, which on musl is less strict than payloads such as
+    // `libc::timespec`, so it cannot be read through an aligned `ptr::read`.
+    ptr::read_unaligned(cmsg.cmsg_data() as *const T)
 }
 
 pub(crate) struct Iter<'a, M: MsgHdr> {

--- a/quinn-udp/src/linux.rs
+++ b/quinn-udp/src/linux.rs
@@ -87,7 +87,8 @@ impl LinuxError {
         let required =
             unsafe { libc::CMSG_LEN(size_of::<libc::sock_extended_err>() as _) as usize };
 
-        if cmsg.cmsg_len < required {
+        #[allow(clippy::unnecessary_cast)] // cmsg.cmsg_len defined as size_t
+        if (cmsg.cmsg_len as usize) < required {
             return None;
         }
 


### PR DESCRIPTION
This PR adds a new CI check to compile `quinn-udp` on musl. Certain alignments and types are different on musl and `quinn-udp` actually fails to compile and run on musl currently.

The two commits following the CI commit each fix a dedicated bug.