### PR TITLE
congestion: saturate CUBIC window increment to avoid overflow

### DIFF
--- a/quinn-proto/src/congestion/cubic.rs
+++ b/quinn-proto/src/congestion/cubic.rs
@@ -146,7 +146,9 @@ impl Controller for Cubic {
                 let cubic_inc =
                     (w_cubic - cubic_cwnd as f64) / cubic_cwnd as f64 * self.current_mtu as f64;
 
-                cubic_cwnd += cubic_inc as u64;
+                // w_cubic grows cubically with the time since the last congestion
+                // event and can exceed `u64::MAX` after a long lossless period.
+                cubic_cwnd = cubic_cwnd.saturating_add(cubic_inc as u64);
             }
 
             // Update the increment and increase cwnd by MSS.
@@ -295,5 +297,25 @@ mod tests {
         );
         assert_eq!(cubic.ssthresh, (window as f64 * BETA_CUBIC) as u64);
         assert_eq!(cubic.window, cubic.ssthresh);
+    }
+
+    #[test]
+    fn congestion_avoidance_does_not_overflow_after_long_lossless_period() {
+        let now = Instant::now();
+        let rtt = RttEstimator::new(Duration::from_millis(100));
+        let config = Arc::new(CubicConfig::default());
+        let mut cubic = Cubic::new(config, now, BASE_DATAGRAM_SIZE as u16);
+
+        // Put CUBIC directly into congestion avoidance.
+        cubic.ssthresh = cubic.window;
+        cubic.recovery_start_time = Some(now);
+        let window = cubic.window;
+
+        // After ten days without a congestion event, w_cubic exceeds u64::MAX.
+        // Before this fix, computing the window increment overflowed.
+        let later = now + Duration::from_secs(10 * 24 * 60 * 60);
+        cubic.on_ack(later, later, BASE_DATAGRAM_SIZE, false, &rtt);
+
+        assert_eq!(cubic.window, window + BASE_DATAGRAM_SIZE);
     }
 }

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -294,7 +294,7 @@ pub struct RttEstimator {
 }
 
 impl RttEstimator {
-    fn new(initial_rtt: Duration) -> Self {
+    pub(crate) fn new(initial_rtt: Duration) -> Self {
         Self {
             latest: initial_rtt,
             smoothed: None,


### PR DESCRIPTION
Backports https://github.com/quinn-rs/quinn/pull/2749 to `0.11.x` track