### PR TITLE
fix(ci): fix clippy lints

### DIFF
--- a/quinn-proto/src/connection/packet_crypto.rs
+++ b/quinn-proto/src/connection/packet_crypto.rs
@@ -88,17 +88,12 @@ pub(super) fn decrypt_packet_body(
         &zero_rtt_crypto.unwrap().packet
     } else if packet_key_phase == conn_key_phase || space != SpaceId::Data {
         &spaces[space].crypto.as_ref().unwrap().packet.remote
-    } else if let Some(prev) = prev_crypto.and_then(|crypto| {
-        // If this packet comes prior to acknowledgment of the key update by the peer,
-        if crypto.end_packet.is_none_or(|(pn, _)| number < pn) {
-            // use the previous keys.
-            Some(crypto)
-        } else {
-            // Otherwise, this must be a remotely-initiated key update, so fall through to the
-            // final case.
-            None
-        }
-    }) {
+    } else if let Some(prev) = prev_crypto.filter(|&crypto|
+        // Use the previous keys if this packet comes prior to acknowledgment of the
+        // key update by the peer; otherwise, this must be a remotely-initiated key
+        // update, so fall through to the final case.
+        crypto.end_packet.is_none_or(|(pn, _)| number < pn))
+    {
         &prev.crypto.remote
     } else {
         // We're in the Data space with a key phase mismatch and either there is no locally

--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -517,7 +517,7 @@ impl Drop for RecvStream {
                     .blocked_readers
                     .contains_key(&self.stream),
                 "Stream {} should not have a blocked reader when all data read is true",
-                &self.stream
+                self.stream
             );
             return;
         }


### PR DESCRIPTION
Fixes:

```
error: manual implementation of `Option::filter`
   --> quinn-proto/src/connection/packet_crypto.rs:91:44
    |
 91 |       } else if let Some(prev) = prev_crypto.and_then(|crypto| {
    |  ____________________________________________^
 92 | |         // If this packet comes prior to acknowledgment of the key update by the peer,
 93 | |         if crypto.end_packet.is_none_or(|(pn, _)| number < pn) {
...   |
101 | |     }) {
    | |______^ help: try: `filter(|&crypto| crypto.end_packet.is_none_or(|(pn, _)| number < pn))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#manual_filter
    = note: `-D clippy::manual-filter` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_filter)]`
```

and

```
error: redundant reference in `debug_assert!` argument
   --> quinn/src/recv_stream.rs:520:17
    |
520 |                 &self.stream
    |                 ^^^^^^^^^^^^ help: remove the redundant `&`: `self.stream`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting
    = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_borrows_in_formatting)]`

```