### PR TITLE
quinn-udp: repair the fallback backend and support wasm32-wasip2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -133,15 +133,22 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
-      - run: rustup target add wasm32-unknown-unknown
+      - run: rustup target add wasm32-unknown-unknown wasm32-wasip2
       - uses: actions/setup-node@v7
         with:
           node-version: 20
       - uses: bytecodealliance/actions/wasm-tools/setup@v1
+      - uses: bytecodealliance/actions/wasmtime/setup@v1
       - uses: cargo-bins/cargo-binstall@main
 
       - run: cargo test --locked -p quinn-proto --target wasm32-unknown-unknown --no-run
       - run: cargo check --locked -p quinn-udp --target wasm32-unknown-unknown --no-default-features --features=tracing,log
+      # Runs `fallback.rs`, which no other CI target so much as compiles. wasip2 is the only
+      # target that both selects it and has real sockets, so it is where the backend can be
+      # tested rather than just built. wasmtime denies network access unless asked.
+      - run: cargo test --locked -p quinn-udp --target wasm32-wasip2 --tests
+        env:
+          CARGO_TARGET_WASM32_WASIP2_RUNNER: wasmtime run -S inherit-network
       - run: cargo rustc --locked -p quinn --target wasm32-unknown-unknown --no-default-features --features=tracing-log,platform-verifier,rustls-ring --crate-type=cdylib
 
       # If the Wasm file contains any 'import "env"' declarations, then

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -31,7 +31,10 @@ socket2 = { workspace = true }
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true }
 
-[dev-dependencies]
+# Only the benchmark uses these, but cargo builds every dev-dependency for every test target, and
+# tokio refuses to compile for wasm with the features the benchmark needs. Scoping them off wasm
+# lets `tests/tests.rs` build for wasm32-wasip2; `cargo bench` is unaffected everywhere else.
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 criterion = { version = "0.8", default-features = false, features = ["async_tokio"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "net"] }
 

--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -1,3 +1,7 @@
+#[cfg(target_os = "wasi")]
+use std::mem::{ManuallyDrop, MaybeUninit};
+#[cfg(target_os = "wasi")]
+use std::os::fd::{AsRawFd, FromRawFd};
 use std::{
     io::{self, IoSliceMut},
     sync::Mutex,
@@ -17,6 +21,20 @@ pub struct UdpSocketState {
 
 impl UdpSocketState {
     pub fn new(socket: UdpSockRef<'_>) -> io::Result<Self> {
+        // socket2 sets the non-blocking flag with `fcntl(F_SETFL, O_NONBLOCK)`, which WASI
+        // rejects with `EINVAL`. wasi-libc only maps `ioctl(FIONBIO)` onto the `wasi:sockets`
+        // blocking flag, and that is the call `std`'s own `set_nonblocking` makes, so go
+        // through `std` here.
+        #[cfg(target_os = "wasi")]
+        {
+            // Safety: the caller owns the descriptor for at least as long as `socket` borrows
+            // it, and `ManuallyDrop` stops `borrowed` from closing it.
+            let borrowed = ManuallyDrop::new(unsafe {
+                std::net::UdpSocket::from_raw_fd(socket.0.as_raw_fd())
+            });
+            borrowed.set_nonblocking(true)?;
+        }
+        #[cfg(not(target_os = "wasi"))]
         socket.0.set_nonblocking(true)?;
         let now = Instant::now();
         Ok(Self {
@@ -58,14 +76,27 @@ impl UdpSocketState {
         bufs: &mut [IoSliceMut<'_>],
         meta: &mut [RecvMeta],
     ) -> io::Result<usize> {
-        // Safety: both `IoSliceMut` and `MaybeUninitSlice` promise to have the
-        // same layout, that of `iovec`/`WSABUF`. Furthermore `recv_vectored`
-        // promises to not write unitialised bytes to the `bufs` and pass it
-        // directly to the `recvmsg` system call, so this is safe.
-        let bufs = unsafe {
-            &mut *(bufs as *mut [IoSliceMut<'_>] as *mut [socket2::MaybeUninitSlice<'_>])
+        // WASI has no vectored reads, so socket2 does not offer `recv_from_vectored` there.
+        // `BATCH_SIZE` is 1, so reading a single datagram into the first buffer loses nothing.
+        #[cfg(target_os = "wasi")]
+        let (len, addr) = {
+            // Safety: `MaybeUninit<u8>` has the same layout as `u8`, and `recv_from` does not
+            // write uninitialised bytes into the prefix it reports as filled.
+            let buf = unsafe { &mut *(&mut *bufs[0] as *mut [u8] as *mut [MaybeUninit<u8>]) };
+            socket.0.recv_from(buf)?
         };
-        let (len, _flags, addr) = socket.0.recv_from_vectored(bufs)?;
+        #[cfg(not(target_os = "wasi"))]
+        let (len, addr) = {
+            // Safety: both `IoSliceMut` and `MaybeUninitSlice` promise to have the
+            // same layout, that of `iovec`/`WSABUF`. Furthermore `recv_vectored`
+            // promises to not write unitialised bytes to the `bufs` and pass it
+            // directly to the `recvmsg` system call, so this is safe.
+            let bufs = unsafe {
+                &mut *(bufs as *mut [IoSliceMut<'_>] as *mut [socket2::MaybeUninitSlice<'_>])
+            };
+            let (len, _flags, addr) = socket.0.recv_from_vectored(bufs)?;
+            (len, addr)
+        };
         meta[0] = RecvMeta {
             len,
             stride: len,

--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -73,6 +73,7 @@ impl UdpSocketState {
             ecn: None,
             dst_ip: None,
             interface_index: None,
+            timestamp: None,
         };
         Ok(1)
     }
@@ -121,7 +122,8 @@ fn send(socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
     socket.0.send_to(
         transmit.contents,
         &socket2::SockAddr::from(transmit.destination),
-    )
+    )?;
+    Ok(())
 }
 
 pub(crate) const BATCH_SIZE: usize = 1;

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -28,8 +28,8 @@
 #![warn(clippy::use_self)]
 
 use core::time::Duration;
-#[cfg(unix)]
-use std::os::unix::io::AsFd;
+#[cfg(any(unix, target_os = "wasi"))]
+use std::os::fd::AsFd;
 #[cfg(windows)]
 use std::os::windows::io::AsSocket;
 use std::{
@@ -297,7 +297,7 @@ fn log_sendmsg_error(_: &Mutex<Instant>, _: impl core::fmt::Debug, _: &Transmit<
 #[cfg(not(wasm_browser))]
 pub struct UdpSockRef<'a>(socket2::SockRef<'a>);
 
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "wasi"))]
 impl<'s, S> From<&'s S> for UdpSockRef<'s>
 where
     S: AsFd,

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -1,9 +1,18 @@
 #[cfg(apple)]
 use std::io::{self, IoSlice};
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", solarish)))]
+#[cfg(target_os = "wasi")]
+use std::mem::ManuallyDrop;
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "wasi",
+    solarish
+)))]
 use std::net::{SocketAddr, SocketAddrV6};
 #[cfg(apple)]
 use std::os::fd::AsRawFd;
+#[cfg(target_os = "wasi")]
+use std::os::fd::{AsRawFd, FromRawFd};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::time::Duration;
 use std::{
@@ -12,7 +21,9 @@ use std::{
     slice,
 };
 
-use quinn_udp::{EcnCodepoint, RecvMeta, Transmit, UdpSocketState};
+#[cfg(not(target_os = "wasi"))]
+use quinn_udp::EcnCodepoint;
+use quinn_udp::{RecvMeta, Transmit, UdpSocketState};
 #[cfg(apple)]
 use socket2::MsgHdr;
 use socket2::Socket;
@@ -62,7 +73,10 @@ fn basic_src_ip() {
     );
 }
 
+// WASI selects `fallback.rs`, which sets no ECN codepoint on send and always reports `None` on
+// receive, so the four ECN tests cannot pass there.
 #[test]
+#[cfg(not(target_os = "wasi"))]
 fn ecn_v6() {
     let send = Socket::from(UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap());
     let recv = Socket::from(UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap());
@@ -82,7 +96,12 @@ fn ecn_v6() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", solarish)))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "wasi",
+    solarish
+)))]
 fn ecn_v4() {
     let send = Socket::from(UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap());
     let recv = Socket::from(UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap());
@@ -102,7 +121,12 @@ fn ecn_v4() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", solarish)))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "wasi",
+    solarish
+)))]
 fn ecn_v6_dualstack() {
     let recv = Socket::new(
         socket2::Domain::IPV6,
@@ -148,7 +172,12 @@ fn ecn_v6_dualstack() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", solarish)))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "wasi",
+    solarish
+)))]
 fn ecn_v4_mapped_v6() {
     let send = Socket::new(
         socket2::Domain::IPV6,
@@ -295,7 +324,7 @@ fn test_send_recv(send: &Socket, recv: &Socket, transmit: Transmit<'_>) {
     let recv_state = UdpSocketState::new(recv.into()).unwrap();
 
     // Reverse non-blocking flag set by `UdpSocketState` to make the test non-racy
-    recv.set_nonblocking(false).unwrap();
+    set_blocking(recv);
 
     send_state.try_send(send.into(), &transmit).unwrap();
 
@@ -389,6 +418,25 @@ fn test_send_recv(send: &Socket, recv: &Socket, transmit: Transmit<'_>) {
         }
     }
     assert_eq!(datagrams, expected_datagrams);
+}
+
+#[cfg(not(target_os = "wasi"))]
+fn set_blocking(socket: &Socket) {
+    socket.set_nonblocking(false).unwrap();
+}
+
+/// Clears the non-blocking flag through `std`, the only way to reach the call WASI accepts.
+///
+/// socket2 uses `fcntl(F_SETFL, O_NONBLOCK)`, which WASI rejects with `EINVAL`; wasi-libc maps
+/// only `ioctl(FIONBIO)` onto the `wasi:sockets` blocking flag, and that is what `std` calls.
+/// `fallback::UdpSocketState::new` carries the same workaround, and both go away together if
+/// socket2 ever makes the call `std` makes.
+#[cfg(target_os = "wasi")]
+fn set_blocking(socket: &Socket) {
+    // Safety: `socket` outlives the borrow, and `ManuallyDrop` stops `borrowed` from closing a
+    // descriptor it does not own.
+    let borrowed = ManuallyDrop::new(unsafe { UdpSocket::from_raw_fd(socket.as_raw_fd()) });
+    borrowed.set_nonblocking(false).unwrap();
 }
 
 fn ip_to_v6_mapped(x: IpAddr) -> IpAddr {


### PR DESCRIPTION
Four commits, each droppable from the top:

1. `quinn-udp: fix bitrot in the fallback backend` — two compile errors on current main, not WASI-specific.
2. `quinn-udp: support wasm32-wasip2` — routes `target_os = "wasi"` into that repaired module.
3. `quinn-udp: run the test suite on wasm32-wasip2` — makes `tests/tests.rs` build and pass there.
4. `ci: test quinn-udp on wasm32-wasip2` — runs it under wasmtime, so the module stops rotting.

## `fallback.rs` does not compile

`cfg(not(any(wasm_browser, unix, windows)))` selects it and no CI target matches, so nothing has built it in a long time. At `a1931ab8`, `cargo check -p quinn-udp --target wasm32-wasip2` (lines dropped, none reworded):

```
error[E0599]: no method named `recv_from_vectored` found for struct `SockRef<'_>` in the current scope
  --> quinn-udp/src/fallback.rs:68:44
error[E0063]: missing field `timestamp` in initializer of `RecvMeta`
  --> quinn-udp/src/fallback.rs:69:19
error[E0308]: mismatched types
   --> quinn-udp/src/fallback.rs:121:5
```

Only the first is WASI-specific. `send` has returned `Result<usize>` from a `Result<()>` function since d442b504 (landed Oct 2024), and `RecvMeta::timestamp` arrived in 9849790f (landed Jun 2026) without this backend being updated. Commit 1 fixes those two and stands on its own merits whatever you make of the rest.

## Why this module rather than a new backend

`target_os = "wasi"` already selects it, and what the module declares is an accurate description of the platform rather than a degraded approximation of it. WASI 0.2's `wasi:sockets` UDP resource is 12 functions plus 5 across the two datagram-stream resources that carry data; the 0.3 draft is 15. Between them: a hop limit, the send and receive buffer sizes, and datagrams that arrive owned with a source address. No ECN, GSO/GRO, pktinfo, DF control, cmsg or vectored I/O in either version — which is `max_gso_segments() == 1`, `gro_segments() == 1`, `ecn: None`, `dst_ip: None`, `may_fragment() == true`, `BATCH_SIZE == 1`, all of which this module already says.

So commit 2 is three adjustments. `UdpSockRef`'s only descriptor constructor was `cfg(unix)`; `std::os::fd::AsFd` covers unix and wasi alike. `recv` calls `recv_from` on wasi, where socket2 offers no `recv_from_vectored` and `BATCH_SIZE` is 1 regardless. And `set_nonblocking` goes through `std`, because socket2 uses `fcntl(F_SETFL, O_NONBLOCK)` and WASI accepts only `ioctl(FIONBIO)`; that hunk is the ugly one, borrowing the descriptor as a `std` socket to reach the call, and it becomes a deletion if socket2 ever does what `std` does. Nothing outside `quinn-udp` changes — `quinn` already builds for wasip2 given `RUSTFLAGS=--cfg tokio_unstable`, which is tokio's gate on its wasm features, not quinn's.

## The crate's own tests now run on it

`tests/tests.rs` never needed tokio; cargo just builds every dev-dependency for every test target, and the benchmark's tokio wants `net`. Scoping the benchmark's dev-dependencies off wasm is enough to build the test target, and wasip2 is the only target that both selects `fallback.rs` and has real sockets — so CI can run the backend instead of only compiling it, via `CARGO_TARGET_WASM32_WASIP2_RUNNER: wasmtime run -S inherit-network` (wasmtime denies sockets by default; without the flag, `PermissionDenied`) and the same `bytecodealliance/actions` family the job already uses for `wasm-tools`. That is the wiring tokio's own CI uses to run its UDP suite on this target:

```
running 4 tests
test basic ... ok
test basic_src_ip ... ok
test gso ... ignored
test socket_buffers ... ok
```

`gso` was already ignored off Linux/Windows/Android; the four ECN tests are skipped, because this backend sets no codepoint and reports `ecn: None`, exactly as it documents; `test_send_recv` clears the non-blocking flag through `std` for the same reason the module does. Host behaviour is untouched — 8 passed, 1 ignored, before and after. What runs is a real send/recv round trip through `UdpSocketState`, and it catches what a `cargo check` cannot. Truncate the datagram by one byte in `send`: `cargo check` stays clean, `basic` fails on `[104, 101, 108, 108]` vs `[104, 101, 108, 108, 111]`. Drop the `set_nonblocking` hunk: `basic` fails with `Os { code: 28, kind: InvalidInput }` — so that hunk is load-bearing rather than defensive, and now says so in CI rather than in a PR description.

Beyond the unit tests, a QUIC handshake and a bidirectional stream from a wasm32-wasip2 guest under wasmtime 44.0.0 to a native quinn peer (rustc 1.95.0, socket2 0.6.5; 0.6.4, as locked here, also builds):

```
client: D QUIC HANDSHAKE COMPLETE : OK in 128.833459ms remote=127.0.0.1:54200 rtt=4.243208ms
client: E read 28 bytes back    : OK "echo:hello-from-wasip2-quinn"
server: received 23 bytes: "hello-from-wasip2-quinn"
```

All of that is loopback, one host, a debug build, `BATCH_SIZE` 1 — no NAT, loss, path MTU discovery, throughput or concurrency numbers. wasm32-wasip1 stays unsupported; socket2 declines it. I would call this the module compiling, its tests passing, and a connection working, not production-ready WASI support. I can publish the reproduction. Your CI bar passes locally (fmt, clippy `-D warnings`, tests, MSRV 1.88, doc, the wasm job) — list on request.

## Prior art, and who is asking

`fallback.rs` was last repaired in 07222809 (Dec 2023) — the same failure mode, one rotation earlier. #2566 touched it since and was closed over its API surface, not because the file is off-limits.

#1996, which introduced `wasm_browser`, reasoned that wasmtime's needs "are met by `wasm32-wasi-*` targets, not `wasm32-unknown-unknown`". I agree, and this is the gap that decision left: the wasi target does select this module — it just does not build. Its author, matheus23, is also the one who agreed downstream in April that compiling the stack for wasip2 is the right strategy for iroh (n0-computer/iroh#2799). To be clear about the limit of that: iroh still will not build for wasip2 after this, because it needs `netdev` and `wasi:sockets` has no interface enumeration — a WASI gap rather than a quinn one. This is the QUIC layer getting out of the way. (Heads-up: #2750 also edits `.github/workflows/rust.yml`, so commit 4 may want a rebase depending on merge order, or you can drop it.)

## The ask

Take whatever subset you are comfortable with. If the wasi routing needs discussion, commit 1 is an independent bug fix and I would rather it landed than waited on the rest; if you would prefer not to carry wasi at all, I would still suggest taking it, and I am happy to put the capability argument into a comment in `fallback.rs` instead.

_Since filing: commits 3 and 4 replace the original CI commit, which was only a `cargo check`. The crate's own tests now build and pass for wasip2 and CI runs them — "it compiles" is exactly the bar that let this file rot twice._
