### PR TITLE
quinn-udp: support wasm32-wasip2 and remove the fallback backend

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -148,15 +148,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
-      - run: rustup target add wasm32-unknown-unknown
+      - run: rustup target add wasm32-unknown-unknown wasm32-wasip2
       - uses: actions/setup-node@v7
         with:
           node-version: 20
       - uses: bytecodealliance/actions/wasm-tools/setup@v1
+      - uses: bytecodealliance/actions/wasmtime/setup@v1
       - uses: cargo-bins/cargo-binstall@main
 
       - run: cargo test --locked -p quinn-proto --target wasm32-unknown-unknown --no-run
       - run: cargo check --locked -p quinn-udp --target wasm32-unknown-unknown --no-default-features --features=tracing,log
+      # Unlike wasm32-unknown-unknown, wasip2 has real sockets, so `wasi.rs` can be tested.
+      - run: cargo test --locked -p quinn-udp --target wasm32-wasip2 --tests
+        env:
+          CARGO_TARGET_WASM32_WASIP2_RUNNER: wasmtime run -S inherit-network
       - run: cargo rustc --locked -p quinn --target wasm32-unknown-unknown --no-default-features --features=tracing-log,platform-verifier,rustls-ring --crate-type=cdylib
 
       # If the Wasm file contains any 'import "env"' declarations, then

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -31,7 +31,8 @@ socket2 = { workspace = true }
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true }
 
-[dev-dependencies]
+# Cargo builds dev-dependencies for every test target, and tokio's `net` doesn't build for wasm.
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 criterion = { version = "0.8", default-features = false, features = ["async_tokio"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "net"] }
 

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -28,13 +28,19 @@
 #![warn(clippy::use_self)]
 
 use core::time::Duration;
-#[cfg(unix)]
-use std::os::unix::io::AsFd;
+#[cfg(any(unix, target_os = "wasi"))]
+use std::os::fd::AsFd;
 #[cfg(windows)]
 use std::os::windows::io::AsSocket;
 use std::{
     io,
     net::{IpAddr, Ipv6Addr, SocketAddr},
+};
+#[cfg(target_os = "wasi")]
+use std::{
+    mem::ManuallyDrop,
+    net::UdpSocket,
+    os::fd::{AsRawFd, FromRawFd},
 };
 #[cfg(not(wasm_browser))]
 use std::{sync::Mutex, time::Instant};
@@ -58,9 +64,8 @@ mod linux;
 #[path = "windows.rs"]
 mod imp;
 
-// No ECN support
-#[cfg(not(any(wasm_browser, unix, windows)))]
-#[path = "fallback.rs"]
+#[cfg(target_os = "wasi")]
+#[path = "wasi.rs"]
 mod imp;
 
 #[allow(unused_imports, unused_macros)]
@@ -297,7 +302,26 @@ fn log_sendmsg_error(_: &Mutex<Instant>, _: impl core::fmt::Debug, _: &Transmit<
 #[cfg(not(wasm_browser))]
 pub struct UdpSockRef<'a>(socket2::SockRef<'a>);
 
-#[cfg(unix)]
+#[cfg(not(wasm_browser))]
+impl UdpSockRef<'_> {
+    /// Configures the socket for non-blocking or blocking operation.
+    pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
+        #[cfg(not(target_os = "wasi"))]
+        self.0.set_nonblocking(nonblocking)?;
+
+        #[cfg(target_os = "wasi")]
+        {
+            // socket2 uses `fcntl`, which WASI rejects; `std` uses `ioctl(FIONBIO)`.
+            // Safety: `self` outlives the borrow, and `ManuallyDrop` prevents a second close.
+            let borrowed = ManuallyDrop::new(unsafe { UdpSocket::from_raw_fd(self.0.as_raw_fd()) });
+            borrowed.set_nonblocking(nonblocking)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(any(unix, target_os = "wasi"))]
 impl<'s, S> From<&'s S> for UdpSockRef<'s>
 where
     S: AsFd,

--- a/quinn-udp/src/wasi.rs
+++ b/quinn-udp/src/wasi.rs
@@ -1,15 +1,15 @@
 use std::{
     io::{self, IoSliceMut},
+    mem::MaybeUninit,
     sync::Mutex,
     time::Instant,
 };
 
 use super::{IO_ERROR_LOG_INTERVAL, RecvMeta, Transmit, UdpSockRef, log_sendmsg_error};
 
-/// Fallback UDP socket interface that stubs out all special functionality
+/// UDP socket interface for WASI
 ///
-/// Used when a better implementation is not available for a particular target, at the cost of
-/// reduced performance compared to that enabled by some target-specific interfaces.
+/// `wasi:sockets` exposes none of this crate's advanced features, so they are stubbed out.
 #[derive(Debug)]
 pub struct UdpSocketState {
     last_send_error: Mutex<Instant>,
@@ -17,7 +17,8 @@ pub struct UdpSocketState {
 
 impl UdpSocketState {
     pub fn new(socket: UdpSockRef<'_>) -> io::Result<Self> {
-        socket.0.set_nonblocking(true)?;
+        socket.set_nonblocking(true)?;
+
         let now = Instant::now();
         Ok(Self {
             last_send_error: Mutex::new(now.checked_sub(2 * IO_ERROR_LOG_INTERVAL).unwrap_or(now)),
@@ -59,14 +60,11 @@ impl UdpSocketState {
         bufs: &mut [IoSliceMut<'_>],
         meta: &mut [RecvMeta],
     ) -> io::Result<usize> {
-        // Safety: both `IoSliceMut` and `MaybeUninitSlice` promise to have the
-        // same layout, that of `iovec`/`WSABUF`. Furthermore `recv_vectored`
-        // promises to not write unitialised bytes to the `bufs` and pass it
-        // directly to the `recvmsg` system call, so this is safe.
-        let bufs = unsafe {
-            &mut *(bufs as *mut [IoSliceMut<'_>] as *mut [socket2::MaybeUninitSlice<'_>])
-        };
-        let (len, _flags, addr) = socket.0.recv_from_vectored(bufs)?;
+        // `wasi:sockets` has no vectored receive, and `BATCH_SIZE` is 1 regardless.
+        // Safety: `MaybeUninit<u8>` shares the layout of `u8`, and `recv_from` writes only
+        // the prefix it reports as filled.
+        let buf = unsafe { &mut *(&mut *bufs[0] as *mut [u8] as *mut [MaybeUninit<u8>]) };
+        let (len, addr) = socket.0.recv_from(buf)?;
         meta[0] = RecvMeta {
             len,
             stride: len,
@@ -74,6 +72,7 @@ impl UdpSocketState {
             ecn: None,
             dst_ip: None,
             interface_index: None,
+            timestamp: None,
         };
         Ok(1)
     }
@@ -122,7 +121,8 @@ fn send(socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
     socket.0.send_to(
         transmit.contents,
         &socket2::SockAddr::from(transmit.destination),
-    )
+    )?;
+    Ok(())
 }
 
 pub(crate) const BATCH_SIZE: usize = 1;

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -1,6 +1,11 @@
 #[cfg(apple)]
 use std::io::{self, IoSlice};
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", solarish)))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "wasi",
+    solarish
+)))]
 use std::net::{SocketAddr, SocketAddrV6};
 #[cfg(apple)]
 use std::os::fd::AsRawFd;
@@ -12,7 +17,9 @@ use std::{
     slice,
 };
 
-use quinn_udp::{EcnCodepoint, RecvMeta, Transmit, UdpSocketState};
+#[cfg(not(target_os = "wasi"))]
+use quinn_udp::EcnCodepoint;
+use quinn_udp::{RecvMeta, Transmit, UdpSockRef, UdpSocketState};
 #[cfg(apple)]
 use socket2::MsgHdr;
 use socket2::Socket;
@@ -62,7 +69,9 @@ fn basic_src_ip() {
     );
 }
 
+// The WASI backend sets no ECN codepoint and always reports `None`.
 #[test]
+#[cfg(not(target_os = "wasi"))]
 fn ecn_v6() {
     let send = Socket::from(UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap());
     let recv = Socket::from(UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap());
@@ -82,7 +91,12 @@ fn ecn_v6() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", solarish)))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "wasi",
+    solarish
+)))]
 fn ecn_v4() {
     let send = Socket::from(UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap());
     let recv = Socket::from(UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap());
@@ -102,7 +116,12 @@ fn ecn_v4() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", solarish)))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "wasi",
+    solarish
+)))]
 fn ecn_v6_dualstack() {
     let recv = Socket::new(
         socket2::Domain::IPV6,
@@ -148,7 +167,12 @@ fn ecn_v6_dualstack() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", solarish)))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "wasi",
+    solarish
+)))]
 fn ecn_v4_mapped_v6() {
     let send = Socket::new(
         socket2::Domain::IPV6,
@@ -295,7 +319,8 @@ fn test_send_recv(send: &Socket, recv: &Socket, transmit: Transmit<'_>) {
     let recv_state = UdpSocketState::new(recv.into()).unwrap();
 
     // Reverse non-blocking flag set by `UdpSocketState` to make the test non-racy
-    recv.set_nonblocking(false).unwrap();
+    UdpSockRef::from(send).set_nonblocking(false).unwrap();
+    UdpSockRef::from(recv).set_nonblocking(false).unwrap();
 
     send_state.try_send(send.into(), &transmit).unwrap();
 


### PR DESCRIPTION
fix the compile errors, route wasi into the module, make the tests build there, run them in CI

Fixes #2754

I attest that I have read and understand this code. 