### PR TITLE
udp: preserve socket-level DSCP in the per-packet ECN cmsg

### DIFF
--- a/quinn-udp/src/apple_fast.rs
+++ b/quinn-udp/src/apple_fast.rs
@@ -57,7 +57,7 @@ fn send_via_sendmsg_x(
             &mut iovs[i],
             &mut ctrls[i],
             true,
-            state.sendmsg_einval(),
+            state,
         );
         hdrs[i].msg_datalen = chunk.len();
         state.check_send_buffer_limit(chunk.len(), &hdrs[i])?;
@@ -78,7 +78,7 @@ fn prepare_msg_x(
     iov: &mut libc::iovec,
     ctrl: &mut cmsg::Aligned<[u8; cmsg::LEN]>,
     #[allow(unused_variables)] encode_src_ip: bool,
-    sendmsg_einval: bool,
+    state: &UdpSocketState,
 ) {
     iov.iov_base = transmit.contents.as_ptr() as *const _ as *mut _;
     iov.iov_len = transmit.contents.len();
@@ -93,15 +93,15 @@ fn prepare_msg_x(
     hdr.msg_control = ctrl.0.as_mut_ptr() as _;
     hdr.msg_controllen = cmsg::LEN as _;
     let mut encoder = unsafe { cmsg::Encoder::new(hdr) };
-    let ecn = transmit.ecn.map_or(0, |x| x as libc::c_int);
+    let tos = state.tos_base() as libc::c_int | transmit.ecn.map_or(0, |x| x as libc::c_int);
     let is_ipv4 = transmit.destination.is_ipv4()
         || matches!(transmit.destination.ip(), IpAddr::V6(addr) if addr.to_ipv4_mapped().is_some());
     if is_ipv4 {
-        if !sendmsg_einval {
-            encoder.push(libc::IPPROTO_IP, libc::IP_TOS, ecn as IpTosTy);
+        if !state.sendmsg_einval() {
+            encoder.push(libc::IPPROTO_IP, libc::IP_TOS, tos as IpTosTy);
         }
     } else {
-        encoder.push(libc::IPPROTO_IPV6, libc::IPV6_TCLASS, ecn);
+        encoder.push(libc::IPPROTO_IPV6, libc::IPV6_TCLASS, tos);
     }
 
     if let Some(ip) = &transmit.src_ip {

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -42,6 +42,14 @@ pub struct UdpSocketState {
     /// which is not supported on Linux <3.13 and results in not sending the UDP packet at all.
     sendmsg_einval: AtomicBool,
 
+    /// The socket-level TOS / traffic-class byte at creation, ECN bits masked off.
+    ///
+    /// The per-packet `IP_TOS` / `IPV6_TCLASS` cmsg overrides the socket-level
+    /// option, so a cmsg valued solely from the ECN codepoint would zero any
+    /// DSCP marking the application configured via `setsockopt` before handing
+    /// the socket over. ORing this base into the cmsg preserves it.
+    tos_base: u8,
+
     /// Whether to use Apple's fast `sendmsg_x`/`recvmsg_x` APIs.
     ///
     /// These private APIs provide better performance but may not be available on all
@@ -83,6 +91,8 @@ impl UdpSocketState {
 
         let addr = io.local_addr()?;
         let is_ipv4 = addr.family() == libc::AF_INET as libc::sa_family_t;
+
+        let tos_base = socket_tos_base(&*io, is_ipv4);
 
         // mac and ios do not support IP_RECVTOS on dual-stack sockets :(
         // older macos versions also don't have the flag and will error out if we don't ignore it
@@ -217,6 +227,7 @@ impl UdpSocketState {
             gro_segments,
             may_fragment,
             sendmsg_einval: AtomicBool::new(false),
+            tos_base,
             #[cfg(apple_fast)]
             apple_fast_path: AtomicBool::new(false),
             #[cfg(apple)]
@@ -400,6 +411,11 @@ impl UdpSocketState {
         self.sendmsg_einval.load(Ordering::Relaxed)
     }
 
+    /// Returns the socket-level TOS / traffic-class byte captured at creation.
+    pub(crate) fn tos_base(&self) -> u8 {
+        self.tos_base
+    }
+
     /// Sets the flag indicating we got EINVAL error from `sendmsg` syscall.
     #[cfg(not(any(apple, target_os = "openbsd", target_os = "netbsd")))]
     fn set_sendmsg_einval(&self) {
@@ -501,7 +517,7 @@ fn send(
         &mut iovec,
         &mut cmsgs,
         encode_src_ip,
-        state.sendmsg_einval(),
+        state,
     );
 
     loop {
@@ -545,7 +561,7 @@ fn send(
                         &mut iovec,
                         &mut cmsgs,
                         encode_src_ip,
-                        state.sendmsg_einval(),
+                        state,
                     );
                     continue;
                 }
@@ -579,7 +595,7 @@ pub(crate) fn send_single(
         &mut iov,
         &mut ctrl,
         cfg!(apple) || cfg!(target_os = "openbsd") || cfg!(target_os = "netbsd"),
-        state.sendmsg_einval(),
+        state,
     );
     #[cfg(apple)]
     state.check_send_buffer_limit(transmit.contents.len(), &hdr)?;
@@ -677,7 +693,7 @@ fn prepare_msg(
     ctrl: &mut cmsg::Aligned<[u8; cmsg::LEN]>,
     #[allow(unused_variables)] // only used on FreeBSD & macOS
     encode_src_ip: bool,
-    sendmsg_einval: bool,
+    state: &UdpSocketState,
 ) {
     iov.iov_base = transmit.contents.as_ptr() as *const _ as *mut _;
     iov.iov_len = transmit.contents.len();
@@ -697,20 +713,20 @@ fn prepare_msg(
     hdr.msg_control = ctrl.0.as_mut_ptr() as _;
     hdr.msg_controllen = cmsg::LEN as _;
     let mut encoder = unsafe { cmsg::Encoder::new(hdr) };
-    let ecn = transmit.ecn.map_or(0, |x| x as libc::c_int);
+    let tos = state.tos_base() as libc::c_int | transmit.ecn.map_or(0, |x| x as libc::c_int);
     // True for IPv4 or IPv4-Mapped IPv6
     let is_ipv4 = transmit.destination.is_ipv4()
         || matches!(transmit.destination.ip(), IpAddr::V6(addr) if addr.to_ipv4_mapped().is_some());
     if is_ipv4 {
-        if !sendmsg_einval {
+        if !state.sendmsg_einval() {
             #[cfg(not(target_os = "netbsd"))]
             {
-                encoder.push(libc::IPPROTO_IP, libc::IP_TOS, ecn as IpTosTy);
+                encoder.push(libc::IPPROTO_IP, libc::IP_TOS, tos as IpTosTy);
             }
         }
     } else {
         #[cfg(not(target_os = "redox"))]
-        encoder.push(libc::IPPROTO_IPV6, libc::IPV6_TCLASS, ecn);
+        encoder.push(libc::IPPROTO_IPV6, libc::IPV6_TCLASS, tos);
     }
 
     // On apple_fast, prepare_msg is only compiled for send_single (fallback path), while the main
@@ -965,6 +981,43 @@ fn set_socket_option_supported(
         Err(err) if err.raw_os_error() == Some(libc::EOPNOTSUPP) => Ok(false),
         Err(err) => Err(err),
     }
+}
+
+/// Returns the socket-level TOS / traffic-class byte with the ECN bits masked off
+///
+/// Captured once at [`UdpSocketState`] creation and ORed into every per-packet
+/// `IP_TOS` / `IPV6_TCLASS` cmsg, so DSCP markings the application configured
+/// on the socket survive the ECN cmsg (which would otherwise override them).
+/// Best-effort: a failed `getsockopt` reads as an unmarked socket.
+fn socket_tos_base(socket: &impl AsRawFd, is_ipv4: bool) -> u8 {
+    let (level, opt) = match is_ipv4 {
+        true => (libc::IPPROTO_IP, libc::IP_TOS),
+        #[cfg(not(target_os = "redox"))]
+        false => (libc::IPPROTO_IPV6, libc::IPV6_TCLASS),
+        // Redox lacks `IPV6_TCLASS` (and no TCLASS cmsg is sent there)
+        #[cfg(target_os = "redox")]
+        false => return 0,
+    };
+    let mut val = [0u8; size_of::<libc::c_int>()];
+    let mut len = val.len() as libc::socklen_t;
+    let rc = unsafe {
+        libc::getsockopt(
+            socket.as_raw_fd(),
+            level,
+            opt,
+            val.as_mut_ptr() as *mut _,
+            &mut len,
+        )
+    };
+    if rc != 0 {
+        return 0;
+    }
+    // Some BSD-derived systems yield a single byte, others a full `c_int`
+    let tos = match len {
+        1 => val[0],
+        _ => libc::c_int::from_ne_bytes(val) as u8,
+    };
+    tos & !0b11
 }
 
 pub(crate) fn set_socket_option(

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -759,7 +759,12 @@ fn test_dscp_preserved(ipv4: bool) {
     let recv = UdpSocket::bind((loopback, 0)).unwrap();
     recv.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
     let (level, name) = match ipv4 {
+        // `libc` lacks `IP_RECVTOS` on solarish, where `dscp_preserved_v4` is
+        // disabled
+        #[cfg(not(solarish))]
         true => (libc::IPPROTO_IP, libc::IP_RECVTOS),
+        #[cfg(solarish)]
+        true => unreachable!("dscp_preserved_v4 is disabled on solarish"),
         false => (libc::IPPROTO_IPV6, libc::IPV6_RECVTCLASS),
     };
     set_socket_int_option(&recv, level, name, 1);
@@ -802,7 +807,22 @@ fn test_dscp_preserved(ipv4: bool) {
         wire_tos >> 2,
         wire_tos & 0b11,
     );
-    assert_eq!(wire_tos & 0b11, ecn as u8, "ECN bits should still be set");
+    // On Android API level <= 25 the IPv4 `IP_TOS` control message is not
+    // supported: `sendmsg` fails with `EINVAL` and quinn-udp resends without
+    // the cmsg, so the socket-level DSCP survives but the ECN codepoint is
+    // lost (mirrors the ECN exemption in `test_send_recv`)
+    if ipv4
+        && cfg!(target_os = "android")
+        && std::env::var("API_LEVEL")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .expect("API_LEVEL environment variable to be set on Android")
+            <= 25
+    {
+        assert_eq!(wire_tos & 0b11, 0, "no ECN expected on Android API <= 25");
+    } else {
+        assert_eq!(wire_tos & 0b11, ecn as u8, "ECN bits should still be set");
+    }
 }
 
 /// Sets a `c_int`-valued socket option via `setsockopt`, panicking on failure
@@ -849,9 +869,16 @@ fn recv_tos(sock: &UdpSocket) -> u8 {
     let mut cmsg = unsafe { libc::CMSG_FIRSTHDR(&hdr) };
     while !cmsg.is_null() {
         let c = unsafe { &*cmsg };
-        let is_tos = (c.cmsg_level == libc::IPPROTO_IP
-            && (c.cmsg_type == libc::IP_TOS || c.cmsg_type == libc::IP_RECVTOS))
-            || (c.cmsg_level == libc::IPPROTO_IPV6 && c.cmsg_type == libc::IPV6_TCLASS);
+        // FreeBSD types the received cmsg `IP_RECVTOS` rather than `IP_TOS`;
+        // `libc` lacks the constant on solarish, where only the v6 variant of
+        // the DSCP test runs
+        #[cfg(not(solarish))]
+        let is_v4_tos = c.cmsg_level == libc::IPPROTO_IP
+            && (c.cmsg_type == libc::IP_TOS || c.cmsg_type == libc::IP_RECVTOS);
+        #[cfg(solarish)]
+        let is_v4_tos = false;
+        let is_tos =
+            is_v4_tos || (c.cmsg_level == libc::IPPROTO_IPV6 && c.cmsg_type == libc::IPV6_TCLASS);
         if is_tos {
             // Delivered as a single byte on BSD/macOS and a host-order int on
             // Linux; either way the value is in the first byte on

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -2,7 +2,7 @@
 use std::io::{self, IoSlice};
 #[cfg(not(any(target_os = "openbsd", target_os = "netbsd", solarish)))]
 use std::net::{SocketAddr, SocketAddrV6};
-#[cfg(apple)]
+#[cfg(unix)]
 use std::os::fd::AsRawFd;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::time::Duration;
@@ -715,4 +715,156 @@ fn recv_transport_error_ipv6() {
     if let Some(addr) = err.addr {
         assert_eq!(addr.ip(), dst.ip());
     }
+}
+
+/// The DSCP marking under test: AF41 (RFC 2597)
+#[cfg(unix)]
+const DSCP: u8 = 34;
+
+#[test]
+#[cfg(unix)]
+fn dscp_preserved_v6() {
+    test_dscp_preserved(false);
+}
+
+#[test]
+#[cfg(all(unix, not(any(target_os = "openbsd", target_os = "netbsd", solarish))))]
+fn dscp_preserved_v4() {
+    test_dscp_preserved(true);
+}
+
+/// DSCP set on the socket via `setsockopt` must survive the per-packet ECN
+/// cmsg
+///
+/// The `IP_TOS` / `IPV6_TCLASS` cmsg attached to every datagram overrides the
+/// socket-level option, so a cmsg valued solely from the ECN codepoint would
+/// rewrite the wire TOS byte to `ecn` — zeroing DSCP markings the application
+/// configured before handing the socket over. (Windows is unaffected: its
+/// `IP_ECN` / `IPV6_ECN` options touch only the ECN bits.)
+///
+/// Sends one datagram over loopback through `UdpSocketState` on a DSCP-tagged
+/// socket and receives it with a raw `recvmsg` requesting the TOS byte.
+#[cfg(unix)]
+fn test_dscp_preserved(ipv4: bool) {
+    use std::{io::ErrorKind, time::Duration};
+
+    let tos = DSCP << 2;
+    let ecn = EcnCodepoint::Ect0;
+
+    let loopback: IpAddr = match ipv4 {
+        true => Ipv4Addr::LOCALHOST.into(),
+        false => Ipv6Addr::LOCALHOST.into(),
+    };
+
+    let recv = UdpSocket::bind((loopback, 0)).unwrap();
+    recv.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    let (level, name) = match ipv4 {
+        true => (libc::IPPROTO_IP, libc::IP_RECVTOS),
+        false => (libc::IPPROTO_IPV6, libc::IPV6_RECVTCLASS),
+    };
+    set_socket_int_option(&recv, level, name, 1);
+    let dst = recv.local_addr().unwrap();
+
+    // Tag the sender *before* constructing `UdpSocketState`, as an
+    // application configuring DSCP would
+    let send = UdpSocket::bind((loopback, 0)).unwrap();
+    let (level, name) = match ipv4 {
+        true => (libc::IPPROTO_IP, libc::IP_TOS),
+        false => (libc::IPPROTO_IPV6, libc::IPV6_TCLASS),
+    };
+    set_socket_int_option(&send, level, name, tos as libc::c_int);
+
+    let send_state = UdpSocketState::new((&send).into()).unwrap();
+    let transmit = Transmit {
+        destination: dst,
+        ecn: Some(ecn),
+        contents: b"dscp",
+        segment_size: None,
+        src_ip: None,
+    };
+    // `UdpSocketState::new` sets the socket nonblocking; loopback won't
+    // backpressure a 4-byte datagram, but retry `WouldBlock` to be safe
+    for _ in 0..10 {
+        match send_state.try_send((&send).into(), &transmit) {
+            Ok(()) => break,
+            Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(e) => panic!("try_send failed: {e}"),
+        }
+    }
+
+    let wire_tos = recv_tos(&recv);
+    assert_eq!(
+        wire_tos >> 2,
+        DSCP,
+        "DSCP clobbered: wire TOS byte was {wire_tos:#04x} (DSCP {}, ECN {:#04b})",
+        wire_tos >> 2,
+        wire_tos & 0b11,
+    );
+    assert_eq!(wire_tos & 0b11, ecn as u8, "ECN bits should still be set");
+}
+
+/// Sets a `c_int`-valued socket option via `setsockopt`, panicking on failure
+#[cfg(unix)]
+fn set_socket_int_option(
+    socket: &impl AsRawFd,
+    level: libc::c_int,
+    name: libc::c_int,
+    value: libc::c_int,
+) {
+    let rc = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            level,
+            name,
+            &value as *const _ as *const libc::c_void,
+            size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    assert_eq!(rc, 0, "setsockopt({level}, {name}) failed");
+}
+
+/// Receives one datagram and returns its TOS / traffic-class byte
+#[cfg(unix)]
+fn recv_tos(sock: &UdpSocket) -> u8 {
+    use std::io::Error;
+
+    let mut buf = [0u8; 64];
+    let mut iov = libc::iovec {
+        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+        iov_len: buf.len(),
+    };
+    // Aligned control buffer
+    let mut ctrl = [0u64; 16];
+    let mut hdr: libc::msghdr = unsafe { std::mem::zeroed() };
+    hdr.msg_iov = &mut iov;
+    hdr.msg_iovlen = 1;
+    hdr.msg_control = ctrl.as_mut_ptr() as *mut libc::c_void;
+    hdr.msg_controllen = size_of_val(&ctrl) as _;
+
+    let n = unsafe { libc::recvmsg(sock.as_raw_fd(), &mut hdr, 0) };
+    assert!(n >= 0, "recvmsg failed: {}", Error::last_os_error());
+
+    let mut cmsg = unsafe { libc::CMSG_FIRSTHDR(&hdr) };
+    while !cmsg.is_null() {
+        let c = unsafe { &*cmsg };
+        let is_tos = (c.cmsg_level == libc::IPPROTO_IP
+            && (c.cmsg_type == libc::IP_TOS || c.cmsg_type == libc::IP_RECVTOS))
+            || (c.cmsg_level == libc::IPPROTO_IPV6 && c.cmsg_type == libc::IPV6_TCLASS);
+        if is_tos {
+            // Delivered as a single byte on BSD/macOS and a host-order int on
+            // Linux; either way the value is in the first byte on
+            // little-endian, and Linux (the only big-endian target in
+            // practice) writes a full int we can read unaligned
+            let data = unsafe { libc::CMSG_DATA(cmsg) };
+            let len = c.cmsg_len as usize - unsafe { libc::CMSG_LEN(0) } as usize;
+            return match len {
+                1 => unsafe { *data },
+                _ => unsafe { (data as *const libc::c_int).read_unaligned() as u8 },
+            };
+        }
+        cmsg = unsafe { libc::CMSG_NXTHDR(&hdr, cmsg) };
+    }
+    panic!("no TOS/TCLASS cmsg on received datagram");
 }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -319,6 +319,10 @@ impl Connection {
     }
 
     /// Accept the next incoming uni-directional stream
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancellation safe. If this does not resolve, no streams were consumed.
     pub fn accept_uni(&self) -> AcceptUni<'_> {
         AcceptUni {
             conn: &self.0,
@@ -336,6 +340,10 @@ impl Connection {
     /// [`open_bi()`]: crate::Connection::open_bi
     /// [`SendStream`]: crate::SendStream
     /// [`RecvStream`]: crate::RecvStream
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancellation safe. If this does not resolve, no streams were consumed.
     pub fn accept_bi(&self) -> AcceptBi<'_> {
         AcceptBi {
             conn: &self.0,
@@ -344,6 +352,10 @@ impl Connection {
     }
 
     /// Receive an application datagram
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancellation safe. If this does not resolve, no datagrams were consumed.
     pub fn read_datagram(&self) -> ReadDatagram<'_> {
         ReadDatagram {
             conn: &self.0,


### PR DESCRIPTION
While working on a different application (github.com/baughn/dessplay) I found a need to use per-stream DSCP tagging. Since Quinn has no support (#1749), I attempted to work around this by creating the socket up-front, setting DSCP, then handing it off. This also did not work, because quinn-udp clears any DSCP bits while attempting to set the ECN bit.

Since there's no intent to handle DSCP internally, this PR sets the ECN setting by read-modify-write so other bits survive unmodified. Tested on OSX + Linux; I do not have a BSD machine of any kind, which makes me suspicious of the BSD-specific code, but I expect the worst it can do is recreate the original bug.

Patch and regression tests coded by Fable, reviewed by me. And because it insists on being helpful:

> On Unix platforms every datagram carries an IP_TOS / IPV6_TCLASS cmsg whose value is derived solely from the transmit's ECN codepoint. A per-packet cmsg overrides the socket-level option, so any DSCP marking an application configured with setsockopt before handing the socket to quinn is silently rewritten to 0 on the wire. Windows is unaffected: its IP_ECN / IPV6_ECN options touch only the ECN bits.
>
> Capture the socket's TOS byte (ECN bits masked off) once at UdpSocketState creation and OR it into every outgoing TOS cmsg, so the DSCP bits survive while ECN continues to work exactly as before. The capture is best-effort: on an unmarked socket the base is 0 and the cmsg value is unchanged from today.
>
> Closes #1749 for the setsockopt use case without adding any API surface: applications mark the socket before constructing the endpoint, as they already must for other socket options.