### PR TITLE
docs(quinn): document cancellation safety for accept_uni, accept_bi and read_datagram

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -319,6 +319,10 @@ impl Connection {
     }
 
     /// Accept the next incoming uni-directional stream
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancellation safe. If this does not resolve, no streams were consumed.
     pub fn accept_uni(&self) -> AcceptUni<'_> {
         AcceptUni {
             conn: &self.0,
@@ -336,6 +340,10 @@ impl Connection {
     /// [`open_bi()`]: crate::Connection::open_bi
     /// [`SendStream`]: crate::SendStream
     /// [`RecvStream`]: crate::RecvStream
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancellation safe. If this does not resolve, no streams were consumed.
     pub fn accept_bi(&self) -> AcceptBi<'_> {
         AcceptBi {
             conn: &self.0,
@@ -344,6 +352,10 @@ impl Connection {
     }
 
     /// Receive an application datagram
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancellation safe. If this does not resolve, no datagrams were consumed.
     pub fn read_datagram(&self) -> ReadDatagram<'_> {
         ReadDatagram {
             conn: &self.0,


### PR DESCRIPTION
Closes #2247 

For these 3 methods, if they consume a stream or datagram (in poll_accept or ReadDatagram::poll), they will definitely return Poll::Ready in this poll; if a Poll::Pending is returned, no intermediate states are stored so it's safe to drop it. As a result they are cancellation safe.
