### PR TITLE
feat(udp): make transport error reception opt-in on Linux/Android

### DIFF
--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -146,21 +146,6 @@ impl UdpSocketState {
             {
                 crate::log::debug!("Ignoring error setting SO_TIMESTAMPNS on socket: {_err:?}");
             }
-
-            if is_ipv4 || !io.only_v6()? {
-                if let Err(_err) =
-                    set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_RECVERR, OPTION_ON)
-                {
-                    crate::log::debug!("ignoring error setting IP_RECVERR on socket: {_err:?}");
-                }
-            }
-            if !is_ipv4 {
-                if let Err(_err) =
-                    set_socket_option(&*io, libc::IPPROTO_IPV6, libc::IPV6_RECVERR, OPTION_ON)
-                {
-                    crate::log::debug!("ignoring error setting IPV6_RECVERR on socket: {_err:?}");
-                }
-            }
         }
         #[cfg(any(target_os = "freebsd", apple))]
         {
@@ -303,13 +288,55 @@ impl UdpSocketState {
         recv_single(socket.0, bufs, meta)
     }
 
-    /// Receives a pending, asynchronous transport-layer error from this socket
+    /// Enables asynchronous transport-layer error reception for this socket.
     ///
-    /// On Linux and Android this pops one entry from the socket error queue
-    /// (`MSG_ERRQUEUE`). Returns `None` if the queue is empty or if the
-    /// underlying platform is unsupported.
+    /// On Linux and Android, this enables the socket error queue via
+    /// `IP_RECVERR`/`IPV6_RECVERR`, allowing ICMP errors to be retrieved with
+    /// [`recv_transport_error`]. On other platforms, this method is a no-op.
+    ///
+    /// # Cost
+    ///
+    /// On Linux and Android, queued ICMP errors are charged against the socket's
+    /// receive buffer (`sk_rmem_alloc`). If the buffer is full, incoming errors
+    /// are silently dropped by the kernel. There is no overhead when the error
+    /// queue is empty.
+    ///
+    /// # Usage
+    ///
+    /// When this feature is enabled, the kernel may return a pending error on the
+    /// next `sendmsg` or `recvmsg` call, preventing that operation from completing.
+    /// To avoid this, callers should drain the error queue via
+    /// [`recv_transport_error`] before sending or receiving.
+    ///
+    /// [`recv_transport_error`]: Self::recv_transport_error
+    pub fn enable_transport_errors(&self, _socket: UdpSockRef<'_>) -> io::Result<()> {
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            let io = _socket.0;
+            let addr = io.local_addr()?;
+            let is_ipv4 = addr.family() == libc::AF_INET as libc::sa_family_t;
+
+            if is_ipv4 || !io.only_v6()? {
+                set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_RECVERR, OPTION_ON)?;
+            }
+
+            if !is_ipv4 {
+                set_socket_option(&*io, libc::IPPROTO_IPV6, libc::IPV6_RECVERR, OPTION_ON)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Receives one pending asynchronous transport-layer error from this socket.
+    ///
+    /// Returns `None` if the error queue is empty or the underlying platform is
+    /// unsupported. On Linux and Android, errors are only available if
+    /// [`enable_transport_errors`] has been called first.
     ///
     /// Returns an error if the underlying system call fails unexpectedly.
+    ///
+    /// [`enable_transport_errors`]: Self::enable_transport_errors
     pub fn recv_transport_error(
         &self,
         _socket: UdpSockRef<'_>,

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -146,21 +146,6 @@ impl UdpSocketState {
             {
                 crate::log::debug!("Ignoring error setting SO_TIMESTAMPNS on socket: {_err:?}");
             }
-
-            if is_ipv4 || !io.only_v6()? {
-                if let Err(_err) =
-                    set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_RECVERR, OPTION_ON)
-                {
-                    crate::log::debug!("ignoring error setting IP_RECVERR on socket: {_err:?}");
-                }
-            }
-            if !is_ipv4 {
-                if let Err(_err) =
-                    set_socket_option(&*io, libc::IPPROTO_IPV6, libc::IPV6_RECVERR, OPTION_ON)
-                {
-                    crate::log::debug!("ignoring error setting IPV6_RECVERR on socket: {_err:?}");
-                }
-            }
         }
         #[cfg(any(target_os = "freebsd", apple))]
         {
@@ -303,13 +288,56 @@ impl UdpSocketState {
         recv_single(socket.0, bufs, meta)
     }
 
-    /// Receives a pending, asynchronous transport-layer error from this socket
+    /// Enables asynchronous transport-layer error reception for this socket
     ///
-    /// On Linux and Android this pops one entry from the socket error queue
-    /// (`MSG_ERRQUEUE`). Returns `None` if the queue is empty or if the
-    /// underlying platform is unsupported.
+    /// On Linux and Android, this enables the socket error queue via
+    /// `IP_RECVERR`/`IPV6_RECVERR`, allowing ICMP errors to be retrieved with
+    /// [`recv_transport_error`]. On other platforms, this method is a no-op and
+    /// [`recv_transport_error`] will always return `None`.
+    ///
+    /// # Cost
+    ///
+    /// On Linux and Android, queued ICMP errors are charged against the socket's
+    /// receive buffer (`sk_rmem_alloc`). If the buffer is full, incoming errors
+    /// are silently dropped by the kernel. There is no overhead when the error
+    /// queue is empty.
+    ///
+    /// # Usage
+    ///
+    /// When this feature is enabled, the kernel may return a pending error on the
+    /// next `sendmsg` or `recvmsg` call, preventing that operation from completing.
+    /// To avoid this, callers should drain the error queue via
+    /// [`recv_transport_error`] before sending or receiving.
+    ///
+    /// [`recv_transport_error`]: Self::recv_transport_error
+    pub fn enable_transport_errors(&self, _socket: UdpSockRef<'_>) -> io::Result<()> {
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            let io = _socket.0;
+            let addr = io.local_addr()?;
+            let is_ipv4 = addr.family() == libc::AF_INET as libc::sa_family_t;
+
+            if is_ipv4 || !io.only_v6()? {
+                set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_RECVERR, OPTION_ON)?;
+            }
+
+            if !is_ipv4 {
+                set_socket_option(&*io, libc::IPPROTO_IPV6, libc::IPV6_RECVERR, OPTION_ON)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Receives one pending asynchronous transport-layer error from this socket
+    ///
+    /// Returns `None` if the error queue is empty or the underlying platform is
+    /// unsupported. On Linux and Android, errors are only available if
+    /// [`enable_transport_errors`] has been called first.
     ///
     /// Returns an error if the underlying system call fails unexpectedly.
+    ///
+    /// [`enable_transport_errors`]: Self::enable_transport_errors
     pub fn recv_transport_error(
         &self,
         _socket: UdpSockRef<'_>,

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -610,6 +610,9 @@ fn recv_transport_error() {
     let sock = Socket::from(UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap());
 
     let state = UdpSocketState::new((&sock).into()).unwrap();
+    state
+        .enable_transport_errors((&sock).into())
+        .expect("failed to enable transport error recv");
 
     // Pick an unused port by binding then dropping.
     let unused_port = {
@@ -672,6 +675,9 @@ fn recv_transport_error_ipv6() {
     let sock = Socket::from(UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap());
 
     let state = UdpSocketState::new((&sock).into()).unwrap();
+    state
+        .enable_transport_errors((&sock).into())
+        .expect("failed to enable transport error recv");
 
     let unused_port = {
         let tmp = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap();
@@ -715,4 +721,82 @@ fn recv_transport_error_ipv6() {
     if let Some(addr) = err.addr {
         assert_eq!(addr.ip(), dst.ip());
     }
+}
+
+/// Verifies the correct usage pattern: draining the error queue before sending
+/// prevents queued ICMP errors from absorbing unrelated `sendmsg` calls.
+///
+/// When `enable_transport_errors` is active, callers are expected to drain
+/// pending errors via `recv_transport_error` before transmitting. This test
+/// confirms that doing so allows a subsequent send to succeed and deliver
+/// its payload.
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn draining_error_queue_before_send_prevents_absorption() {
+    let sock = Socket::from(UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap());
+
+    let state = UdpSocketState::new((&sock).into()).unwrap();
+    state
+        .enable_transport_errors((&sock).into())
+        .expect("failed to enable transport error recv");
+
+    // Pick an unused port by binding then dropping.
+    let unused_port = {
+        let tmp = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        tmp.local_addr().unwrap().port()
+    };
+
+    // Enqueue an ICMP port-unreachable error
+    let dst = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, unused_port));
+    state
+        .try_send(
+            (&sock).into(),
+            &Transmit {
+                destination: dst,
+                ecn: None,
+                contents: b"hello",
+                segment_size: None,
+                src_ip: None,
+            },
+        )
+        .unwrap();
+
+    std::thread::sleep(Duration::from_millis(20));
+
+    // Drain the error queue before sending — this is the intended usage pattern
+    let mut got_error = false;
+    for _ in 0..10 {
+        match state.recv_transport_error((&sock).into()) {
+            Ok(Some(_)) => {
+                got_error = true;
+                break;
+            }
+            _ => std::thread::sleep(Duration::from_millis(10)),
+        }
+    }
+    assert!(got_error, "expected one queued error");
+
+    let receiver = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    receiver.set_nonblocking(true).unwrap();
+
+    state
+        .try_send(
+            (&sock).into(),
+            &Transmit {
+                destination: receiver.local_addr().unwrap(),
+                ecn: None,
+                contents: b"connection close",
+                segment_size: None,
+                src_ip: None,
+            },
+        )
+        .expect("send failed after draining the error queue");
+
+    std::thread::sleep(Duration::from_millis(20));
+
+    let mut buf = [0u8; 64];
+    let n = receiver
+        .recv(&mut buf)
+        .expect("packet was not delivered after draining the error queue");
+    assert_eq!(&buf[..n], b"connection close");
 }

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -610,6 +610,9 @@ fn recv_transport_error() {
     let sock = Socket::from(UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap());
 
     let state = UdpSocketState::new((&sock).into()).unwrap();
+    state
+        .enable_transport_errors((&sock).into())
+        .expect("failed to enable transport error recv");
 
     // Pick an unused port by binding then dropping.
     let unused_port = {
@@ -672,6 +675,9 @@ fn recv_transport_error_ipv6() {
     let sock = Socket::from(UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap());
 
     let state = UdpSocketState::new((&sock).into()).unwrap();
+    state
+        .enable_transport_errors((&sock).into())
+        .expect("failed to enable transport error recv");
 
     let unused_port = {
         let tmp = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap();
@@ -715,4 +721,80 @@ fn recv_transport_error_ipv6() {
     if let Some(addr) = err.addr {
         assert_eq!(addr.ip(), dst.ip());
     }
+}
+
+/// Draining the error queue prevents queued ICMP errors from absorbing unrelated sends
+///
+/// When `enable_transport_errors` is active, callers are expected to drain pending
+/// errors via `recv_transport_error` before transmitting. This test confirms that
+/// doing so allows a subsequent send to succeed and deliver its payload.
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn draining_error_queue_before_send_prevents_absorption() {
+    let sock = Socket::from(UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap());
+
+    let state = UdpSocketState::new((&sock).into()).unwrap();
+    state
+        .enable_transport_errors((&sock).into())
+        .expect("failed to enable transport error recv");
+
+    // Pick an unused port by binding then dropping.
+    let unused_port = {
+        let tmp = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        tmp.local_addr().unwrap().port()
+    };
+
+    // Enqueue an ICMP port-unreachable error
+    let dst = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, unused_port));
+    state
+        .try_send(
+            (&sock).into(),
+            &Transmit {
+                destination: dst,
+                ecn: None,
+                contents: b"hello",
+                segment_size: None,
+                src_ip: None,
+            },
+        )
+        .unwrap();
+
+    std::thread::sleep(Duration::from_millis(20));
+
+    // Drain the error queue before sending — this is the intended usage pattern
+    let mut got_error = false;
+    for _ in 0..10 {
+        match state.recv_transport_error((&sock).into()) {
+            Ok(Some(_)) => {
+                got_error = true;
+                break;
+            }
+            _ => std::thread::sleep(Duration::from_millis(10)),
+        }
+    }
+    assert!(got_error, "expected one queued error");
+
+    let receiver = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    receiver.set_nonblocking(true).unwrap();
+
+    state
+        .try_send(
+            (&sock).into(),
+            &Transmit {
+                destination: receiver.local_addr().unwrap(),
+                ecn: None,
+                contents: b"connection close",
+                segment_size: None,
+                src_ip: None,
+            },
+        )
+        .expect("send failed after draining the error queue");
+
+    std::thread::sleep(Duration::from_millis(20));
+
+    let mut buf = [0u8; 64];
+    let n = receiver
+        .recv(&mut buf)
+        .expect("packet was not delivered after draining the error queue");
+    assert_eq!(&buf[..n], b"connection close");
 }


### PR DESCRIPTION
Addresses #2704

#2646 enabled `IP_RECVERR`/`IPV6_RECVERR` unconditionally on Linux and Android. This has two side effects discussed in #2704:
* queued errors can cause subsequent syscalls (e.g. `recvmmsg` or `sendmsg`) to return the error instead of completing the operation;
* enabling this feature has a non-zero cost since queued errors use the same receive buffer as incoming packets.

This PR implements the proposed resolution from #2704 and makes transport error reception opt-in via a new `enable_transport_errors` method on `UdpSocketState`. Users that need asynchronous transport errors can enable the feature explicitly and retrieve them through the existing `recv_transport_error`.

When enabled, callers are responsible for draining pending transport errors before sending or receiving, as queued errors may otherwise be returned by subsequent socket operations.

Existing transport error tests are updated to enable the feature explicitly, and a regression test verifies the documented usage pattern.