### PR TITLE
feat(proto): support QUIC version 2

### DIFF
--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -18,7 +18,7 @@ use rustls::{
 use rustls_platform_verifier::BuilderVerifierExt;
 
 use crate::{
-    ConnectError, ConnectionId, Side, TransportError, TransportErrorCode,
+    ConnectError, ConnectionId, QUIC_V2_VERSION, Side, TransportError, TransportErrorCode,
     crypto::{
         self, CryptoError, ExportKeyingMaterialError, HeaderKey, KeyPair, Keys, UnsupportedVersion,
     },
@@ -198,7 +198,8 @@ impl crypto::Session for TlsSession {
         let (nonce, key) = match self.version {
             Version::V1 => (RETRY_INTEGRITY_NONCE_V1, RETRY_INTEGRITY_KEY_V1),
             Version::V1Draft => (RETRY_INTEGRITY_NONCE_DRAFT, RETRY_INTEGRITY_KEY_DRAFT),
-            _ => unreachable!(),
+            Version::V2 => (RETRY_INTEGRITY_NONCE_V2, RETRY_INTEGRITY_KEY_V2),
+            _ => unreachable!("unsupported QUIC version"),
         };
 
         let nonce = aead::Nonce::assume_unique_for_key(nonce);
@@ -233,6 +234,12 @@ const RETRY_INTEGRITY_KEY_V1: [u8; 16] = [
 ];
 const RETRY_INTEGRITY_NONCE_V1: [u8; 12] = [
     0x46, 0x15, 0x99, 0xd3, 0x5d, 0x63, 0x2b, 0xf2, 0x23, 0x98, 0x25, 0xbb,
+];
+const RETRY_INTEGRITY_KEY_V2: [u8; 16] = [
+    0x8f, 0xb4, 0xb0, 0x1b, 0x56, 0xac, 0x48, 0xe2, 0x60, 0xfb, 0xcb, 0xce, 0xad, 0x7c, 0xcc, 0x92,
+];
+const RETRY_INTEGRITY_NONCE_V2: [u8; 12] = [
+    0xd8, 0x69, 0x69, 0xbc, 0x2d, 0x7c, 0x6d, 0x99, 0x90, 0xef, 0xb0, 0x4a,
 ];
 
 impl HeaderKey for Box<dyn HeaderProtectionKey> {
@@ -559,7 +566,8 @@ impl crypto::ServerConfig for QuicServerConfig {
         let (nonce, key) = match version {
             Version::V1 => (RETRY_INTEGRITY_NONCE_V1, RETRY_INTEGRITY_KEY_V1),
             Version::V1Draft => (RETRY_INTEGRITY_NONCE_DRAFT, RETRY_INTEGRITY_KEY_DRAFT),
-            _ => unreachable!(),
+            Version::V2 => (RETRY_INTEGRITY_NONCE_V2, RETRY_INTEGRITY_KEY_V2),
+            _ => unreachable!("unsupported QUIC version"),
         };
 
         let mut pseudo_packet = Vec::with_capacity(packet.len() + orig_dst_cid.len() + 1);
@@ -664,6 +672,7 @@ fn interpret_version(version: u32) -> Result<Version, UnsupportedVersion> {
     match version {
         0xff00_001d..=0xff00_0020 => Ok(Version::V1Draft),
         0x0000_0001 | 0xff00_0021..=0xff00_0022 => Ok(Version::V1),
+        QUIC_V2_VERSION => Ok(Version::V2),
         _ => Err(UnsupportedVersion),
     }
 }

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -156,9 +156,13 @@ pub mod fuzzing {
     }
 }
 
-/// The QUIC protocol version implemented.
+/// The QUIC version 2 protocol codepoint, as specified by RFC 9369.
+pub(crate) const QUIC_V2_VERSION: u32 = 0x6b33_43cf;
+
+/// The QUIC protocol versions implemented.
 pub const DEFAULT_SUPPORTED_VERSIONS: &[u32] = &[
     0x00000001,
+    QUIC_V2_VERSION,
     0xff00_001d,
     0xff00_001e,
     0xff00_001f,

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -1077,4 +1077,56 @@ mod tests {
             }
         }
     }
+
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+    #[test]
+    fn v2_server_initial_rfc_vector() {
+        use crate::Side;
+        use crate::crypto::rustls::{initial_keys, initial_suite_from_provider};
+        #[cfg(all(feature = "rustls-aws-lc-rs", not(feature = "rustls-ring")))]
+        use rustls::crypto::aws_lc_rs::default_provider;
+        #[cfg(feature = "rustls-ring")]
+        use rustls::crypto::ring::default_provider;
+        use rustls::quic::Version;
+
+        // RFC 9369, Appendix A.3
+        let dcid = ConnectionId::new(&hex!("8394c8f03e515708"));
+        let provider = default_provider();
+        let suite = initial_suite_from_provider(&std::sync::Arc::new(provider)).unwrap();
+        let server = initial_keys(Version::V2, dcid, Side::Server, &suite);
+        let mut buf = Vec::new();
+        let header = Header::Initial(InitialHeader {
+            dst_cid: ConnectionId::new(&[]),
+            src_cid: ConnectionId::new(&hex!("f067a5502a4262b5")),
+            token: Bytes::new(),
+            number: PacketNumber::U16(1),
+            version: crate::QUIC_V2_VERSION,
+        });
+        let encode = header.encode(&mut buf);
+        let header_len = buf.len();
+        buf.extend_from_slice(&hex!(
+            "02000000000600405a020000560303eefce7f7b37ba1d1632e96677825ddf739
+             88cfc79825df566dc5430b9a045a1200130100002e00330024001d00209d3c94
+             0d89690b84d08a60993c144eca684d1081287c834d5311bcf32bb9da1a002b00
+             020304"
+        ));
+        buf.resize(buf.len() + server.packet.local.tag_len(), 0);
+        encode.finish(
+            &mut buf,
+            &*server.header.local,
+            Some((1, &*server.packet.local)),
+        );
+
+        assert_eq!(header_len, 20);
+        assert_eq!(
+            buf,
+            hex!(
+                "dc6b3343cf0008f067a5502a4262b5004075d92faaf16f05d8a4398c47089698
+                 baeea26b91eb761d9b89237bbf87263017915358230035f7fd3945d88965cf17
+                 f9af6e16886c61bfc703106fbaf3cb4cfa52382dd16a393e42757507698075b2
+                 c984c707f0a0812d8cd5a6881eaf21ceda98f4bd23f6fe1a3e2c43edd9ce7ca8
+                 4bed8521e2e140"
+            )
+        );
+    }
 }

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -292,7 +292,7 @@ impl Header {
                 number,
                 version,
             }) => {
-                w.write(u8::from(LongHeaderType::Initial) | number.tag());
+                w.write(LongHeaderType::Initial.encode(version) | number.tag());
                 w.write(version);
                 dst_cid.encode_long(w);
                 src_cid.encode_long(w);
@@ -313,7 +313,7 @@ impl Header {
                 number,
                 version,
             } => {
-                w.write(u8::from(LongHeaderType::Standard(ty)) | number.tag());
+                w.write(LongHeaderType::Standard(ty).encode(version) | number.tag());
                 w.write(version);
                 dst_cid.encode_long(w);
                 src_cid.encode_long(w);
@@ -330,7 +330,7 @@ impl Header {
                 ref src_cid,
                 version,
             } => {
-                w.write(u8::from(LongHeaderType::Retry));
+                w.write(LongHeaderType::Retry.encode(version));
                 w.write(version);
                 dst_cid.encode_long(w);
                 src_cid.encode_long(w);
@@ -617,7 +617,7 @@ impl ProtectedHeader {
                 });
             }
 
-            match LongHeaderType::from_byte(first)? {
+            match LongHeaderType::from_byte(first, version)? {
                 LongHeaderType::Initial => {
                     let token_len = buf.get_var()? as usize;
                     let token_start = buf.position() as usize;
@@ -814,10 +814,15 @@ pub(crate) enum LongHeaderType {
 }
 
 impl LongHeaderType {
-    fn from_byte(b: u8) -> Result<Self, PacketDecodeError> {
+    fn from_byte(b: u8, version: u32) -> Result<Self, PacketDecodeError> {
         use {LongHeaderType::*, LongType::*};
         debug_assert!(b & LONG_HEADER_FORM != 0, "not a long packet");
+        let v2 = version == crate::QUIC_V2_VERSION;
         Ok(match (b & 0x30) >> 4 {
+            0x0 if v2 => Retry,
+            0x1 if v2 => Initial,
+            0x2 if v2 => Standard(ZeroRtt),
+            0x3 if v2 => Standard(Handshake),
             0x0 => Initial,
             0x1 => Standard(ZeroRtt),
             0x2 => Standard(Handshake),
@@ -825,17 +830,20 @@ impl LongHeaderType {
             _ => unreachable!(),
         })
     }
-}
 
-impl From<LongHeaderType> for u8 {
-    fn from(ty: LongHeaderType) -> Self {
+    fn encode(self, version: u32) -> u8 {
         use {LongHeaderType::*, LongType::*};
-        match ty {
-            Initial => LONG_HEADER_FORM | FIXED_BIT,
-            Standard(ZeroRtt) => LONG_HEADER_FORM | FIXED_BIT | (0x1 << 4),
-            Standard(Handshake) => LONG_HEADER_FORM | FIXED_BIT | (0x2 << 4),
-            Retry => LONG_HEADER_FORM | FIXED_BIT | (0x3 << 4),
-        }
+        let type_bits = match (version == crate::QUIC_V2_VERSION, self) {
+            (true, Retry) => 0x0,
+            (true, Initial) => 0x1,
+            (true, Standard(ZeroRtt)) => 0x2,
+            (true, Standard(Handshake)) => 0x3,
+            (false, Initial) => 0x0,
+            (false, Standard(ZeroRtt)) => 0x1,
+            (false, Standard(Handshake)) => 0x2,
+            (false, Retry) => 0x3,
+        };
+        LONG_HEADER_FORM | FIXED_BIT | (type_bits << 4)
     }
 }
 
@@ -931,6 +939,65 @@ mod tests {
             for actual in expected..1024 {
                 assert_eq!(actual, PacketNumber::new(actual, expected).expand(expected));
             }
+        }
+    }
+
+    #[test]
+    fn v2_long_header_type_bits() {
+        const VERSION: u32 = crate::QUIC_V2_VERSION;
+        let cases = [
+            (
+                Header::Initial(InitialHeader {
+                    dst_cid: ConnectionId::new(&[]),
+                    src_cid: ConnectionId::new(&[]),
+                    token: Bytes::new(),
+                    number: PacketNumber::U8(0),
+                    version: VERSION,
+                }),
+                0x10,
+                LongHeaderType::Initial,
+            ),
+            (
+                Header::Long {
+                    ty: LongType::ZeroRtt,
+                    dst_cid: ConnectionId::new(&[]),
+                    src_cid: ConnectionId::new(&[]),
+                    number: PacketNumber::U8(0),
+                    version: VERSION,
+                },
+                0x20,
+                LongHeaderType::Standard(LongType::ZeroRtt),
+            ),
+            (
+                Header::Long {
+                    ty: LongType::Handshake,
+                    dst_cid: ConnectionId::new(&[]),
+                    src_cid: ConnectionId::new(&[]),
+                    number: PacketNumber::U8(0),
+                    version: VERSION,
+                },
+                0x30,
+                LongHeaderType::Standard(LongType::Handshake),
+            ),
+            (
+                Header::Retry {
+                    dst_cid: ConnectionId::new(&[]),
+                    src_cid: ConnectionId::new(&[]),
+                    version: VERSION,
+                },
+                0x00,
+                LongHeaderType::Retry,
+            ),
+        ];
+
+        for (header, type_bits, expected_type) in cases {
+            let mut buf = Vec::new();
+            header.encode(&mut buf);
+            assert_eq!(buf[0] & 0x30, type_bits);
+            assert_eq!(
+                LongHeaderType::from_byte(buf[0], VERSION).unwrap(),
+                expected_type
+            );
         }
     }
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -179,6 +179,52 @@ fn draft_version_compat() {
 }
 
 #[test]
+fn v2_compat() {
+    let _guard = subscribe();
+
+    let mut client_config = client_config();
+    client_config.version(QUIC_V2_VERSION);
+
+    let mut pair = Pair::default();
+    let (client_ch, server_ch) = pair.connect_with(client_config);
+
+    assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
+    assert!(pair.client_conn_mut(client_ch).using_ecn());
+    assert!(pair.server_conn_mut(server_ch).using_ecn());
+}
+
+#[test]
+fn v2_compat_with_retry() {
+    let _guard = subscribe();
+
+    let mut pair = Pair::default();
+    pair.server.handle_incoming = Box::new(validate_incoming);
+
+    let mut client_config = client_config();
+    client_config.version(QUIC_V2_VERSION);
+    let (client_ch, server_ch) = pair.connect_with(client_config);
+
+    assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
+    assert!(pair.client_conn_mut(client_ch).using_ecn());
+    assert!(pair.server_conn_mut(server_ch).using_ecn());
+}
+
+#[test]
+fn v2_retry_integrity_vector() {
+    use crate::crypto::ServerConfig as _;
+
+    // RFC 9369, Appendix A.4
+    let crypto = server_crypto();
+    let orig_dst_cid = ConnectionId::new(&hex!("8394c8f03e515708"));
+    let packet = hex!("cf6b3343cf0008f067a5502a4262b5746f6b656ec8646ce8bfe33952d955543665dcc7b6");
+
+    assert_eq!(
+        crypto.retry_tag(QUIC_V2_VERSION, orig_dst_cid, &packet[..20]),
+        packet[20..]
+    );
+}
+
+#[test]
 fn server_stateless_reset() {
     let _guard = subscribe();
     let mut key_material = vec![0; 64];


### PR DESCRIPTION
Implements #2740. Adds RFC 9369 QUIC v2 support to quinn-proto by advertising 0x6b3343cf, selecting rustls Version::V2, using v2 packet type bits and Retry integrity keys, and exercising direct and retry handshakes. The tests include the RFC 9369 Appendix A.3 server Initial vector and Appendix A.4 Retry vector. Compatible version negotiation remains separate work tracked by #1235. Verified with cargo test --locked, the aws-lc-rs and aws-lc-rs-fips matrices, ignored stress tests, cargo clippy --locked --all-targets -- -D warnings, cargo fmt --all -- --check, cargo check --locked --lib --all-features -p quinn-udp -p quinn-proto -p quinn, and a clean fuzz crate build.