### PR TITLE
fix(quinn-udp): repair fallback backend compile errors

### DIFF
--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -1,5 +1,6 @@
 use std::{
     io::{self, IoSliceMut},
+    mem::MaybeUninit,
     sync::Mutex,
     time::Instant,
 };
@@ -61,10 +62,21 @@ impl UdpSocketState {
         if bufs.is_empty() || meta.is_empty() {
             return Ok(0);
         }
-        // socket2::recv_from requires &mut [MaybeUninit<u8>]; IoSliceMut is [u8].
+
+        // `recv_from_vectored` is not available on every target that uses this backend: socket2
+        // gates it out on redox, wasi and horizon, since they have no `recvmsg`. We only ever
+        // receive one datagram at a time here (`BATCH_SIZE` is 1), so read into the first buffer
+        // with plain `recv_from` instead, which is available everywhere.
+        //
+        // Safety: `recv_from` takes `&mut [MaybeUninit<u8>]`, and `MaybeUninit<u8>` has the same
+        // size and alignment as `u8`, so the pointer and length taken from `bufs[0]` describe a
+        // valid slice of the same region. Treating initialised memory as possibly-uninitialised is
+        // always sound, and `recv_from` promises not to write uninitialised bytes, so `bufs[0]`
+        // stays fully initialised. The mutable borrow of `bufs` lasts for the whole call, so
+        // nothing else can access the region while `buf` is alive.
         let buf = unsafe {
             std::slice::from_raw_parts_mut(
-                bufs[0].as_mut_ptr() as *mut std::mem::MaybeUninit<u8>,
+                bufs[0].as_mut_ptr().cast::<MaybeUninit<u8>>(),
                 bufs[0].len(),
             )
         };
@@ -72,9 +84,7 @@ impl UdpSocketState {
         meta[0] = RecvMeta {
             len,
             stride: len,
-            addr: addr
-                .as_socket()
-                .unwrap_or_else(|| std::net::SocketAddr::from(([0, 0, 0, 0], 0))),
+            addr: addr.as_socket().unwrap(),
             ecn: None,
             dst_ip: None,
             interface_index: None,

--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -58,21 +58,27 @@ impl UdpSocketState {
         bufs: &mut [IoSliceMut<'_>],
         meta: &mut [RecvMeta],
     ) -> io::Result<usize> {
-        // Safety: both `IoSliceMut` and `MaybeUninitSlice` promise to have the
-        // same layout, that of `iovec`/`WSABUF`. Furthermore `recv_vectored`
-        // promises to not write unitialised bytes to the `bufs` and pass it
-        // directly to the `recvmsg` system call, so this is safe.
-        let bufs = unsafe {
-            &mut *(bufs as *mut [IoSliceMut<'_>] as *mut [socket2::MaybeUninitSlice<'_>])
+        if bufs.is_empty() || meta.is_empty() {
+            return Ok(0);
+        }
+        // socket2::recv_from requires &mut [MaybeUninit<u8>]; IoSliceMut is [u8].
+        let buf = unsafe {
+            std::slice::from_raw_parts_mut(
+                bufs[0].as_mut_ptr() as *mut std::mem::MaybeUninit<u8>,
+                bufs[0].len(),
+            )
         };
-        let (len, _flags, addr) = socket.0.recv_from_vectored(bufs)?;
+        let (len, addr) = socket.0.recv_from(buf)?;
         meta[0] = RecvMeta {
             len,
             stride: len,
-            addr: addr.as_socket().unwrap(),
+            addr: addr
+                .as_socket()
+                .unwrap_or_else(|| std::net::SocketAddr::from(([0, 0, 0, 0], 0))),
             ecn: None,
             dst_ip: None,
             interface_index: None,
+            timestamp: None,
         };
         Ok(1)
     }
@@ -121,7 +127,8 @@ fn send(socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
     socket.0.send_to(
         transmit.contents,
         &socket2::SockAddr::from(transmit.destination),
-    )
+    )?;
+    Ok(())
 }
 
 pub(crate) const BATCH_SIZE: usize = 1;


### PR DESCRIPTION
## Summary

The `fallback` UDP backend (`cfg(not(any(wasm_browser, unix, windows)))`) no longer
compiled: `send_to` returns `usize`, `RecvMeta` gained a `timestamp` field, and
`recv_from_vectored` is gone from `socket2::Socket`.

- Map `send_to` into `io::Result<()>`
- Fill `timestamp: None` on `RecvMeta`
- Receive with `recv_from` over a `MaybeUninit<u8>` view of the first buffer

Verified by temporarily selecting the fallback module on this host and
`cargo check -p quinn-udp`.

Related to #2754 (orthogonal to #2755, which removes the backend for wasi).
