### PR TITLE
Raise error for out-of-bounds STOP_SENDING and MAX_STREAM_DATA

### DIFF
--- a/fuzz/fuzz_targets/streams.rs
+++ b/fuzz/fuzz_targets/streams.rs
@@ -53,7 +53,7 @@ fuzz_target!(|input: (StreamParams, Vec<Operation>)| {
                 let _ = SendStream::new(id, &mut state, &mut pending, &conn_state).finish();
             }
             Operation::ReceivedStopSending(sid, err_code) => {
-                Streams::new(&mut state, &conn_state)
+                let _ = Streams::new(&mut state, &conn_state)
                     .state()
                     .received_stop_sending(sid, err_code);
             }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2922,7 +2922,7 @@ impl Connection {
                             "STOP_SENDING on unopened stream",
                         ));
                     }
-                    self.streams.received_stop_sending(id, error_code);
+                    self.streams.received_stop_sending(id, error_code)?;
                 }
                 Frame::RetireConnectionId { sequence } => {
                     let allow_more_cids = self

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -356,21 +356,37 @@ impl StreamsState {
 
     /// Process incoming `STOP_SENDING` frame
     #[allow(unreachable_pub)] // fuzzing only
-    pub fn received_stop_sending(&mut self, id: StreamId, error_code: VarInt) {
+    pub fn received_stop_sending(
+        &mut self,
+        id: StreamId,
+        error_code: VarInt,
+    ) -> Result<(), TransportError> {
+        if id.initiator() != self.side
+            && id.dir() == Dir::Bi
+            && id.index() >= self.max_remote[id.dir() as usize]
+        {
+            debug!("got STOP_SENDING exceeds stream limit {}", id);
+            return Err(TransportError::STREAM_LIMIT_ERROR(
+                "STOP_SENDING exceeds stream limit",
+            ));
+        }
+
         let max_send_data = self.max_send_data(id);
         let Some(stream) = self
             .send
             .get_mut(&id)
             .map(get_or_insert_send(max_send_data))
         else {
-            return;
+            return Ok(());
         };
 
         if stream.try_stop(error_code) {
             self.events
                 .push_back(StreamEvent::Stopped { id, error_code });
             self.on_stream_frame(false, id);
-        }
+        };
+
+        Ok(())
     }
 
     pub(crate) fn reset_acked(&mut self, id: StreamId) {
@@ -747,6 +763,14 @@ impl StreamsState {
             debug!("got MAX_STREAM_DATA on recv-only {}", id);
             return Err(TransportError::STREAM_STATE_ERROR(
                 "MAX_STREAM_DATA on recv-only stream",
+            ));
+        } else if id.initiator() != self.side
+            && id.dir() == Dir::Bi
+            && id.index() >= self.max_remote[id.dir() as usize]
+        {
+            debug!("got MAX_STREAM_DATA exceeds stream limit {}", id);
+            return Err(TransportError::STREAM_LIMIT_ERROR(
+                "MAX_STREAM_DATA exceeds stream limit",
             ));
         }
 
@@ -1315,7 +1339,7 @@ mod tests {
         };
 
         let error_code = 0u32.into();
-        stream.state.received_stop_sending(id, error_code);
+        assert_eq!(stream.state.received_stop_sending(id, error_code), Ok(()));
         assert!(
             stream
                 .state
@@ -1330,7 +1354,7 @@ mod tests {
         assert_eq!(stream.write(&[]), Err(WriteError::ClosedStream));
 
         // A duplicate frame is a no-op
-        stream.state.received_stop_sending(id, error_code);
+        assert_eq!(stream.state.received_stop_sending(id, error_code), Ok(()));
         assert!(stream.state.events.is_empty());
     }
 
@@ -1742,6 +1766,32 @@ mod tests {
                 0
             ),
             Ok(ShouldTransmit(false))
+        );
+    }
+
+    #[test]
+    fn stream_sending_limit() {
+        let mut client = make(Side::Client);
+        // Try to open stream with index u64::MAX, far exceeding limit
+        assert_eq!(
+            client
+                .received_stop_sending(StreamId::new(Side::Server, Dir::Bi, u64::MAX), 0u32.into())
+                .unwrap_err()
+                .code,
+            TransportErrorCode::STREAM_LIMIT_ERROR
+        );
+    }
+
+    #[test]
+    fn max_stream_data_limit() {
+        let mut client = make(Side::Client);
+        // Try to open stream with index u64::MAX, far exceeding limit
+        assert_eq!(
+            client
+                .received_max_stream_data(StreamId::new(Side::Server, Dir::Bi, u64::MAX), 0)
+                .unwrap_err()
+                .code,
+            TransportErrorCode::STREAM_LIMIT_ERROR
         );
     }
 


### PR DESCRIPTION
Fixes #2650.

Fixes the STOP_SENDING/MAX_STREAM_DATA silent ignore by adding index >= max_remote
checks in both received_stop_sending and received_max_stream_data
(received_stop_sending's signature changed to Result for raising the error).
Added regression tests for both cases.

New to open source contributing, happy to revise based on feedback.