### PR TITLE
chore(udp): deprecate `UdpSocketState::send`

### DIFF
--- a/quinn-udp/benches/throughput.rs
+++ b/quinn-udp/benches/throughput.rs
@@ -86,7 +86,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     send_socket.writable().await.unwrap();
                     send_socket
                         .try_io(Interest::WRITABLE, || {
-                            send_state.send((&send_socket).into(), &transmit)
+                            send_state.try_send((&send_socket).into(), &transmit)
                         })
                         .unwrap();
                     sent += transmit.contents.len();

--- a/quinn-udp/src/fallback.rs
+++ b/quinn-udp/src/fallback.rs
@@ -35,6 +35,7 @@ impl UdpSocketState {
     ///
     /// If you would like to handle these errors yourself, use [`UdpSocketState::try_send`]
     /// instead.
+    #[deprecated(note = "silences I/O errors; use `UdpSocketState::try_send() instead")]
     pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
         match send(socket, transmit) {
             Ok(()) => Ok(()),

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -235,6 +235,7 @@ impl UdpSocketState {
     ///
     /// If you would like to handle these errors yourself, use [`UdpSocketState::try_send`]
     /// instead.
+    #[deprecated(note = "silences I/O errors; use `UdpSocketState::try_send() instead")]
     pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
         match send(self, socket.0, transmit) {
             Ok(()) => Ok(()),

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -196,6 +196,7 @@ impl UdpSocketState {
     ///
     /// If you would like to handle these errors yourself, use [`UdpSocketState::try_send`]
     /// instead.
+    #[deprecated(note = "silences I/O errors; use `UdpSocketState::try_send() instead")]
     pub fn send(&self, socket: UdpSockRef<'_>, transmit: &Transmit<'_>) -> io::Result<()> {
         match send(
             socket,

--- a/quinn/src/runtime/mod.rs
+++ b/quinn/src/runtime/mod.rs
@@ -7,6 +7,7 @@ use std::{
     net::SocketAddr,
     pin::Pin,
     task::{self, Context, Poll},
+    time::Duration,
 };
 
 use udp::{RecvMeta, Transmit};
@@ -118,6 +119,7 @@ pin_project_lite::pin_project! {
     /// used in its dyn-compatible form as a `Pin<Box<dyn UdpSender>>`.
     struct UdpSenderHelper<Socket, MakeWritableFutFn, WritableFut> {
         socket: Socket,
+        last_send_error: Option<Instant>,
         make_writable_fut_fn: MakeWritableFutFn,
         #[pin]
         writable_fut: Option<WritableFut>,
@@ -145,6 +147,7 @@ impl<Socket, MakeWritableFutFn, WriteableFut>
     fn new(inner: Socket, make_fut: MakeWritableFutFn) -> Self {
         Self {
             socket: inner,
+            last_send_error: None,
             make_writable_fut_fn: make_fut,
             writable_fut: None,
         }
@@ -188,8 +191,11 @@ where
                 // registers us for a wakeup, or the send succeeds if this really was just a
                 // transient failure.
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                // In all other cases, either propagate the error or we're Ok
-                result => return Poll::Ready(result),
+                Err(e) => {
+                    log_sendmsg_error(this.last_send_error, &e, transmit);
+                    return Poll::Ready(Ok(()));
+                }
+                Ok(()) => return Poll::Ready(Ok(())),
             }
         }
     }
@@ -197,6 +203,39 @@ where
     fn max_transmit_segments(&self) -> usize {
         self.socket.max_transmit_segments()
     }
+}
+
+/// Limits I/O error logging to one message per minute.
+const IO_ERROR_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
+fn log_sendmsg_error(
+    last_send_error: &mut Option<Instant>,
+    error: &io::Error,
+    transmit: &Transmit<'_>,
+) {
+    #[cfg(unix)]
+    // Unix `EMSGSIZE` is expected for MTU probes.
+    if udp::is_msg_size_err(error) {
+        return;
+    }
+
+    let now = Instant::now();
+    if last_send_error
+        .is_some_and(|last| now.saturating_duration_since(last) <= IO_ERROR_LOG_INTERVAL)
+    {
+        return;
+    }
+    *last_send_error = Some(now);
+
+    tracing::warn!(
+        "sendmsg error: {:?}, Transmit: {{ destination: {:?}, src_ip: {:?}, ecn: {:?}, len: {:?}, segment_size: {:?} }}",
+        error,
+        transmit.destination,
+        transmit.src_ip,
+        transmit.ecn,
+        transmit.contents.len(),
+        transmit.segment_size
+    );
 }
 
 /// Parts of the [`UdpSender`] trait that aren't asynchronous or require storing wakers.
@@ -247,3 +286,45 @@ pub use tokio::TokioRuntime;
 mod smol;
 #[cfg(feature = "runtime-smol")]
 pub use smol::*;
+
+#[cfg(all(test, any(feature = "runtime-tokio", feature = "runtime-smol")))]
+mod tests {
+    use std::{future, task::Waker};
+
+    use super::*;
+
+    #[test]
+    fn non_would_block_send_errors_are_logged_and_ignored() {
+        let mut sender = Box::pin(UdpSenderHelper::new(TestSocket, writable));
+        let transmit = Transmit {
+            destination: SocketAddr::from(([127, 0, 0, 1], 4433)),
+            ecn: None,
+            contents: &[],
+            segment_size: None,
+            src_ip: None,
+        };
+        let mut cx = Context::from_waker(Waker::noop());
+
+        let result = sender.as_mut().poll_send(&transmit, &mut cx);
+
+        assert!(matches!(result, Poll::Ready(Ok(()))));
+        assert!(sender.last_send_error.is_some());
+    }
+
+    #[derive(Debug)]
+    struct TestSocket;
+
+    impl UdpSenderHelperSocket for TestSocket {
+        fn try_send(&self, _transmit: &Transmit<'_>) -> io::Result<()> {
+            Err(io::ErrorKind::PermissionDenied.into())
+        }
+
+        fn max_transmit_segments(&self) -> usize {
+            1
+        }
+    }
+
+    fn writable(_: &TestSocket) -> future::Ready<io::Result<()>> {
+        future::ready(Ok(()))
+    }
+}

--- a/quinn/src/runtime/smol.rs
+++ b/quinn/src/runtime/smol.rs
@@ -61,7 +61,9 @@ impl UdpSenderHelperSocket for UdpSocket {
     }
 
     fn try_send(&self, transmit: &udp::Transmit<'_>) -> io::Result<()> {
-        self.inner.send((&self.io).into(), transmit)
+        self.inner.try_send((&self.io).into(), transmit)?;
+
+        Ok(())
     }
 }
 

--- a/quinn/src/runtime/tokio.rs
+++ b/quinn/src/runtime/tokio.rs
@@ -61,8 +61,10 @@ impl UdpSenderHelperSocket for UdpSocket {
 
     fn try_send(&self, transmit: &udp::Transmit<'_>) -> io::Result<()> {
         self.io.try_io(Interest::WRITABLE, || {
-            self.inner.send((&self.io).into(), transmit)
-        })
+            self.inner.try_send((&self.io).into(), transmit)
+        })?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
In preparation for https://github.com/quinn-rs/quinn/pull/2748, this PR deprecates the `send` API and encourages users to use `try_send` instead.

https://github.com/quinn-rs/quinn/pull/2748 is a breaking change by itself. I'd therefore suggest we make a patch-release that deprecates `send` and then remove it as part of https://github.com/quinn-rs/quinn/pull/2748.