### PR TITLE
Expose max locally-initiated concurrent_streams

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1419,6 +1419,11 @@ impl Connection {
         self.streams.max_concurrent(dir)
     }
 
+    /// Current number of locally initiated streams that may be concurrently open
+    pub fn max_locally_initiated_concurrent_streams(&self, dir: Dir) -> u64 {
+        self.streams.max_locally_initiated_concurrent(dir)
+    }
+
     /// See [`TransportConfig::send_window()`]
     pub fn set_send_window(&mut self, send_window: u64) {
         self.streams.set_send_window(send_window);

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -870,6 +870,10 @@ impl StreamsState {
         self.allocated_remote_count[dir as usize]
     }
 
+    pub(crate) fn max_locally_initiated_concurrent(&self, dir: Dir) -> u64 {
+        self.max[dir as usize]
+    }
+
     pub(crate) fn set_send_window(&mut self, send_window: u64) {
         self.send_window = send_window;
     }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -609,13 +609,20 @@ impl Connection {
 
     /// Current number of locally initiated unidirectional streams that may be concurrently open
     pub fn max_locally_initiated_concurrent_uni_streams(&self) -> u64 {
-        let conn = self.0.state.lock("max_locally_initiated_concurrent_streams");
-        conn.inner.max_locally_initiated_concurrent_streams(Dir::Uni)
+        let conn = self
+            .0
+            .state
+            .lock("max_locally_initiated_concurrent_streams");
+        conn.inner
+            .max_locally_initiated_concurrent_streams(Dir::Uni)
     }
 
     /// Current number of locally initiated bidirectional streams that may be concurrently open
     pub fn max_locally_initiated_concurrent_bi_streams(&self) -> u64 {
-        let conn = self.0.state.lock("max_locally_initiated_concurrent_streams");
+        let conn = self
+            .0
+            .state
+            .lock("max_locally_initiated_concurrent_streams");
         conn.inner.max_locally_initiated_concurrent_streams(Dir::Bi)
     }
 

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -607,6 +607,18 @@ impl Connection {
             .clone_box()
     }
 
+    /// Current number of locally initiated unidirectional streams that may be concurrently open
+    pub fn max_locally_initiated_concurrent_uni_streams(&self) -> u64 {
+        let conn = self.0.state.lock("max_locally_initiated_concurrent_streams");
+        conn.inner.max_locally_initiated_concurrent_streams(Dir::Uni)
+    }
+
+    /// Current number of locally initiated bidirectional streams that may be concurrently open
+    pub fn max_locally_initiated_concurrent_bi_streams(&self) -> u64 {
+        let conn = self.0.state.lock("max_locally_initiated_concurrent_streams");
+        conn.inner.max_locally_initiated_concurrent_streams(Dir::Bi)
+    }
+
     /// Succeeds when an incoming connection is proven not to be a replay attack.
     ///
     /// Only interesting for `Connection`s obtained from [`Connecting::into_0rtt`]. On 1-RTT


### PR DESCRIPTION
This PR adds 2 function to `quinn::Connection` that expose the maximum number of locally-initiated concurrent streams.

Right now, when this limit is reached Quinn automatically stalls requests to open new streams. In a high-concurrency environment, this can affect performance. By exposing this limit, clients can track their stream count and have the option of starting a new Quinn connection when they reach the limit.