### PR TITLE
proto: treat an equal-size delivery as evidence against a preceding loss burst

### DIFF
--- a/quinn-proto/src/connection/mtud.rs
+++ b/quinn-proto/src/connection/mtud.rs
@@ -403,9 +403,16 @@ impl BlackHoleDetector {
     }
 
     fn on_non_probe_acked(&mut self, pn: u64, len: u16) {
-        if len <= self.acked_mtu {
+        if len < self.acked_mtu {
             // We've already seen a larger packet since the most recent suspicious loss burst;
             // nothing to do.
+            return;
+        }
+        if len == self.acked_mtu {
+            // Another delivery of the largest size seen since the most recent suspicious loss
+            // burst. It doesn't raise `acked_mtu`, but loss bursts that precede it cannot be
+            // explained by an MTU reduction either, so remember it as the newest such delivery.
+            self.largest_post_loss_packet = self.largest_post_loss_packet.max(pn);
             return;
         }
         self.acked_mtu = len;
@@ -961,6 +968,36 @@ mod tests {
         assert!(
             bhd.black_hole_detected(),
             "1300 byte losses following a 1400 byte delivery are suspicious"
+        );
+    }
+
+    // Loss bursts that precede the delivery of another packet of the largest size seen so far
+    // are not suspicious: that delivery proves the path still carries packets of that size, even
+    // though it does not raise `acked_mtu`. This is the steady state of a bulk transfer, where
+    // every packet is full-size and one ACK typically both confirms new packets and reveals
+    // older losses.
+    #[test]
+    fn equal_size_delivery_clears_preceding_bursts() {
+        let mut bhd = BlackHoleDetector::new(1200);
+        // A full-size packet was delivered long ago...
+        bhd.on_non_probe_acked(0, 1400);
+        // ...and a newer full-size packet is delivered now, before loss detection runs
+        bhd.on_non_probe_acked((BLACK_HOLE_THRESHOLD + 1) as u64 * 2, 1400);
+        // Loss detection then reveals bursts that were transmitted before that delivery
+        for i in 0..(BLACK_HOLE_THRESHOLD + 1) {
+            bhd.on_non_probe_lost(i as u64 * 2 + 1, 1400);
+        }
+        assert!(
+            !bhd.black_hole_detected(),
+            "full-size losses preceding a full-size delivery are not suspicious"
+        );
+        // Full-size losses transmitted after the last delivery are still suspicious
+        for i in 0..(BLACK_HOLE_THRESHOLD + 1) {
+            bhd.on_non_probe_lost((BLACK_HOLE_THRESHOLD as u64 + 1 + i as u64) * 2 + 1, 1400);
+        }
+        assert!(
+            bhd.black_hole_detected(),
+            "full-size losses following the last full-size delivery are suspicious"
         );
     }
 


### PR DESCRIPTION
Fixes #2791.

`BlackHoleDetector::on_non_probe_acked` returned early for any packet no larger than `acked_mtu`, so once a full-size packet had been acknowledged, `largest_post_loss_packet` never advanced again as long as every packet was full-size — the steady state of a bulk transfer. Because `on_ack_received` registers acknowledgments before running loss detection, one ACK that confirms newer full-size packets and reveals ≥ `BLACK_HOLE_THRESHOLD + 1` older non-adjacent holes then judged all of those holes suspicious, even though the same ACK had just shown that full-size packets still get through. On a lossy path this turns ordinary congestion loss during a download into a black hole verdict and a drop to `min_mtu` (details and production numbers in #2791).

The change: when `len == acked_mtu`, keep `acked_mtu` but advance `largest_post_loss_packet` to the newer packet number, so loss bursts that precede that delivery are non-suspicious under the existing rule while losses transmitted after the last delivery remain suspicious. This matches the design in #1855 ("larger than any more recently acknowledged packet").

The new unit test fails on `main` before the change and passes after; the existing black hole tests, including `blackhole_after_mtu_change_repairs_itself`, still pass.

On 0.11.x this fix alone is not sufficient because `finish_loss_burst` there still uses strict `<` (fixed on `main` by #2400 but not backported); I have a branch with #2400's two commits cherry-picked plus this one, all tests green (https://github.com/vcarus/quinn/tree/bhd-0.11.x), if you'd like a backport PR.
