### PR TITLE
Add option to configure ACK frequency. Fixes 2783

### DIFF
--- a/quinn-proto/src/config/transport.rs
+++ b/quinn-proto/src/config/transport.rs
@@ -233,8 +233,9 @@ impl TransportConfig {
 
     /// Specifies the ACK frequency config (see [`AckFrequencyConfig`] for details)
     ///
-    /// The provided configuration will be ignored if the peer does not support the acknowledgement
-    /// frequency QUIC extension.
+    /// The configuration is also used as the local endpoint's initial acknowledgement policy for
+    /// application-data packets. A valid `ACK_FREQUENCY` frame received from the peer may
+    /// subsequently replace it.
     ///
     /// Defaults to `None`, which disables controlling the peer's acknowledgement frequency. Even
     /// if set to `None`, the local side still supports the acknowledgement frequency QUIC

--- a/quinn-proto/src/connection/ack_frequency.rs
+++ b/quinn-proto/src/connection/ack_frequency.rs
@@ -32,6 +32,10 @@ impl AckFrequencyState {
         }
     }
 
+    pub(super) fn set_max_ack_delay(&mut self, max_ack_delay: Duration) {
+        self.max_ack_delay = max_ack_delay;
+    }
+
     /// Returns the `max_ack_delay` that should be requested of the peer when sending an
     /// ACK_FREQUENCY frame
     pub(super) fn candidate_max_ack_delay(

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -267,6 +267,17 @@ impl Connection {
             crypto: Some(crypto.initial_keys(init_cid, side)),
             ..PacketSpace::new(now)
         };
+        let mut data_space = PacketSpace::new(now);
+        let mut ack_frequency =
+            AckFrequencyState::new(get_max_ack_delay(&TransportParameters::default()));
+        if let Some(ack_frequency_config) = &config.ack_frequency_config {
+            data_space
+                .pending_acks
+                .set_ack_frequency_config(ack_frequency_config);
+            if let Some(max_ack_delay) = ack_frequency_config.max_ack_delay {
+                ack_frequency.set_max_ack_delay(max_ack_delay);
+            }
+        }
         let state = State::Handshake(state::Handshake {
             rem_cid_set: side.is_server(),
             expected_token: Bytes::new(),
@@ -309,7 +320,7 @@ impl Connection {
             endpoint_events: VecDeque::new(),
             spin_enabled: config.allow_spin && rng.random_ratio(7, 8),
             spin: false,
-            spaces: [initial_space, PacketSpace::new(now), PacketSpace::new(now)],
+            spaces: [initial_space, PacketSpace::new(now), data_space],
             highest_space: SpaceId::Initial,
             prev_crypto: None,
             next_crypto: None,
@@ -333,9 +344,7 @@ impl Connection {
             path_responses: PathResponses::default(),
             close: false,
 
-            ack_frequency: AckFrequencyState::new(get_max_ack_delay(
-                &TransportParameters::default(),
-            )),
+            ack_frequency,
 
             pto_count: 0,
 

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -12,9 +12,9 @@ use tracing::trace;
 use super::assembler::Assembler;
 use super::sent_packets::SentPackets;
 use crate::{
-    Dir, Duration, Instant, SocketAddr, StreamId, TransportError, VarInt, cid_queue::CidQueue,
-    connection::StreamsState, crypto::Keys, frame, packet::SpaceId, range_set::ArrayRangeSet,
-    shared::IssuedCid,
+    AckFrequencyConfig, Dir, Duration, Instant, SocketAddr, StreamId, TransportError, VarInt,
+    cid_queue::CidQueue, connection::StreamsState, crypto::Keys, frame, packet::SpaceId,
+    range_set::ArrayRangeSet, shared::IssuedCid,
 };
 
 pub(super) struct PacketSpace {
@@ -660,6 +660,11 @@ impl PendingAcks {
         }
     }
 
+    pub(super) fn set_ack_frequency_config(&mut self, config: &AckFrequencyConfig) {
+        self.ack_eliciting_threshold = config.ack_eliciting_threshold.into_inner();
+        self.reordering_threshold = config.reordering_threshold.into_inner();
+    }
+
     pub(super) fn set_ack_frequency_params(&mut self, frame: &frame::AckFrequency) {
         self.ack_eliciting_threshold = frame.ack_eliciting_threshold.into_inner();
         self.reordering_threshold = frame.reordering_threshold.into_inner();
@@ -1053,6 +1058,39 @@ mod test {
         dedup.insert(0);
         acks.packet_received(Instant::now(), 0, true, &dedup);
         assert!(!acks.immediate_ack_required);
+    }
+
+    #[test]
+    fn pending_acks_respects_initial_ack_frequency() {
+        let now = Instant::now();
+        let mut dedup = Dedup::new();
+
+        let mut every_packet = PendingAcks::new();
+        every_packet.set_ack_frequency_config(
+            AckFrequencyConfig::default()
+                .ack_eliciting_threshold(VarInt::from_u32(0))
+                .reordering_threshold(VarInt::from_u32(0)),
+        );
+        assert_eq!(every_packet.reordering_threshold, 0);
+        dedup.insert(0);
+        every_packet.packet_received(now, 0, true, &dedup);
+        assert!(every_packet.immediate_ack_required);
+
+        let mut every_fourth_packet = PendingAcks::new();
+        every_fourth_packet.set_ack_frequency_config(
+            AckFrequencyConfig::default()
+                .ack_eliciting_threshold(VarInt::from_u32(3))
+                .reordering_threshold(VarInt::from_u32(4)),
+        );
+        assert_eq!(every_fourth_packet.reordering_threshold, 4);
+        for packet_number in 0..3 {
+            dedup.insert(packet_number);
+            every_fourth_packet.packet_received(now, packet_number, true, &dedup);
+            assert!(!every_fourth_packet.immediate_ack_required);
+        }
+        dedup.insert(3);
+        every_fourth_packet.packet_received(now, 3, true, &dedup);
+        assert!(every_fourth_packet.immediate_ack_required);
     }
 
     #[test]


### PR DESCRIPTION
Proposed fix for #2783.

The idea is to reuse the existing `quinn::TransportConfig`.