### PR TITLE
quinn-proto: avoid unnecessary PING when a DATAGRAM fits into a tail-loss probe

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -475,9 +475,25 @@ impl Connection {
 
         // If we need to send a probe, make sure we have something to send.
         for space in SpaceId::iter() {
-            let request_immediate_ack =
-                space == SpaceId::Data && self.peer_supports_ack_frequency();
-            self.spaces[space].maybe_queue_probe(request_immediate_ack, &self.streams);
+            if space != SpaceId::Data {
+                self.spaces[space].maybe_queue_probe(false, false, &self.streams);
+                continue;
+            }
+
+            let has_ack_eliciting_data = self.can_send_1rtt(
+                Ord::min(segment_size, usize::from(INITIAL_MTU)).saturating_sub(
+                    self.predict_1rtt_overhead(Some(
+                        self.packet_number_filter.peek(&self.spaces[SpaceId::Data]),
+                    )),
+                ),
+            );
+            let request_immediate_ack = self.peer_supports_ack_frequency();
+
+            self.spaces[space].maybe_queue_probe(
+                request_immediate_ack,
+                has_ack_eliciting_data,
+                &self.streams,
+            );
         }
 
         // Check whether we need to send a close message
@@ -3590,6 +3606,11 @@ impl Connection {
 
     fn peer_supports_ack_frequency(&self) -> bool {
         self.peer_params.min_ack_delay.is_some()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn disable_peer_ack_frequency(&mut self) {
+        self.peer_params.min_ack_delay = None;
     }
 
     /// Send an IMMEDIATE_ACK frame to the remote endpoint

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -119,6 +119,7 @@ impl PacketSpace {
     pub(super) fn maybe_queue_probe(
         &mut self,
         request_immediate_ack: bool,
+        has_ack_eliciting_data: bool,
         streams: &StreamsState,
     ) {
         if self.loss_probes == 0 {
@@ -133,6 +134,12 @@ impl PacketSpace {
 
         if !self.pending.is_empty(streams) {
             // There's real data to send here, no need to make something up
+            return;
+        }
+
+        if has_ack_eliciting_data {
+            // A fitting DATAGRAM is held outside `pending` until packet assembly, but it
+            // still makes the probe ack-eliciting without a fallback frame.
             return;
         }
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1917,6 +1917,9 @@ fn tail_loss_small_segment_size() {
     let _guard = subscribe();
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
+    // Keep IMMEDIATE_ACK out of the probe so the test isolates whether the available
+    // DATAGRAM suppresses the fallback PING.
+    pair.client_conn_mut(client_ch).disable_peer_ack_frequency();
 
     // No datagrams frames received in the handshake.
     let server_stats = pair.server_conn_mut(server_ch).stats();
@@ -1936,6 +1939,7 @@ fn tail_loss_small_segment_size() {
     // Doing one step makes the client advance time to the PTO fire time.
     info!("stepping forward to PTO");
     pair.step();
+    let ping_count = pair.client_conn_mut(client_ch).stats().frame_tx.ping;
 
     // Still no datagrams frames received by the server.
     let server_stats = pair.server_conn_mut(server_ch).stats();
@@ -1958,6 +1962,59 @@ fn tail_loss_small_segment_size() {
     // Finally the server should have received some datagrams.
     let server_stats = pair.server_conn_mut(server_ch).stats();
     assert_eq!(server_stats.frame_rx.datagram, DGRAM_NUM);
+
+    // DATAGRAM frames are ack-eliciting, so the loss probe does not need an additional PING.
+    let client_stats = pair.client_conn_mut(client_ch).stats();
+    assert_eq!(client_stats.frame_tx.ping, ping_count);
+}
+
+#[test]
+fn tail_loss_probe_keeps_ping_when_datagram_does_not_fit() {
+    let _guard = subscribe();
+
+    const PATH_MTU: u16 = 1452;
+
+    let client_config = {
+        let mut config = client_config();
+        Arc::get_mut(&mut config.transport)
+            .unwrap()
+            .initial_mtu(PATH_MTU)
+            .mtu_discovery_config(None);
+        config
+    };
+
+    let mut pair = Pair::default();
+    pair.mtu = PATH_MTU as usize;
+    let (client_ch, server_ch) = pair.connect_with(client_config);
+
+    pair.client_conn_mut(client_ch).disable_peer_ack_frequency();
+    assert_eq!(pair.client_conn_mut(client_ch).path_mtu(), PATH_MTU);
+
+    // Establish an outstanding ack-eliciting packet and discard it.
+    pair.client_conn_mut(client_ch).ping();
+    pair.drive_client();
+    assert!(!pair.server.inbound.is_empty());
+    pair.server.inbound.clear();
+
+    // Advance to the PTO without transmitting the queued loss probe yet.
+    pair.step();
+    let ping_count = pair.client_conn_mut(client_ch).stats().frame_tx.ping;
+
+    // This fits the normal path MTU, but not a loss probe capped to INITIAL_MTU.
+    let datagram_len = pair.client_datagrams(client_ch).max_size().unwrap();
+    assert!(datagram_len > INITIAL_MTU as usize);
+    pair.client_datagrams(client_ch)
+        .send(vec![0; datagram_len].into(), false)
+        .unwrap();
+
+    pair.drive();
+
+    // The probe must retain its PING when the queued DATAGRAM cannot fit in that packet.
+    let client_stats = pair.client_conn_mut(client_ch).stats();
+    assert_eq!(client_stats.frame_tx.ping, ping_count + 2);
+
+    let server_stats = pair.server_conn_mut(server_ch).stats();
+    assert_eq!(server_stats.frame_rx.datagram, 1);
 }
 
 // Respect max_datagrams when TLP happens


### PR DESCRIPTION
When the peer does not support ACK Frequency, the loss-probe logic falls back to a PING frame to make the probe ack-eliciting. If a DATAGRAM is already queued and actually fits into that probe, the extra PING is redundant – DATAGRAM frames are ack-eliciting on their own.

The catch is that loss probes are always capped at INITIAL_MTU (1200 bytes), which can be smaller than the current path MTU. A DATAGRAM that comfortably fits a normal-sized packet might not fit into the smaller probe packet. So we cannot just check whether a DATAGRAM is pending; we have to check whether it physically fits into that constrained probe space.

The change does exactly that: for the 1-RTT space it computes the available frame space inside an INITIAL_MTU-sized probe and only avoids queueing the fallback PING if can_send_1rtt() confirms that the pending ACK-eliciting 1-RTT data can actually be placed there.

The new regression test (tail_loss_probe_keeps_ping_when_datagram_does_not_fit) sets the path MTU to 1452, queues a DATAGRAM that fits 1452 but not 1200, and verifies that the fallback PING is queued. The existing tail_loss_small_segment_size test was adjusted to confirm that the fallback PING is not queued when the DATAGRAM does fit. All local checks – formatting, clippy, and the full quinn-proto test suite with default and all features enabled – are green.

Closes #2173

Related context: #2169 and #2172
