### PR TITLE
Release endpoint lock during incoming TLS setup

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -343,7 +343,8 @@ impl Endpoint {
         trace!(initial_dcid = %remote_id);
 
         let ch = ConnectionHandle(self.connections.vacant_key());
-        let loc_cid = self.new_cid(RouteDatagramTo::Connection(ch));
+        let route = RouteDatagramTo::Connection(ch);
+        let loc_cid = self.new_cid(route);
         let params = TransportParameters::new(
             &config.transport,
             &self.config,
@@ -373,6 +374,7 @@ impl Endpoint {
                 token_store: config.token_store,
                 server_name: server_name.into(),
             },
+            route,
         );
         Ok((ch, conn))
     }
@@ -399,8 +401,8 @@ impl Endpoint {
         ConnectionEvent(ConnectionEventInner::NewIdentifiers(ids, now))
     }
 
-    /// Generate and reserve a local connection ID
-    fn new_cid(&mut self, route_to: RouteDatagramTo) -> ConnectionId {
+    /// Generate a connection ID and reserve it for `route`
+    fn new_cid(&mut self, route: RouteDatagramTo) -> ConnectionId {
         loop {
             let cid = self.local_cid_generator.generate_cid();
             if cid.is_empty() {
@@ -409,7 +411,7 @@ impl Endpoint {
                 return cid;
             }
             if let hash_map::Entry::Vacant(e) = self.index.connection_ids.entry(cid) {
-                e.insert(route_to);
+                e.insert(route);
                 break cid;
             }
         }
@@ -530,15 +532,34 @@ impl Endpoint {
     // box err to avoid clippy::result_large_err
     pub fn accept(
         &mut self,
-        mut incoming: Incoming,
+        incoming: Incoming,
         now: Instant,
         buf: &mut Vec<u8>,
         server_config: Option<Arc<ServerConfig>>,
     ) -> Result<(ConnectionHandle, Connection), Box<AcceptError>> {
+        let mut prepared = self.prepare_accept(incoming, now, buf, server_config)?;
+        prepared.process_first_packet();
+        self.finish_accept(prepared, buf)
+    }
+
+    /// Prepare an incoming connection without processing its TLS ClientHello.
+    ///
+    /// The returned value keeps all packets for this connection routed to the bounded incoming
+    /// buffer. Call [`PreparedAccept::process_first_packet`] without holding an endpoint-wide lock,
+    /// then pass it to [`Endpoint::finish_accept`] while holding that lock again.
+    ///
+    /// This is an implementation detail used by `quinn` to keep synchronous TLS certificate
+    /// resolution from blocking unrelated endpoint I/O.
+    #[doc(hidden)]
+    pub fn prepare_accept(
+        &mut self,
+        mut incoming: Incoming,
+        now: Instant,
+        buf: &mut Vec<u8>,
+        server_config: Option<Arc<ServerConfig>>,
+    ) -> Result<PreparedAccept, Box<AcceptError>> {
         let remote_address_validated = incoming.remote_address_validated();
         incoming.improper_drop_warner.dismiss();
-        let incoming_buffer = self.incoming_buffers.remove(incoming.incoming_idx);
-        self.all_incoming_buffers_total_bytes -= incoming_buffer.total_bytes;
 
         let packet_number = incoming.packet.header.number.expand(0);
         let InitialHeader {
@@ -558,7 +579,7 @@ impl Endpoint {
             })
         {
             debug!("abandoning accept of stale initial");
-            self.index.remove_initial(dst_cid);
+            self.clean_up_incoming_parts(dst_cid, incoming.incoming_idx);
             return Err(Box::new(AcceptError {
                 cause: ConnectionError::TimedOut,
                 response: None,
@@ -567,7 +588,7 @@ impl Endpoint {
 
         if self.cids_exhausted() {
             debug!("refusing connection");
-            self.index.remove_initial(dst_cid);
+            self.clean_up_incoming_parts(dst_cid, incoming.incoming_idx);
             return Err(Box::new(AcceptError {
                 cause: ConnectionError::CidsExhausted,
                 response: Some(self.initial_close(
@@ -593,7 +614,7 @@ impl Endpoint {
             .is_err()
         {
             debug!(packet_number, "failed to authenticate initial packet");
-            self.index.remove_initial(dst_cid);
+            self.clean_up_incoming_parts(dst_cid, incoming.incoming_idx);
             return Err(Box::new(AcceptError {
                 cause: TransportError::PROTOCOL_VIOLATION("authentication failed").into(),
                 response: None,
@@ -601,7 +622,8 @@ impl Endpoint {
         };
 
         let ch = ConnectionHandle(self.connections.vacant_key());
-        let loc_cid = self.new_cid(RouteDatagramTo::Connection(ch));
+        let pending_route = RouteDatagramTo::Incoming(incoming.incoming_idx);
+        let loc_cid = self.new_cid(pending_route);
         let mut params = TransportParameters::new(
             &server_config.transport,
             &self.config,
@@ -615,7 +637,7 @@ impl Endpoint {
         params.retry_src_cid = incoming.token.retry_src_cid;
         let mut pref_addr_cid = None;
         if server_config.has_preferred_address() {
-            let cid = self.new_cid(RouteDatagramTo::Connection(ch));
+            let cid = self.new_cid(pending_route);
             pref_addr_cid = Some(cid);
             params.preferred_address = Some(PreferredAddress {
                 address_v4: server_config.preferred_address_v4,
@@ -627,7 +649,7 @@ impl Endpoint {
 
         let tls = server_config.crypto.clone().start_session(version, &params);
         let transport_config = server_config.transport.clone();
-        let mut conn = self.add_connection(
+        let conn = self.add_connection(
             ch,
             version,
             dst_cid,
@@ -642,35 +664,65 @@ impl Endpoint {
                 pref_addr_cid,
                 path_validated: remote_address_validated,
             },
+            pending_route,
         );
-        self.index.insert_initial(dst_cid, ch);
 
-        match conn.handle_first_packet(
-            incoming.received_at,
-            incoming.addresses.remote,
-            incoming.ecn,
+        Ok(PreparedAccept {
+            handle: ch,
+            connection: conn,
+            version,
+            initial_dst_cid: dst_cid,
+            remote_cid: src_cid,
+            received_at: incoming.received_at,
+            addresses: incoming.addresses,
+            ecn: incoming.ecn,
             packet_number,
-            incoming.packet,
-            incoming.rest,
-        ) {
+            packet: Some(incoming.packet),
+            rest: incoming.rest,
+            crypto: incoming.crypto,
+            incoming_idx: incoming.incoming_idx,
+            first_packet_result: None,
+        })
+    }
+
+    /// Finalize a prepared incoming connection after its first packet has been processed.
+    #[doc(hidden)]
+    // AcceptError cannot be made smaller without semver breakage
+    #[allow(clippy::result_large_err)]
+    pub fn finish_accept(
+        &mut self,
+        mut prepared: PreparedAccept,
+        buf: &mut Vec<u8>,
+    ) -> Result<(ConnectionHandle, Connection), Box<AcceptError>> {
+        let incoming_buffer = self.incoming_buffers.remove(prepared.incoming_idx);
+        self.all_incoming_buffers_total_bytes -= incoming_buffer.total_bytes;
+
+        match prepared
+            .first_packet_result
+            .take()
+            .expect("PreparedAccept::process_first_packet must be called before finish_accept")
+        {
             Ok(()) => {
-                trace!(id = ch.0, icid = %dst_cid, "new connection");
+                self.activate_connection(prepared.handle, prepared.initial_dst_cid);
+                trace!(id = prepared.handle.0, icid = %prepared.initial_dst_cid, "new connection");
 
                 for event in incoming_buffer.datagrams {
-                    conn.handle_event(ConnectionEvent(ConnectionEventInner::Datagram(event)))
+                    prepared
+                        .connection
+                        .handle_event(ConnectionEvent(ConnectionEventInner::Datagram(event)))
                 }
 
-                Ok((ch, conn))
+                Ok((prepared.handle, prepared.connection))
             }
             Err(e) => {
                 debug!("handshake failed: {}", e);
-                self.handle_event(ch, EndpointEvent(EndpointEventInner::Drained));
+                self.handle_event(prepared.handle, EndpointEvent(EndpointEventInner::Drained));
                 let response = match e {
                     ConnectionError::TransportError(ref e) => Some(self.initial_close(
-                        version,
-                        incoming.addresses,
-                        &incoming.crypto,
-                        src_cid,
+                        prepared.version,
+                        prepared.addresses,
+                        &prepared.crypto,
+                        prepared.remote_cid,
                         e.clone(),
                         buf,
                     )),
@@ -678,6 +730,21 @@ impl Endpoint {
                 };
                 Err(Box::new(AcceptError { cause: e, response }))
             }
+        }
+    }
+
+    fn activate_connection(&mut self, ch: ConnectionHandle, initial_dst_cid: ConnectionId) {
+        let meta = &self.connections[ch];
+        self.index.insert_initial(initial_dst_cid, ch);
+        for cid in meta.loc_cids.values().filter(|cid| !cid.is_empty()) {
+            self.index
+                .connection_ids
+                .insert(*cid, RouteDatagramTo::Connection(ch));
+        }
+        if meta.loc_cids.values().any(|cid| cid.is_empty()) {
+            self.index
+                .incoming_connection_remotes
+                .insert(meta.addresses, RouteDatagramTo::Connection(ch));
         }
     }
 
@@ -784,8 +851,12 @@ impl Endpoint {
 
     /// Clean up endpoint data structures associated with an `Incoming`.
     fn clean_up_incoming(&mut self, incoming: &Incoming) {
-        self.index.remove_initial(incoming.packet.header.dst_cid);
-        let incoming_buffer = self.incoming_buffers.remove(incoming.incoming_idx);
+        self.clean_up_incoming_parts(incoming.packet.header.dst_cid, incoming.incoming_idx);
+    }
+
+    fn clean_up_incoming_parts(&mut self, dst_cid: ConnectionId, incoming_idx: usize) {
+        self.index.remove_initial(dst_cid);
+        let incoming_buffer = self.incoming_buffers.remove(incoming_idx);
         self.all_incoming_buffers_total_bytes -= incoming_buffer.total_bytes;
     }
 
@@ -801,6 +872,7 @@ impl Endpoint {
         tls: Box<dyn crypto::Session>,
         transport_config: Arc<TransportConfig>,
         side_args: SideArgs,
+        route: RouteDatagramTo,
     ) -> Connection {
         let mut rng_seed = [0; 32];
         self.rng.fill_bytes(&mut rng_seed);
@@ -824,7 +896,7 @@ impl Endpoint {
             side_args,
         );
 
-        self.register_connection(ch, init_cid, loc_cid, pref_addr_cid, addresses, side);
+        self.register_connection(ch, init_cid, loc_cid, pref_addr_cid, addresses, side, route);
 
         conn
     }
@@ -838,6 +910,7 @@ impl Endpoint {
         pref_addr_cid: Option<ConnectionId>,
         addresses: FourTuple,
         side: Side,
+        route: RouteDatagramTo,
     ) {
         let mut cids_issued = 0;
         let mut loc_cids = FxHashMap::default();
@@ -861,7 +934,7 @@ impl Endpoint {
         });
         debug_assert_eq!(id, ch.0, "connection handle allocation out of sync");
 
-        self.index.insert_conn(addresses, loc_cid, ch, side);
+        self.index.insert_conn(addresses, loc_cid, route, side);
     }
 
     fn initial_close(
@@ -1002,7 +1075,7 @@ struct ConnectionIndex {
     /// Identifies incoming connections with zero-length CIDs
     ///
     /// Uses a standard `HashMap` to protect against hash collision attacks.
-    incoming_connection_remotes: HashMap<FourTuple, ConnectionHandle>,
+    incoming_connection_remotes: HashMap<FourTuple, RouteDatagramTo>,
     /// Identifies outgoing connections with zero-length CIDs
     ///
     /// We don't yet support explicit source addresses for client connections, and zero-length CIDs
@@ -1053,23 +1126,24 @@ impl ConnectionIndex {
         &mut self,
         addresses: FourTuple,
         dst_cid: ConnectionId,
-        connection: ConnectionHandle,
+        route: RouteDatagramTo,
         side: Side,
     ) {
         match dst_cid.len() {
             0 => match side {
                 Side::Server => {
-                    self.incoming_connection_remotes
-                        .insert(addresses, connection);
+                    self.incoming_connection_remotes.insert(addresses, route);
                 }
                 Side::Client => {
+                    let RouteDatagramTo::Connection(connection) = route else {
+                        unreachable!("outgoing connections cannot be pending");
+                    };
                     self.outgoing_connection_remotes
                         .insert(addresses.remote, connection);
                 }
             },
             _ => {
-                self.connection_ids
-                    .insert(dst_cid, RouteDatagramTo::Connection(connection));
+                self.connection_ids.insert(dst_cid, route);
             }
         }
     }
@@ -1108,8 +1182,8 @@ impl ConnectionIndex {
             }
         }
         if datagram.dst_cid().is_empty() {
-            if let Some(&ch) = self.incoming_connection_remotes.get(addresses) {
-                return Some(RouteDatagramTo::Connection(ch));
+            if let Some(&route) = self.incoming_connection_remotes.get(addresses) {
+                return Some(route);
             }
             if let Some(&ch) = self.outgoing_connection_remotes.get(&addresses.remote) {
                 return Some(RouteDatagramTo::Connection(ch));
@@ -1237,6 +1311,67 @@ impl fmt::Debug for Incoming {
             .field("token", &self.token)
             .field("incoming_idx", &self.incoming_idx)
             // improper drop warner contains no information
+            .finish_non_exhaustive()
+    }
+}
+
+/// A connection whose endpoint state is reserved but whose first packet has not yet been
+/// finalized.
+///
+/// This type is an implementation detail used by `quinn` to process TLS setup without holding the
+/// endpoint-wide state lock.
+#[doc(hidden)]
+#[must_use = "a prepared accept must be processed and passed to Endpoint::finish_accept"]
+pub struct PreparedAccept {
+    handle: ConnectionHandle,
+    connection: Connection,
+    version: u32,
+    initial_dst_cid: ConnectionId,
+    remote_cid: ConnectionId,
+    received_at: Instant,
+    addresses: FourTuple,
+    ecn: Option<EcnCodepoint>,
+    packet_number: u64,
+    packet: Option<InitialPacket>,
+    rest: Option<BytesMut>,
+    crypto: Keys,
+    incoming_idx: usize,
+    first_packet_result: Option<Result<(), ConnectionError>>,
+}
+
+impl PreparedAccept {
+    /// Process the first packet, including the TLS ClientHello and certificate resolution.
+    #[doc(hidden)]
+    pub fn process_first_packet(&mut self) {
+        assert!(
+            self.first_packet_result.is_none(),
+            "PreparedAccept::process_first_packet called more than once"
+        );
+        let packet = self
+            .packet
+            .take()
+            .expect("PreparedAccept first packet is missing");
+        self.first_packet_result = Some(self.connection.handle_first_packet(
+            self.received_at,
+            self.addresses.remote,
+            self.ecn,
+            self.packet_number,
+            packet,
+            self.rest.take(),
+        ));
+    }
+}
+
+impl fmt::Debug for PreparedAccept {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("PreparedAccept")
+            .field("handle", &self.handle)
+            .field("version", &self.version)
+            .field("initial_dst_cid", &self.initial_dst_cid)
+            .field("remote_cid", &self.remote_cid)
+            .field("addresses", &self.addresses)
+            .field("incoming_idx", &self.incoming_idx)
+            .field("processed", &self.first_packet_result.is_some())
             .finish_non_exhaustive()
     }
 }

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -447,13 +447,31 @@ impl EndpointInner {
         incoming: proto::Incoming,
         server_config: Option<Arc<ServerConfig>>,
     ) -> Result<Connecting, ConnectionError> {
-        let mut state = self.state.lock().unwrap();
         let mut response_buffer = Vec::new();
-        let now = state.runtime.now();
-        match state
-            .inner
-            .accept(incoming, now, &mut response_buffer, server_config)
-        {
+        let mut prepared = {
+            let mut state = self.state.lock().unwrap();
+            let now = state.runtime.now();
+            match state
+                .inner
+                .prepare_accept(incoming, now, &mut response_buffer, server_config)
+            {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    if let Some(transmit) = error.response {
+                        respond(transmit, &response_buffer, &mut state.sender);
+                    }
+                    return Err(error.cause);
+                }
+            }
+        };
+
+        // rustls invokes synchronous certificate resolvers while processing the ClientHello.
+        // Keep this outside the endpoint state lock so a slow resolver cannot stall UDP intake or
+        // unrelated connections. The proto endpoint buffers retransmits until finalization.
+        prepared.process_first_packet();
+
+        let mut state = self.state.lock().unwrap();
+        match state.inner.finish_accept(prepared, &mut response_buffer) {
             Ok((handle, conn)) => {
                 state.stats.accepted_handshakes += 1;
                 let sender = state.socket.create_sender();

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -7,13 +7,14 @@ use rustls::crypto::ring::default_provider;
 
 use std::{
     convert::TryInto,
+    fmt,
     future::Future,
     io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
     pin::pin,
     str,
     sync::{
-        Arc,
+        Arc, Condvar, Mutex,
         atomic::{AtomicUsize, Ordering},
     },
     task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
@@ -22,11 +23,16 @@ use std::{
 use crate::runtime::TokioRuntime;
 use crate::{Duration, Instant};
 use bytes::Bytes;
-use proto::{RandomConnectionIdGenerator, crypto::rustls::QuicClientConfig};
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use proto::{
+    RandomConnectionIdGenerator,
+    crypto::rustls::{QuicClientConfig, QuicServerConfig},
+};
+use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 use rustls::{
     RootCertStore,
     pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
+    server::{ClientHello, ResolvesServerCert},
+    sign::CertifiedKey,
 };
 use tokio::time::{sleep, timeout};
 use tokio::{
@@ -312,6 +318,153 @@ impl EndpointFactory {
 
         endpoint
     }
+}
+
+struct BlockingCertResolver {
+    certified_key: Arc<CertifiedKey>,
+    entered: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    released: Mutex<bool>,
+    release_changed: Condvar,
+}
+
+impl BlockingCertResolver {
+    fn new(certified_key: Arc<CertifiedKey>, entered: tokio::sync::oneshot::Sender<()>) -> Self {
+        Self {
+            certified_key,
+            entered: Mutex::new(Some(entered)),
+            released: Mutex::new(false),
+            release_changed: Condvar::new(),
+        }
+    }
+
+    fn release(&self) {
+        *self.released.lock().unwrap() = true;
+        self.release_changed.notify_all();
+    }
+}
+
+impl fmt::Debug for BlockingCertResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BlockingCertResolver")
+            .finish_non_exhaustive()
+    }
+}
+
+impl ResolvesServerCert for BlockingCertResolver {
+    fn resolve(&self, _client_hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+        let should_block = if let Some(entered) = self.entered.lock().unwrap().take() {
+            let _ = entered.send(());
+            true
+        } else {
+            false
+        };
+        if should_block {
+            let mut released = self.released.lock().unwrap();
+            while !*released {
+                released = self.release_changed.wait(released).unwrap();
+            }
+        }
+        Some(self.certified_key.clone())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn synchronous_cert_resolution_does_not_stall_endpoint_io() {
+    let _guard = subscribe();
+    let factory = EndpointFactory::new();
+    let server = factory.endpoint();
+    let client_1 = factory.endpoint();
+    let mut retransmit_transport = TransportConfig::default();
+    retransmit_transport.initial_rtt(Duration::from_millis(10));
+    let client_2 = factory.endpoint_with_config(retransmit_transport);
+    let client_3 = factory.endpoint();
+    let server_addr = server.local_addr().unwrap();
+
+    let (client_1_connection, server_1_connection) =
+        tokio::try_join!(client_1.connect(server_addr, "localhost").unwrap(), async {
+            server.accept().await.unwrap().await
+        })
+        .unwrap();
+
+    let provider = default_provider();
+    let signing_key = provider
+        .key_provider
+        .load_private_key(PrivateKeyDer::Pkcs8(
+            factory.cert.signing_key.serialize_der().into(),
+        ))
+        .unwrap();
+    let certified_key = Arc::new(CertifiedKey::new(
+        vec![factory.cert.cert.der().clone()],
+        signing_key,
+    ));
+    let (resolver_entered_tx, resolver_entered_rx) = tokio::sync::oneshot::channel();
+    let resolver = Arc::new(BlockingCertResolver::new(
+        certified_key,
+        resolver_entered_tx,
+    ));
+    let crypto = rustls::ServerConfig::builder_with_provider(Arc::new(provider))
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap()
+        .with_no_client_auth()
+        .with_cert_resolver(resolver.clone());
+    server.set_server_config(Some(crate::ServerConfig::with_crypto(Arc::new(
+        QuicServerConfig::try_from(crypto).unwrap(),
+    ))));
+
+    let server_for_accept = server.clone();
+    let server_accept = tokio::spawn(async move {
+        server_for_accept
+            .accept()
+            .await
+            .unwrap()
+            .await
+            .expect("second server connection")
+    });
+    let second_connect = tokio::spawn(async move {
+        client_2
+            .connect(server_addr, "localhost")
+            .unwrap()
+            .await
+            .expect("second client connection")
+    });
+
+    tokio::time::timeout(Duration::from_secs(2), resolver_entered_rx)
+        .await
+        .expect("resolver was not invoked")
+        .expect("resolver entry sender dropped");
+
+    let existing_connection_io = async {
+        let mut send = client_1_connection.open_uni().await.unwrap();
+        send.write_all(b"still-live").await.unwrap();
+        send.finish().unwrap();
+        let mut recv = server_1_connection.accept_uni().await.unwrap();
+        assert_eq!(recv.read_to_end(64).await.unwrap(), b"still-live");
+    };
+    tokio::time::timeout(Duration::from_millis(500), existing_connection_io)
+        .await
+        .expect("existing connection stalled during certificate resolution");
+
+    let server_for_concurrent_accept = server.clone();
+    let concurrent_handshake = async move {
+        tokio::try_join!(client_3.connect(server_addr, "localhost").unwrap(), async {
+            server_for_concurrent_accept.accept().await.unwrap().await
+        })
+    };
+    tokio::time::timeout(Duration::from_millis(500), concurrent_handshake)
+        .await
+        .expect("new handshake stalled during unrelated certificate resolution")
+        .expect("concurrent handshake failed");
+
+    // Keep the first handshake blocked long enough for its Initial PTO to fire. The retransmitted
+    // Initial must stay in the pending connection's bounded buffer and be replayed at finalization.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    resolver.release();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        server_accept.await.unwrap();
+        second_connect.await.unwrap();
+    })
+    .await
+    .expect("connection did not recover after certificate resolution");
 }
 
 #[tokio::test]


### PR DESCRIPTION
We hit this running a server that resolves certificates on demand rather than from a static keypair. Throughput would collapse whenever a new client connected, and it took a while to work out why.

`EndpointInner::accept` takes the endpoint state lock and holds it across `state.inner.accept(...)`, which is where rustls processes the ClientHello — and rustls calls `ResolvesServerCert` synchronously from there. So if your resolver does anything slow, you are holding the endpoint lock for the duration. Not just that handshake: UDP intake and every other connection on the endpoint wait behind it.

The test I added sets up a resolver that blocks, then checks that a connection which was already established keeps making progress while a new handshake is stuck in it. On main it fails:

```
panicked at quinn/src/tests.rs:445:
  existing connection stalled during certificate resolution: Elapsed(())
```

The fix splits accept into three parts so the lock only covers the endpoint state mutations. `prepare_accept` allocates the connection under the lock and points its packets at the bounded incoming buffer. `process_first_packet` drives the ClientHello with the lock released, which is where the resolver runs. `finish_accept` takes the lock again to reinstall routing and register the connection.

Packets that arrive while the resolver is working keep going to the incoming buffer that already exists for pending connections, so nothing gets dropped and there is no new queue to bound. The single-call `accept` still works exactly as before, so this is invisible to existing callers; the two halves are `#[doc(hidden)]` in quinn-proto since quinn is the only intended caller.

Worth mentioning #2024, since it is adjacent. That asks for ClientHello access before accepting, which would let people use the rustls `Acceptor` pattern and do resolution before a connection exists — a better answer in general. This is narrower: it does not expose anything new, it just stops a synchronous resolver from blocking the whole endpoint. The two are compatible, and this still helps anyone who wants to keep a sync resolver.

If you would rather `prepare_accept`/`finish_accept` stay private and the split live entirely inside quinn, I am happy to redo it that way — I put them in quinn-proto because that is where the routing state lives, but I do not feel strongly about it.