### PR TITLE
build(deps): bump h2 from 0.4.13 to 0.4.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,9 +1108,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
The `audit` job has been failing since RUSTSEC-2026-0258 was published on 2026-08-17: h2 < 0.4.16 accepts and queues empty DATA frames without limit, and cargo-deny errors on the advisory (`advisories FAILED, bans ok, licenses ok, sources ok`).

This blocks the merge queue for every PR. #2792 was enqueued and evicted 49 seconds later, with `audit` the only red job out of 20: https://github.com/quinn-rs/quinn/actions/runs/32289479766/job/96186717814

Nothing published is affected. h2 reaches the lock file only through `perf` (`publish = false`) with its non-default `tokio-console` feature, via console-subscriber -> tonic -> hyper; `quinn`, `quinn-proto` and `quinn-udp` do not depend on it at all. The lock file entry is enough to fail the check regardless, so the check needs either this bump or an `[advisories] ignore` entry in `deny.toml` — happy to switch to the latter if you would rather not carry the bump.

The diff is deliberately just the two lines of the h2 entry: a plain `cargo update -p h2` also reshuffles five crates from `windows-sys 0.52.0` to `0.61.2` (which #2768 does anyway), so I edited the version and checksum by hand and confirmed `cargo metadata --locked` accepts the result without rewriting it. MSRV is unchanged (h2 declares 1.63 in both versions), and `cargo audit` on the resulting lock file reports no vulnerabilities.
