### PR TITLE
proto: expose BBR bandwidth estimate in path stats

### DIFF
--- a/quinn-proto/src/congestion.rs
+++ b/quinn-proto/src/congestion.rs
@@ -72,12 +72,14 @@ pub trait Controller: Send + Sync {
     /// Number of ack-eliciting bytes that may be in flight
     fn window(&self) -> u64;
 
-    /// Retrieve implementation-specific metrics used to populate `qlog` traces when they are enabled
+    /// Retrieve implementation-specific metrics used to populate connection statistics and `qlog`
+    /// traces when they are enabled
     fn metrics(&self) -> ControllerMetrics {
         ControllerMetrics {
             congestion_window: self.window(),
             ssthresh: None,
             pacing_rate: None,
+            bandwidth_estimate: None,
         }
     }
 
@@ -101,6 +103,8 @@ pub struct ControllerMetrics {
     pub ssthresh: Option<u64>,
     /// Pacing rate (bits/s)
     pub pacing_rate: Option<u64>,
+    /// Estimated sustainable path bandwidth (bits/s)
+    pub bandwidth_estimate: Option<u64>,
 }
 
 /// Constructs controllers on demand

--- a/quinn-proto/src/congestion/bbr/mod.rs
+++ b/quinn-proto/src/congestion/bbr/mod.rs
@@ -493,10 +493,13 @@ impl Controller for Bbr {
     }
 
     fn metrics(&self) -> ControllerMetrics {
+        let bandwidth_estimate = self.max_bandwidth.get_estimate();
         ControllerMetrics {
             congestion_window: self.window(),
             ssthresh: None,
             pacing_rate: Some(self.pacing_rate * 8),
+            bandwidth_estimate: (bandwidth_estimate != 0)
+                .then(|| bandwidth_estimate.saturating_mul(8)),
         }
     }
 
@@ -650,3 +653,26 @@ const K_MAX_INITIAL_CONGESTION_WINDOW: u64 = 200;
 
 const PROBE_RTT_BASED_ON_BDP: bool = true;
 const DRAIN_TO_TARGET: bool = true;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metrics_report_bandwidth_estimate() {
+        let mut bbr = Bbr::new(Arc::new(BbrConfig::default()), 1200);
+        assert_eq!(bbr.metrics().bandwidth_estimate, None);
+
+        let start = Instant::now();
+        let interval = Duration::from_millis(10);
+        bbr.max_bandwidth.on_sent(start, 1200);
+        bbr.max_bandwidth.on_sent(start + interval, 1200);
+        bbr.max_bandwidth
+            .on_ack(start + interval * 2, start, 1200, 0, false);
+        bbr.max_bandwidth.on_sent(start + interval * 2, 1200);
+        bbr.max_bandwidth
+            .on_ack(start + interval * 3, start + interval, 1200, 0, false);
+
+        assert_eq!(bbr.metrics().bandwidth_estimate, Some(960_000));
+    }
+}

--- a/quinn-proto/src/congestion/cubic.rs
+++ b/quinn-proto/src/congestion/cubic.rs
@@ -261,6 +261,7 @@ impl Controller for Cubic {
             congestion_window: self.window(),
             ssthresh: Some(self.state.ssthresh),
             pacing_rate: None,
+            bandwidth_estimate: None,
         }
     }
 

--- a/quinn-proto/src/congestion/new_reno.rs
+++ b/quinn-proto/src/congestion/new_reno.rs
@@ -118,6 +118,7 @@ impl Controller for NewReno {
             congestion_window: self.window(),
             ssthresh: Some(self.ssthresh),
             pacing_rate: None,
+            bandwidth_estimate: None,
         }
     }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1268,6 +1268,7 @@ impl Connection {
         let mut stats = self.stats;
         stats.path.rtt = self.path.rtt.get();
         stats.path.cwnd = self.path.congestion.window();
+        stats.path.bandwidth_estimate = self.path.congestion.metrics().bandwidth_estimate;
         stats.path.current_mtu = self.path.mtud.current_mtu();
 
         stats

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -138,6 +138,10 @@ pub struct PathStats {
     pub rtt: Duration,
     /// Current congestion window of the connection
     pub cwnd: u64,
+    /// Congestion controller's estimate of sustainable path bandwidth, in bits per second
+    ///
+    /// `None` when the congestion controller does not provide an estimate.
+    pub bandwidth_estimate: Option<u64>,
     /// Congestion events on the connection
     pub congestion_events: u64,
     /// Spurious congestion events on the connection

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -146,6 +146,77 @@ fn lifecycle() {
 }
 
 #[test]
+fn stats_include_congestion_controller_bandwidth_estimate() {
+    const WINDOW: u64 = 12_000;
+    const BANDWIDTH_ESTIMATE: u64 = 4_000_000;
+
+    #[derive(Clone)]
+    struct TestController;
+
+    impl congestion::Controller for TestController {
+        fn on_congestion_event(
+            &mut self,
+            _now: Instant,
+            _sent: Instant,
+            _is_persistent_congestion: bool,
+            _is_ecn: bool,
+            _lost_bytes: u64,
+        ) {
+        }
+
+        fn on_mtu_update(&mut self, _new_mtu: u16) {}
+
+        fn window(&self) -> u64 {
+            WINDOW
+        }
+
+        fn metrics(&self) -> congestion::ControllerMetrics {
+            congestion::ControllerMetrics {
+                congestion_window: WINDOW,
+                bandwidth_estimate: Some(BANDWIDTH_ESTIMATE),
+                ..Default::default()
+            }
+        }
+
+        fn clone_box(&self) -> Box<dyn congestion::Controller> {
+            Box::new(self.clone())
+        }
+
+        fn initial_window(&self) -> u64 {
+            WINDOW
+        }
+
+        fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+            self
+        }
+    }
+
+    struct TestControllerFactory;
+
+    impl congestion::ControllerFactory for TestControllerFactory {
+        fn build(
+            self: Arc<Self>,
+            _now: Instant,
+            _current_mtu: u16,
+        ) -> Box<dyn congestion::Controller> {
+            Box::new(TestController)
+        }
+    }
+
+    let mut transport = TransportConfig::default();
+    transport.congestion_controller_factory(Arc::new(TestControllerFactory));
+    let mut config = client_config();
+    config.transport_config(Arc::new(transport));
+
+    let mut pair = Pair::default();
+    let (client_ch, _) = pair.connect_with(config);
+    let stats = pair.client_conn_mut(client_ch).stats();
+
+    assert_eq!(stats.path.cwnd, WINDOW);
+    assert_eq!(stats.path.bandwidth_estimate, Some(BANDWIDTH_ESTIMATE));
+}
+
+#[test]
 fn draft_version_compat() {
     let _guard = subscribe();
 

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -231,7 +231,7 @@ pub enum TransportErrorPayload {
 
 /// Returns true if the given I/O error corresponds to a message size error
 ///
-/// Useful, for example, after invoking [`io::Error::last_os_error()`]
+/// Useful, for example, after invoking `std::io::Error::last_os_error()`
 /// to check if the last OS error was a message size error
 /// (EMSGSIZE on Unix, WSAEMSGSIZE on Windows).
 ///


### PR DESCRIPTION
Expose the bandwidth estimate from the congestion controller.

With Reno/CUBIC we can compute this from window / RTT, but for BBR we need the actual estimate from the CC algorithm.