### PR TITLE
0.11.x: fix payload_bytes double subtraction when evicting outgoing datagrams

### DIFF
--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -46,7 +46,6 @@ impl Datagrams<'_> {
                     .pop_front()
                     .expect("datagrams.outgoing.payload_bytes desynchronized");
                 trace!(len = prev.data.len(), "dropping outgoing datagram");
-                self.conn.datagrams.outgoing.payload_bytes -= prev.data.len();
             }
         } else if self.conn.datagrams.outgoing.payload_bytes + data.len() + size_of::<Datagram>()
             > self.conn.config.datagram_send_buffer_size

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1947,6 +1947,46 @@ fn datagram_recv_buffer_overflow() {
 }
 
 #[test]
+fn datagram_send_buffer_overflow() {
+    let _guard = subscribe();
+    const PAYLOAD_WINDOW: usize = 100;
+    const METADATA_WINDOW: usize = 2 * size_of::<Datagram>();
+    const WINDOW: usize = PAYLOAD_WINDOW + METADATA_WINDOW;
+    let client_config = {
+        let mut config = client_config();
+        let mut transport = TransportConfig::default();
+        transport.datagram_send_buffer_size(WINDOW);
+        config.transport_config(transport.into());
+        config
+    };
+    let mut pair = Pair::default();
+    let (client_ch, server_ch) = pair.connect_with(client_config);
+    assert_matches!(pair.server_conn_mut(server_ch).poll(), None);
+
+    // Keep the send buffer full so most sends evict the oldest queued datagram;
+    // `payload_bytes` bookkeeping must survive sustained eviction
+    const LEN: usize = (PAYLOAD_WINDOW / 3) + 1;
+    for i in 0..10u8 {
+        pair.client_datagrams(client_ch)
+            .send(vec![i; LEN].into(), true)
+            .unwrap();
+    }
+    pair.drive();
+
+    assert_matches!(
+        pair.server_conn_mut(server_ch).poll(),
+        Some(Event::DatagramReceived)
+    );
+    for i in 7..10u8 {
+        assert_eq!(
+            pair.server_datagrams(server_ch).recv().unwrap(),
+            vec![i; LEN]
+        );
+    }
+    assert_matches!(pair.server_datagrams(server_ch).recv(), None);
+}
+
+#[test]
 fn datagram_unsupported() {
     let _guard = subscribe();
     let server = ServerConfig {


### PR DESCRIPTION
Fixes #2805.

`Datagrams::send(drop = true)`'s eviction loop subtracts an evicted datagram's size from `payload_bytes` at the call site even though `DatagramBuffer::pop_front` already does so internally. Under sustained eviction the counter drifts below its true value and underflows: a debug build panics with `attempt to subtract with overflow`, and a release build wraps the counter, drains the whole queue, and then panics on the `.expect("datagrams.outgoing.payload_bytes desynchronized")` inside `send_datagram`, while the connection lock is held.

The fix is deleting the redundant subtraction; eviction semantics are otherwise unchanged. `main` is not affected — its version of the outgoing memory limit (`DatagramState::make_space_for`) never had the manual subtraction, so there is no upstream commit to cherry-pick and this is written directly against `0.11.x`.

The added regression test keeps a small send buffer in sustained eviction and asserts the surviving datagrams are delivered. On current `0.11.x` it fails at the removed line with `attempt to subtract with overflow` (debug) before reaching any assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)