### PR TITLE
feat(proto): Use linear instead of binary search in `Assembler::restore_front_order`

### DIFF
--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -106,11 +106,8 @@ impl Assembler {
 
     /// Restore ordering after `read` advanced the front's offset
     fn restore_front_order(&mut self) {
-        if self.data.len() < 2 || self.data[0] <= self.data[1] {
-            return;
-        }
         let chunk = self.data.pop_front().unwrap();
-        let idx = self.data.partition_point(|other| *other <= chunk);
+        let idx = self.data.iter().take_while(|other| **other < chunk).count();
         self.data.insert(idx, chunk);
     }
 


### PR DESCRIPTION
Builds on #2803.

Factored out from #2808.

Changes `Assembler::restore_front_order` to use a linear search instead of a binary search. This may be faster if the index of the front does not change by much, which is probably the common case, and this remains O(N) either way.

This allows us to remove the hard-coded short-circuit for if its position did not change, which no longer makes sense as an optimization due to it becoming just an implicit degenerate case of the linear search.
