### PR TITLE
proto: coalesce contiguous chunks during defragment

### DIFF
--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -1,4 +1,8 @@
-use std::{cmp::Ordering, collections::VecDeque, mem};
+use std::{
+    cmp::{Ordering, max},
+    collections::VecDeque,
+    mem,
+};
 
 use bytes::{Buf, Bytes, BytesMut};
 
@@ -115,6 +119,8 @@ impl Assembler {
     /// This makes sure we're not unnecessarily holding on to many larger allocations.
     /// We merge contiguous chunks in the process of doing so.
     fn defragment(&mut self) {
+        // Chunks smaller than min_chunk_size are merged regardless of fragmentation
+        let min_chunk_size = max(self.buffered.div_ceil(MAX_CHUNKS), MIN_RETAINED_CHUNK_SIZE);
         let mut buffers = mem::take(&mut self.data);
         self.buffered = 0;
         let mut fragmented_buffered = 0;
@@ -124,7 +130,7 @@ impl Assembler {
             let size = chunk.bytes.len();
             offset = chunk.offset + size as u64;
             self.buffered += size;
-            if !chunk.defragmented {
+            if !chunk.defragmented || size < min_chunk_size {
                 fragmented_buffered += size;
             }
         }
@@ -133,11 +139,11 @@ impl Assembler {
         let mut buffer = BytesMut::with_capacity(fragmented_buffered);
         let mut offset = 0;
         for chunk in buffers {
-            if chunk.defragmented {
-                // bytes might be empty after try_mark_defragment
-                if chunk.bytes.is_empty() {
-                    continue;
-                }
+            // bytes might be empty after try_mark_defragment
+            if chunk.bytes.is_empty() {
+                continue;
+            }
+            if chunk.defragmented && chunk.bytes.len() >= min_chunk_size {
                 // The accumulated chunk starts before this one, so it goes first
                 if !buffer.is_empty() {
                     self.data
@@ -389,6 +395,12 @@ fn insert_ordered(data: &mut VecDeque<Buffer>, buffer: Buffer) {
 /// Independent of how much memory those spans over-allocate. A frame is rejected only
 /// if compaction cannot get the count back down to this.
 const MAX_CHUNKS: usize = 1024;
+
+/// Minimum size of a defragmented chunk that is retained without coalescing.
+///
+/// Chunks below this size will be copied on every compaction. 128 bytes balances
+/// being cheap to copy while reducing the overhead of many small buffer nodes.
+const MIN_RETAINED_CHUNK_SIZE: usize = 128;
 
 /// Chunk count past which `insert` compacts before deciding whether to reject
 ///
@@ -710,6 +722,37 @@ mod test {
             Some(Chunk::new(0, Bytes::from_static(b"abc")))
         );
         assert_eq!(x.read(3, false), None);
+    }
+
+    #[test]
+    fn ordered_lossless_stream_is_not_rejected() {
+        const FRAME_LEN: usize = 32;
+
+        let mut x = Assembler::new();
+        let data = Bytes::from(vec![0; FRAME_LEN]);
+        let mut offset = 0u64;
+        while offset < (2 * COMPACT_THRESHOLD * FRAME_LEN) as u64 {
+            x.insert(offset, data.clone(), FRAME_LEN)
+                .expect("contiguous lossless data must not be rejected");
+            offset += FRAME_LEN as u64;
+        }
+    }
+
+    #[test]
+    fn defrag_respects_max_chunks_at_rounding_boundary() {
+        let mut x = Assembler::new();
+        let data = Bytes::from(vec![0; MIN_RETAINED_CHUNK_SIZE]);
+        let mut offset = 0;
+        // Fill with minimium sized chunks.
+        for _ in 0..MAX_CHUNKS {
+            x.insert(offset, data.clone(), data.len()).unwrap();
+            offset += data.len() as u64;
+        }
+        // Add 1 extra chunk, defragment must coalesce the previous
+        // chunks to stay within MAX_CHUNKS
+        x.insert(offset, Bytes::from_static(b"x"), 1).unwrap();
+        x.defragment();
+        assert!(x.data.len() <= MAX_CHUNKS);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Previously, `defragment()` would ignore high utilization chunks, while still capping `MAX_CHUNKS=1024` (Triggered at `COMPACT_THRESHOLD=2048`)
This places a practical limit on `stream_receive_window` of `frame_len * 2048`, or 2.44 MB with an MTU of 1200.

Any peer sending lossless contiguous data with a window larger than this can exceed the limit and get a transport error if the reader lags behind:
```
INTERNAL_ERROR("too many gaps in stream buffer").
```


## Fix

Contiguous chunks are coalesced together during `defragment()` if they are smaller than `min_chunk_size = buffered / MAX_CHUNKS`
This allows us to fit the buffered data while still protecting from floods of out of order data.

We don't want to unconditionally merge chunks, as that could result in many copy operations which would be wasteful.
By only coalescing chunks smaller than `min_chunk_size` we avoid copying chunks which are already a good size for the current buffer. This also protects us from compacting the same chunk multiple times.