### PR TITLE
Add minimum rtt to path stats for connection

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1267,6 +1267,7 @@ impl Connection {
     pub fn stats(&self) -> ConnectionStats {
         let mut stats = self.stats;
         stats.path.rtt = self.path.rtt.get();
+        stats.path.min_rtt = self.path.rtt.min();
         stats.path.cwnd = self.path.congestion.window();
         stats.path.current_mtu = self.path.mtud.current_mtu();
 
@@ -1377,6 +1378,11 @@ impl Connection {
     /// Current best estimate of this connection's latency (round-trip-time)
     pub fn rtt(&self) -> Duration {
         self.path.rtt.get()
+    }
+
+    /// Minimum RTT seen on this path, ignoring ack delay
+    pub fn min_rtt(&self) -> Duration {
+        self.path.rtt.min()
     }
 
     /// Current state of this connection's congestion controller, for debugging purposes

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -136,6 +136,8 @@ impl std::fmt::Debug for FrameStats {
 pub struct PathStats {
     /// Current best estimate of this connection's latency (round-trip-time)
     pub rtt: Duration,
+    /// Minimum RTT seen on this path, ignoring ack delay
+    pub min_rtt: Duration,
     /// Current congestion window of the connection
     pub cwnd: u64,
     /// Congestion events on the connection

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -592,6 +592,11 @@ impl Connection {
         self.0.state.lock("rtt").inner.rtt()
     }
 
+    /// Minimum RTT seen on this path, ignoring ack delay
+    pub fn min_rtt(&self) -> Duration {
+        self.0.state.lock("min_rtt").inner.min_rtt()
+    }
+
     /// Returns connection statistics
     pub fn stats(&self) -> ConnectionStats {
         self.0.state.lock("stats").inner.stats()


### PR DESCRIPTION
This pull request add  minimum rtt to `PathStats`, useful for users that need a stable floor estimate of rtt.

Closes: #2815
