### PR TITLE
test: use deterministic pns to fix ack_bundled_with_datagrams flakiness

### DIFF
--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -3659,8 +3659,8 @@ fn voluntary_ack_with_large_datagrams() {
 #[test]
 fn ack_bundled_with_datagrams() {
     let _guard = subscribe();
-    let mut pair = Pair::default();
-    let (client_ch, server_ch) = pair.connect();
+    let mut pair = Pair::default_with_deterministic_pns();
+    let (client_ch, server_ch) = pair.connect_with(client_config_with_deterministic_pns());
 
     // Send packet from client and then send from server. the packet from server should include ACKs
     pair.client_datagrams(client_ch)


### PR DESCRIPTION
Fixes test flakiness found in #2819.

I checked the following locally:
- before this pr, the test fails with same reason, by running the test in shell while loop.
- after on this pr, the test won't fail by running the test in shell while loop for long time.
