### PR TITLE
fix(udp): don't panic in `UdpSocketState::new` on unbound socket

### DIFF
--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -53,12 +53,19 @@ impl UdpSocketState {
         );
 
         socket.0.set_nonblocking(true)?;
-        let addr = socket.0.local_addr()?;
-        let is_ipv6 = addr.as_socket_ipv6().is_some();
+        let info = unsafe {
+            get_socket_option::<WinSock::WSAPROTOCOL_INFOW>(
+                &*socket.0,
+                WinSock::SOL_SOCKET,
+                WinSock::SO_PROTOCOL_INFOW,
+            )
+        }?;
+        let family = info.iAddressFamily;
+        let is_ipv6 = family == c_int::from(WinSock::AF_INET6);
         let v6only = unsafe {
             get_socket_option::<u32>(&*socket.0, WinSock::IPPROTO_IPV6, WinSock::IPV6_V6ONLY as _)
         }?;
-        let is_ipv4 = addr.as_socket_ipv4().is_some() || v6only == 0;
+        let is_ipv4 = family == c_int::from(WinSock::AF_INET) || v6only == 0;
 
         // We don't support old versions of Windows that do not enable access to `WSARecvMsg()`
         if WSARECVMSG_PTR.is_none() {

--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -1,6 +1,6 @@
 use std::{
     io::{self, IoSliceMut},
-    mem,
+    mem::{self, MaybeUninit},
     net::{IpAddr, Ipv4Addr},
     os::windows::io::AsRawSocket,
     ptr,
@@ -56,21 +56,9 @@ impl UdpSocketState {
         let addr = socket.0.local_addr()?;
         let is_ipv6 = addr.as_socket_ipv6().is_some();
         let v6only = unsafe {
-            let mut result: u32 = 0;
-            let mut len = size_of_val(&result) as i32;
-            let rc = WinSock::getsockopt(
-                socket.0.as_raw_socket() as _,
-                WinSock::IPPROTO_IPV6,
-                WinSock::IPV6_V6ONLY as _,
-                &mut result as *mut _ as _,
-                &mut len,
-            );
-            if rc == -1 {
-                return Err(io::Error::last_os_error());
-            }
-            result != 0
-        };
-        let is_ipv4 = addr.as_socket_ipv4().is_some() || !v6only;
+            get_socket_option::<u32>(&*socket.0, WinSock::IPPROTO_IPV6, WinSock::IPV6_V6ONLY as _)
+        }?;
+        let is_ipv4 = addr.as_socket_ipv4().is_some() || v6only == 0;
 
         // We don't support old versions of Windows that do not enable access to `WSARecvMsg()`
         if WSARECVMSG_PTR.is_none() {
@@ -481,6 +469,32 @@ fn send(
     match rc {
         0 => Ok(()),
         _ => Err(io::Error::last_os_error()),
+    }
+}
+
+/// Reads a socket option into a zero-initialized `T`.
+///
+/// # Safety
+///
+/// `T` must be valid for the all-zero bit pattern: Windows may fill fewer bytes than
+/// `size_of::<T>()`, as it does for `IPV6_V6ONLY`.
+unsafe fn get_socket_option<T>(socket: &impl AsRawSocket, level: i32, name: i32) -> io::Result<T> {
+    let mut value = MaybeUninit::<T>::zeroed();
+    let mut len = size_of::<T>() as i32;
+    let rc = unsafe {
+        WinSock::getsockopt(
+            socket.as_raw_socket() as usize,
+            level,
+            name,
+            value.as_mut_ptr() as _,
+            &mut len,
+        )
+    };
+
+    match rc == 0 {
+        // SAFETY: `value` is zero-initialized and `getsockopt` only writes within it.
+        true => Ok(unsafe { value.assume_init() }),
+        false => Err(io::Error::last_os_error()),
     }
 }
 

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -40,6 +40,16 @@ fn basic() {
 }
 
 #[test]
+fn state_before_bind() {
+    for domain in [socket2::Domain::IPV6, socket2::Domain::IPV4] {
+        let Ok(socket) = Socket::new(domain, socket2::Type::DGRAM, None) else {
+            continue;
+        };
+        UdpSocketState::new((&socket).into()).unwrap();
+    }
+}
+
+#[test]
 fn basic_src_ip() {
     let send = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0))
         .or_else(|_| UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)))


### PR DESCRIPTION
Currently, `UdpSocketState::new` on Windows learns the socket's address family via `local_addr` (which uses `getsockname` internally). This fails on an unbound socket.

Why would we want to do this on an unbound socket? On Windows (and Apple for that matter), the destination IP in `RecvMeta` gets attached based on the socket setting at the time the datagram arrives. When a socket gets discarded and rebound on the same port, datagrams that are still in-flight and arrive between us calling `bind` and initializing the `UdpSocketState` don't have a destination IP attached.

In Firezone, we have to drop such packets because we use this information to learn about our local interfaces. Constructing the `UdpSocketState` prior to calling `UdpSocket::bind` fixes this race condition but requires us to not use `getsockname` on Windows. On Unix, this is already possible and therefore requires no changes.

Code has been written by Claude. Description and commit messages have been written by me.