### PR TITLE
quinn-proto: drop short packets with unsupported versions (0.11.x)

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -176,6 +176,13 @@ impl Endpoint {
                     debug!("dropping packet with unsupported version");
                     return None;
                 }
+                // RFC 9000 §5.2.2: "Servers MUST drop smaller packets that specify unsupported
+                // versions." Responding to short packets would let a spoofed source elicit a
+                // Version Negotiation packet larger than the datagram that triggered it.
+                if datagram_len < MIN_INITIAL_SIZE as usize {
+                    debug!("dropping short packet with unsupported version");
+                    return None;
+                }
                 trace!("sending version negotiation");
                 // Negotiate versions
                 Header::VersionNegotiate {

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -57,15 +57,17 @@ fn version_negotiate_server() {
     );
     let now = Instant::now();
     let mut buf = Vec::with_capacity(server.config().get_max_udp_payload_size() as usize);
-    let event = server.handle(
-        now,
-        client_addr,
-        None,
-        None,
-        // Long-header packet with reserved version number
-        hex!("80 0a1a2a3a 04 00000000 04 00000000 00")[..].into(),
-        &mut buf,
-    );
+    // Long-header packet with reserved version number
+    let header = hex!("80 0a1a2a3a 04 00000000 04 00000000 00");
+
+    // RFC 9000 §5.2.2: packets too small to initiate a connection are dropped
+    let event = server.handle(now, client_addr, None, None, header[..].into(), &mut buf);
+    assert!(event.is_none());
+    assert!(buf.is_empty());
+
+    let mut packet = header.to_vec();
+    packet.resize(MIN_INITIAL_SIZE as usize, 0);
+    let event = server.handle(now, client_addr, None, None, packet[..].into(), &mut buf);
     let Some(DatagramEvent::Response(Transmit { .. })) = event else {
         panic!("expected a response");
     };


### PR DESCRIPTION
Backport of #2822 to `0.11.x`. Clean cherry-pick, no conflicts.

RFC 9000 §5.2.2: "Servers MUST drop smaller packets that specify unsupported versions." This adds the same `datagram_len < MIN_INITIAL_SIZE` check that already guards Initial packets to the `UnsupportedVersion` branch, so a short datagram from a spoofed source no longer elicits a larger Version Negotiation response.