### PR TITLE
fix(windows): disable USO after probing for GSO support

### DIFF
--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -567,8 +567,16 @@ fn max_gso_segments(socket: &impl AsRawSocket) -> usize {
         WinSock::UDP_SEND_MSG_SIZE,
         GSO_SIZE,
     ) {
-        // Empirically found on Windows 11 x64
-        Ok(()) => 512,
+        Ok(()) => {
+            // Disable USO again at the socket level so that it is only enabled per message through
+            // the `UDP_SEND_MSG_SIZE` control message. This mirrors the Linux behaviour, see:
+            // - https://github.com/quinn-rs/quinn/issues/2818
+            // - https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-udp-socket-options
+            let _ = set_socket_option(socket, WinSock::IPPROTO_UDP, WinSock::UDP_SEND_MSG_SIZE, 0);
+
+            // Empirically found on Windows 11 x64
+            512
+        }
         Err(_) => 1,
     }
 }

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -217,6 +217,28 @@ fn gso() {
     );
 }
 
+/// A single datagram larger than the segment size used to probe for GSO support must be
+/// delivered as one datagram. The probe must not leave segmentation enabled on the socket.
+#[test]
+fn large_single_datagram_is_not_segmented() {
+    let send = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let recv = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let dst_addr = recv.local_addr().unwrap();
+    // Larger than the 1500 byte segment size of the GSO probe.
+    let msg = vec![0xCD; 2048];
+    test_send_recv(
+        &send.into(),
+        &recv.into(),
+        Transmit {
+            destination: dst_addr,
+            ecn: None,
+            contents: &msg,
+            segment_size: None,
+            src_ip: None,
+        },
+    );
+}
+
 #[test]
 fn socket_buffers() {
     const BUFFER_SIZE: usize = 123456;


### PR DESCRIPTION
Since #2564, the Windows GSO probe sets `UDP_SEND_MSG_SIZE` to 1500 on
the caller's socket and never clears it. Winsock splits every send
without a `UDP_SEND_MSG_SIZE` control message into 1500 byte datagrams.
Reset the option to 0 after a successful probe, as #2584 did for Linux,
and add a test that sends a 2048 byte datagram and checks that it
arrives in one piece.

Fixes #2818
