### PR TITLE
fix: resolve `WSARecvMsg` per socket

### DIFF
--- a/quinn-udp/src/windows.rs
+++ b/quinn-udp/src/windows.rs
@@ -5,7 +5,7 @@ use std::{
     os::windows::io::AsRawSocket,
     ptr,
     sync::{
-        LazyLock, Mutex,
+        Mutex,
         atomic::{AtomicUsize, Ordering},
     },
     time::Instant,
@@ -37,6 +37,9 @@ pub struct UdpSocketState {
 
     /// Whether the underlying Winsock provider supports IPv6 ECN socket options/control messages.
     ecn_v6_supported: bool,
+
+    /// `WSARecvMsg`, resolved for this socket's Winsock provider.
+    wsa_recvmsg: WsaRecvMsg,
 }
 
 impl UdpSocketState {
@@ -73,12 +76,12 @@ impl UdpSocketState {
         let is_ipv4 = addr.as_socket_ipv4().is_some() || !v6only;
 
         // We don't support old versions of Windows that do not enable access to `WSARecvMsg()`
-        if WSARECVMSG_PTR.is_none() {
-            return Err(io::Error::new(
+        let wsa_recvmsg = resolve_wsa_recvmsg(&*socket.0).ok_or_else(|| {
+            io::Error::new(
                 io::ErrorKind::Unsupported,
                 "network stack does not support WSARecvMsg function",
-            ));
-        }
+            )
+        })?;
 
         // ECN is best-effort on Windows: if the Winsock provider doesn't support these options
         // (common under Wine/Proton), we disable ECN and keep working.
@@ -160,6 +163,7 @@ impl UdpSocketState {
             max_gso_segments: AtomicUsize::new(max_gso_segments(&*socket.0)),
             ecn_v4_supported,
             ecn_v6_supported,
+            wsa_recvmsg,
         })
     }
 
@@ -230,8 +234,6 @@ impl UdpSocketState {
         bufs: &mut [IoSliceMut<'_>],
         meta: &mut [RecvMeta],
     ) -> io::Result<usize> {
-        let wsa_recvmsg_ptr = WSARECVMSG_PTR.expect("valid function pointer for WSARecvMsg");
-
         // we cannot use [`socket2::MsgHdrMut`] as we do not have access to inner field which holds the WSAMSG
         let mut ctrl_buf = cmsg::Aligned([0; CMSG_LEN]);
         let mut source: WinSock::SOCKADDR_INET = unsafe { mem::zeroed() };
@@ -256,7 +258,7 @@ impl UdpSocketState {
 
         let mut len = 0;
         unsafe {
-            let rc = (wsa_recvmsg_ptr)(
+            let rc = (self.wsa_recvmsg)(
                 socket.0.as_raw_socket() as usize,
                 &mut wsa_msg,
                 &mut len,
@@ -511,31 +513,38 @@ pub(crate) const BATCH_SIZE: usize = 1;
 const CMSG_LEN: usize = 128;
 const OPTION_ON: u32 = 1;
 
-static WSARECVMSG_PTR: LazyLock<WinSock::LPFN_WSARECVMSG> = LazyLock::new(|| {
-    let s = unsafe { WinSock::socket(WinSock::AF_INET as _, WinSock::SOCK_DGRAM as _, 0) };
-    if s == WinSock::INVALID_SOCKET {
-        debug!(
-            "ignoring WSARecvMsg function pointer due to socket creation error: {}",
-            io::Error::last_os_error()
-        );
-        return None;
-    }
+/// Names the function type inside [`WinSock::LPFN_WSARECVMSG`] without restating its signature.
+trait Inner {
+    type Type;
+}
 
+impl<T> Inner for Option<T> {
+    type Type = T;
+}
+
+type WsaRecvMsg = <WinSock::LPFN_WSARECVMSG as Inner>::Type;
+
+/// Resolve `WSARecvMsg` for `socket`.
+///
+/// The pointer belongs to the Winsock provider serving `socket`, so it has to be resolved per
+/// socket: calling one provider's `WSARecvMsg` on another provider's socket crashes when a layered
+/// service provider is installed. See <https://bugzilla.mozilla.org/show_bug.cgi?id=2068899>.
+fn resolve_wsa_recvmsg(socket: &impl AsRawSocket) -> WinSock::LPFN_WSARECVMSG {
     // Detect if OS expose WSARecvMsg API based on
     // https://github.com/Azure/mio-uds-windows/blob/a3c97df82018086add96d8821edb4aa85ec1b42b/src/stdnet/ext.rs#L601
     let guid = WinSock::WSAID_WSARECVMSG;
-    let mut wsa_recvmsg_ptr = None;
+    let mut func = None;
     let mut len = 0;
 
     // Safety: Option handles the NULL pointer with a None value
     let rc = unsafe {
         WinSock::WSAIoctl(
-            s as _,
+            socket.as_raw_socket() as _,
             WinSock::SIO_GET_EXTENSION_FUNCTION_POINTER,
             &guid as *const _ as *const _,
             size_of_val(&guid) as u32,
-            &mut wsa_recvmsg_ptr as *mut _ as *mut _,
-            size_of_val(&wsa_recvmsg_ptr) as u32,
+            &mut func as *mut _ as *mut _,
+            size_of_val(&func) as u32,
             &mut len,
             ptr::null_mut(),
             None,
@@ -547,17 +556,15 @@ static WSARECVMSG_PTR: LazyLock<WinSock::LPFN_WSARECVMSG> = LazyLock::new(|| {
             "ignoring WSARecvMsg function pointer due to ioctl error: {}",
             io::Error::last_os_error()
         );
-    } else if len as usize != size_of::<WinSock::LPFN_WSARECVMSG>() {
+        return None;
+    }
+    if len as usize != size_of_val(&func) {
         debug!("ignoring WSARecvMsg function pointer due to pointer size mismatch");
-        wsa_recvmsg_ptr = None;
+        return None;
     }
 
-    unsafe {
-        WinSock::closesocket(s);
-    }
-
-    wsa_recvmsg_ptr
-});
+    func
+}
 
 fn max_gso_segments(socket: &impl AsRawSocket) -> usize {
     const GSO_SIZE: c_uint = 1500;


### PR DESCRIPTION
`SIO_GET_EXTENSION_FUNCTION_POINTER` returns a pointer owned by the Winsock provider serving the socket it is requested on, so it is only valid for that socket. With a layered service provider in the catalog, calling it on a different socket enters the provider with no context for that handle and crashes.

https://bugzilla.mozilla.org/show_bug.cgi?id=2068899