### PR TITLE
chore(udp): prepare v0.6.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "cfg_aliases",
  "criterion",

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn-udp"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Closes #2801.

What landed since `v0.6.1`:

- macOS: no longer stuck on `EWOULDBLOCK` after the `sendmsg` kernel bug (#2727)
- Linux: an `EMSGSIZE` caused by ICMP "fragmentation needed" no longer fails the send (#2736)
- musl: cmsg payloads read unaligned, `cmsg_len` compared as `usize` (#2750)
- Windows: USO disabled after GSO probing (#2824), no panic in `UdpSocketState::new` on an unbound socket (#2821), `WSARecvMsg` resolved per socket (#2825)
- new: opt-in transport error reception on Linux/Android (#2765), kernel receive timestamps (#2634), wasm32-wasip2 support (#2755)
- `UdpSocketState::send` is deprecated in favour of `try_send`

Full range: https://github.com/quinn-rs/quinn/compare/quinn-udp-0.6.1...main

#2755 dropped the no-op fallback backend, so targets that are neither Unix, Windows, WASI nor wasm32-unknown-unknown no longer build. Should this be a breaking change instead?