### PR TITLE
refactor: Inline `get_or_insert_send` and de-curry `get_or_insert_recv`

### DIFF
--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -134,7 +134,7 @@ impl RecvStream<'_> {
             hash_map::Entry::Occupied(s) => s,
             hash_map::Entry::Vacant(_) => return Err(ClosedStream { _private: () }),
         };
-        let stream = get_or_insert_recv(self.state.stream_receive_window)(entry.get_mut());
+        let stream = get_or_insert_recv(entry.get_mut(), self.state.stream_receive_window);
 
         let (read_credits, stop_sending) = stream.stop()?;
         if stop_sending.should_transmit() {

--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -8,11 +8,7 @@ use thiserror::Error;
 use tracing::trace;
 
 use super::spaces::{Retransmits, ThinRetransmits};
-use crate::{
-    Dir, StreamId, VarInt,
-    connection::streams::state::{get_or_insert_recv, get_or_insert_send},
-    frame,
-};
+use crate::{Dir, StreamId, VarInt, connection::streams::state::get_or_insert_recv, frame};
 
 mod recv;
 use recv::Recv;
@@ -248,7 +244,7 @@ impl<'a> SendStream<'a> {
             .state
             .send
             .get_mut(&self.id)
-            .map(get_or_insert_send(max_send_data))
+            .map(|opt| opt.get_or_insert_with(|| Send::new(max_send_data)))
             .ok_or(WriteError::ClosedStream)?;
 
         if limit == 0 {
@@ -294,7 +290,7 @@ impl<'a> SendStream<'a> {
             .state
             .send
             .get_mut(&self.id)
-            .map(get_or_insert_send(max_send_data))
+            .map(|opt| opt.get_or_insert_with(|| Send::new(max_send_data)))
             .ok_or(FinishError::ClosedStream)?;
 
         let was_pending = stream.is_pending();
@@ -316,7 +312,7 @@ impl<'a> SendStream<'a> {
             .state
             .send
             .get_mut(&self.id)
-            .map(get_or_insert_send(max_send_data))
+            .map(|opt| opt.get_or_insert_with(|| Send::new(max_send_data)))
             .ok_or(ClosedStream { _private: () })?;
 
         if matches!(stream.state, SendState::ResetSent) {
@@ -345,7 +341,7 @@ impl<'a> SendStream<'a> {
             .state
             .send
             .get_mut(&self.id)
-            .map(get_or_insert_send(max_send_data))
+            .map(|opt| opt.get_or_insert_with(|| Send::new(max_send_data)))
             .ok_or(ClosedStream { _private: () })?;
 
         stream.priority = priority;

--- a/quinn-proto/src/connection/streams/recv.rs
+++ b/quinn-proto/src/connection/streams/recv.rs
@@ -266,7 +266,7 @@ impl<'a> Chunks<'a> {
         };
 
         let mut recv =
-            match get_or_insert_recv(streams.stream_receive_window)(entry.get_mut()).stopped {
+            match get_or_insert_recv(entry.get_mut(), streams.stream_receive_window).stopped {
                 true => return Err(ReadableError::ClosedStream),
                 false => entry.remove().unwrap().into_inner(), // this can't fail due to the previous get_or_insert_with
             };

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -266,7 +266,7 @@ impl StreamsState {
         let Some(rs) = self
             .recv
             .get_mut(&id)
-            .map(get_or_insert_recv(self.stream_receive_window))
+            .map(|opt| get_or_insert_recv(opt, self.stream_receive_window))
         else {
             trace!("dropping frame for closed stream");
             return Ok(ShouldTransmit(false));
@@ -316,7 +316,7 @@ impl StreamsState {
         let Some(rs) = self
             .recv
             .get_mut(&id)
-            .map(get_or_insert_recv(self.stream_receive_window))
+            .map(|opt| get_or_insert_recv(opt, self.stream_receive_window))
         else {
             trace!("received RESET_STREAM on closed stream");
             return Ok(ShouldTransmit(false));
@@ -971,18 +971,14 @@ impl StreamsState {
 }
 
 #[inline]
-pub(super) fn get_or_insert_recv(
-    initial_max_data: u64,
-) -> impl FnMut(&mut Option<StreamRecv>) -> &mut Recv {
-    move |opt| {
-        *opt = opt.take().map(|s| match s {
-            StreamRecv::Free(recv) => StreamRecv::Open(recv),
-            s => s,
-        });
-        opt.get_or_insert_with(|| StreamRecv::Open(Recv::new(initial_max_data)))
-            .as_open_recv_mut()
-            .unwrap()
-    }
+pub(super) fn get_or_insert_recv(opt: &mut Option<StreamRecv>, initial_max_data: u64) -> &mut Recv {
+    *opt = opt.take().map(|s| match s {
+        StreamRecv::Free(recv) => StreamRecv::Open(recv),
+        s => s,
+    });
+    opt.get_or_insert_with(|| StreamRecv::Open(Recv::new(initial_max_data)))
+        .as_open_recv_mut()
+        .unwrap()
 }
 
 #[cfg(test)]

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -361,7 +361,7 @@ impl StreamsState {
         let Some(stream) = self
             .send
             .get_mut(&id)
-            .map(get_or_insert_send(max_send_data))
+            .map(|opt| opt.get_or_insert_with(|| Send::new(max_send_data)))
         else {
             return;
         };
@@ -755,7 +755,7 @@ impl StreamsState {
         if let Some(ss) = self
             .send
             .get_mut(&id)
-            .map(get_or_insert_send(max_send_data))
+            .map(|opt| opt.get_or_insert_with(|| Send::new(max_send_data)))
         {
             if ss.increase_max_data(offset) {
                 if write_limit > 0 {
@@ -968,13 +968,6 @@ impl StreamsState {
             Dir::Bi => self.initial_max_stream_data_bidi_remote,
         }
     }
-}
-
-#[inline]
-pub(super) fn get_or_insert_send(
-    max_data: VarInt,
-) -> impl Fn(&mut Option<Box<Send>>) -> &mut Box<Send> {
-    move |opt| opt.get_or_insert_with(|| Send::new(max_data))
 }
 
 #[inline]


### PR DESCRIPTION
See individual commits.

`get_or_insert_send` and `get_or_insert_recv` are two functions which return closures out of an attempt to work well with `map` calls, but I think this just makes things pretty confusing, and the former is also trivially small. Inlines and removes the former, removes the closuring from the second.