### PR TITLE
refactor(proto): Remove superfluous map calls

### DIFF
--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -244,8 +244,8 @@ impl<'a> SendStream<'a> {
             .state
             .send
             .get_mut(&self.id)
-            .map(|opt| opt.get_or_insert_with(|| Send::new(max_send_data)))
-            .ok_or(WriteError::ClosedStream)?;
+            .ok_or(WriteError::ClosedStream)?
+            .get_or_insert_with(|| Send::new(max_send_data));
 
         if limit == 0 {
             trace!(
@@ -290,8 +290,8 @@ impl<'a> SendStream<'a> {
             .state
             .send
             .get_mut(&self.id)
-            .map(|opt| opt.get_or_insert_with(|| Send::new(max_send_data)))
-            .ok_or(FinishError::ClosedStream)?;
+            .ok_or(FinishError::ClosedStream)?
+            .get_or_insert_with(|| Send::new(max_send_data));
 
         let was_pending = stream.is_pending();
         stream.finish()?;
@@ -312,8 +312,8 @@ impl<'a> SendStream<'a> {
             .state
             .send
             .get_mut(&self.id)
-            .map(|opt| opt.get_or_insert_with(|| Send::new(max_send_data)))
-            .ok_or(ClosedStream { _private: () })?;
+            .ok_or(ClosedStream { _private: () })?
+            .get_or_insert_with(|| Send::new(max_send_data));
 
         if matches!(stream.state, SendState::ResetSent) {
             // Redundant reset call
@@ -341,8 +341,8 @@ impl<'a> SendStream<'a> {
             .state
             .send
             .get_mut(&self.id)
-            .map(|opt| opt.get_or_insert_with(|| Send::new(max_send_data)))
-            .ok_or(ClosedStream { _private: () })?;
+            .ok_or(ClosedStream { _private: () })?
+            .get_or_insert_with(|| Send::new(max_send_data));
 
         stream.priority = priority;
         Ok(())

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -358,13 +358,10 @@ impl StreamsState {
     #[allow(unreachable_pub)] // fuzzing only
     pub fn received_stop_sending(&mut self, id: StreamId, error_code: VarInt) {
         let max_send_data = self.max_send_data(id);
-        let Some(stream) = self
-            .send
-            .get_mut(&id)
-            .map(|opt| opt.get_or_insert_with(|| Send::new(max_send_data)))
-        else {
+        let Some(stream_opt) = self.send.get_mut(&id) else {
             return;
         };
+        let stream = stream_opt.get_or_insert_with(|| Send::new(max_send_data));
 
         if stream.try_stop(error_code) {
             self.events
@@ -752,11 +749,8 @@ impl StreamsState {
 
         let write_limit = self.write_limit();
         let max_send_data = self.max_send_data(id);
-        if let Some(ss) = self
-            .send
-            .get_mut(&id)
-            .map(|opt| opt.get_or_insert_with(|| Send::new(max_send_data)))
-        {
+        if let Some(ss_opt) = self.send.get_mut(&id) {
+            let ss = ss_opt.get_or_insert_with(|| Send::new(max_send_data));
             if ss.increase_max_data(offset) {
                 if write_limit > 0 {
                     self.events.push_back(StreamEvent::Writable { id });


### PR DESCRIPTION
Related to 210d79ed5df723a5ac395a2fa5b7fdddcad9a9b8, we have a number of places where we call `StreamsState.send.get_mut`, then call `map` on the resultant `Option`, then short-circuit if the `Option` is `None`. This can be simplified by short-circuiting first, then performing the logic within the map plainly.
