### PR TITLE
proto: reject transport parameters with a mismatched length

### DIFF
--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -436,6 +436,8 @@ impl TransportParameters {
                 continue;
             };
 
+            let remaining_before = r.remaining();
+
             match id {
                 TransportParameterId::OriginalDestinationConnectionId => {
                     decode_cid(len, &mut params.original_dst_cid, r)?
@@ -493,6 +495,10 @@ impl TransportParameters {
                     }
                     apply_params!(parse);
                 }
+            }
+
+            if remaining_before - r.remaining() != len {
+                return Err(Error::Malformed);
             }
         }
 
@@ -864,6 +870,62 @@ mod test {
                 Err(Error::IllegalValue)
             );
         }
+    }
+
+    #[test]
+    fn read_length_mismatch() {
+        // `max_datagram_frame_size` claims three bytes of value but encodes a one-byte `VarInt`,
+        // so a whole `disable_active_migration` parameter fits inside its declared length.
+        let mut buf = Vec::new();
+        buf.write_var(TransportParameterId::MaxDatagramFrameSize as u64);
+        buf.write_var(3);
+        buf.write(VarInt::from_u32(0));
+        buf.write_var(TransportParameterId::DisableActiveMigration as u64);
+        buf.write_var(0);
+        assert_eq!(
+            TransportParameters::read(Side::Server, &mut buf.as_slice()),
+            Err(Error::Malformed)
+        );
+    }
+
+    #[test]
+    fn read_min_ack_delay_length_mismatch() {
+        // `min_ack_delay` claims no value at all, so its `VarInt` starts on the parameter that
+        // follows it.
+        let mut buf = Vec::new();
+        buf.write_var(TransportParameterId::MinAckDelayDraft07 as u64);
+        buf.write_var(0);
+        buf.write_var(TransportParameterId::InitialMaxData as u64);
+        buf.write_var(1);
+        buf.write(VarInt::from_u32(7));
+        assert_eq!(
+            TransportParameters::read(Side::Server, &mut buf.as_slice()),
+            Err(Error::Malformed)
+        );
+    }
+
+    #[test]
+    fn read_preferred_address_length_mismatch() {
+        // `preferred_address` has a fixed size for a given connection ID length, so bytes past
+        // that size are read as a parameter of their own.
+        let address = PreferredAddress {
+            address_v4: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 42)),
+            address_v6: None,
+            connection_id: ConnectionId::new(&[0x42]),
+            stateless_reset_token: [0xab; RESET_TOKEN_SIZE].into(),
+        };
+        let mut value = Vec::new();
+        address.write(&mut value);
+        value.write_var(TransportParameterId::DisableActiveMigration as u64);
+        value.write_var(0);
+        let mut buf = Vec::new();
+        buf.write_var(TransportParameterId::PreferredAddress as u64);
+        buf.write_var(value.len() as u64);
+        buf.extend_from_slice(&value);
+        assert_eq!(
+            TransportParameters::read(Side::Client, &mut buf.as_slice()),
+            Err(Error::Malformed)
+        );
     }
 
     #[test]


### PR DESCRIPTION
`TransportParameters::read` reads the length field of every transport parameter, but three arms of its decoding loop never check that the value actually takes up that many bytes. In `quinn-proto/src/transport_parameters.rs` on main, `PreferredAddress` (line 457) decodes a fixed number of bytes for a given connection ID length, `MaxDatagramFrameSize` (line 469) only rejects a length above 8, and `MinAckDelayDraft07` (line 479) checks nothing at all. Anything left over stays in the buffer, and the next turn of the loop decodes it as though it were the start of the next parameter. Every other arm does check, either directly or through `decode_cid`, and the macro arm rejects `len != value.size()`.

The effect is that a peer can hide a parameter it never encoded. Send `max_datagram_frame_size` with a declared length of 3 and the value bytes `00 0c 00`: the value decodes as the one-byte varint 0, and the trailing `0c 00` is a complete `disable_active_migration`. On main that byte string parses without error and comes back with `max_datagram_frame_size: Some(0)` and `disable_active_migration: true`. So the parameters quinn ends up acting on are not the ones the peer encoded.

RFC 9000 section 18 says the Transport Parameter Length field "contains the length of the Transport Parameter Value field in bytes", and section 7.4 asks for TRANSPORT_PARAMETER_ERROR on a parameter with an invalid value, which is what `Error::Malformed` maps to here.

Rather than patch the three arms one at a time, I record `r.remaining()` before the match and compare it once afterwards. That covers all three, and any arm added later gets the check for free. The new `read_length_mismatch` test builds a byte string for each of the three cases and expects `Err(Error::Malformed)`.

Verification on macOS with rustc 1.95.0: `cargo test --locked -p quinn-proto` gives 303 passed, 0 failed, plus 3 doc-tests passing. `cargo fmt --all -- --check` and `cargo clippy --locked -p quinn-proto --all-targets -- -D warnings` are both clean. To confirm the test is really testing the fix I backed the length check out and left the test in: `read_length_mismatch` then fails on the first case, reporting the parsed parameters with `disable_active_migration: true` where it expected `Err(Malformed)`.
