### PR TITLE
proto: release the send window when rejecting 0-RTT

### DIFF
--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -247,6 +247,7 @@ impl StreamsState {
         self.pending.clear();
         self.send_streams = 0;
         self.data_sent = 0;
+        self.unacked_data = 0;
         self.connection_blocked.clear();
     }
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -763,6 +763,8 @@ fn zero_rtt_rejection() {
     assert!(pair.client_conn_mut(client_ch).has_0rtt());
     let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
     const MSG: &[u8] = b"Hello, 0-RTT!";
+    pair.client_conn_mut(client_ch)
+        .set_send_window(MSG.len() as u64);
     pair.client_send(client_ch, s).write(MSG).unwrap();
     pair.drive();
     assert!(!pair.client_conn_mut(client_ch).accepted_0rtt());
@@ -788,6 +790,19 @@ fn zero_rtt_rejection() {
     assert_eq!(chunks.next(usize::MAX), Err(ReadError::Blocked));
     let _ = chunks.finalize();
     assert_eq!(pair.client_conn_mut(client_ch).stats().path.lost_packets, 0);
+
+    // Rejecting early data must release the entire send window for 1-RTT traffic.
+    assert_eq!(
+        pair.client_send(client_ch, s2).write(MSG).unwrap(),
+        MSG.len()
+    );
+    pair.client_send(client_ch, s2).finish().unwrap();
+    pair.drive();
+    let mut recv = pair.server_recv(server_ch, s2);
+    let mut chunks = recv.read(false).unwrap();
+    assert_eq!(chunks.next(usize::MAX).unwrap().unwrap().bytes, MSG);
+    assert_eq!(chunks.next(usize::MAX).unwrap(), None);
+    let _ = chunks.finalize();
 }
 
 fn test_zero_rtt_incoming_limit<F: FnOnce(&mut ServerConfig)>(configure_server: F) {


### PR DESCRIPTION
Rejecting 0-RTT discards the outgoing streams and packets but leaves their bytes in `StreamsState::unacked_data`. Those bytes keep consuming the connection's send window, so 1-RTT writes can remain blocked even after the handshake succeeds.

Reset the outstanding byte count alongside the other outgoing stream state. The existing `zero_rtt_rejection` case now fills a small send window with early data and checks that the same capacity is available for 1-RTT traffic after rejection.

Validation: formatted with rustfmt and checked with `git diff --check`. Tests and builds have not been run locally.

Draft prepared with AI assistance from an existing fork change, pending the author's review.
