### PR TITLE
quinn: refresh the endpoint sender after rebinding

### DIFF
--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -280,6 +280,7 @@ impl Endpoint {
         let addr = socket.local_addr()?;
         let mut inner = self.inner.state.lock().unwrap();
         inner.prev_socket = Some(mem::replace(&mut inner.socket, socket));
+        inner.sender = inner.socket.create_sender();
         inner.ipv6 = addr.is_ipv6();
 
         // Update connection socket references

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -689,6 +689,36 @@ fn rt_threaded() -> Runtime {
 }
 
 #[tokio::test]
+async fn retry_after_rebind() {
+    let _guard = subscribe();
+    let factory = EndpointFactory::new();
+    let server = factory.endpoint();
+    let client = factory.endpoint();
+    server
+        .rebind(UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap())
+        .unwrap();
+
+    timeout(Duration::from_secs(5), async {
+        let connecting = client
+            .connect(server.local_addr().unwrap(), "localhost")
+            .unwrap();
+        let incoming = server.accept().await.unwrap();
+        assert!(!incoming.remote_address_validated());
+        incoming.retry().unwrap();
+
+        let incoming = server.accept().await.unwrap();
+        assert!(incoming.remote_address_validated());
+        let (accepted, connected) = join!(incoming, connecting);
+        let _server_connection = accepted.unwrap();
+        let _client_connection = connected.unwrap();
+        server.close(0u32.into(), b"done");
+        client.close(0u32.into(), b"done");
+    })
+    .await
+    .expect("retried handshake must complete using the rebound socket");
+}
+
+#[tokio::test]
 async fn rebind_recv() {
     let _guard = subscribe();
 


### PR DESCRIPTION
`Endpoint::rebind_abstract` replaces the receive socket and updates existing connections, but leaves the endpoint's response sender attached to the previous socket. A Retry response therefore leaves from the old address and the retried handshake cannot complete through the rebound endpoint.

Create a new endpoint sender from the replacement socket. The included regression case rebinds a server, requests Retry and checks completion of the retried handshake.

Validation: formatted with rustfmt and checked with `git diff --check`. Tests and builds have not been run locally.

Draft prepared with AI assistance from an existing fork change, pending the author's review.
