### PR TITLE
proto: prune queued DATAGRAMs after path MTU changes

### DIFF
--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use thiserror::Error;
 use tracing::{debug, trace};
 
-use super::Connection;
+use super::{Connection, Event};
 use crate::{
     TransportError,
     frame::{Datagram, FrameStruct},
@@ -50,6 +50,21 @@ impl Datagrams<'_> {
         }
         self.conn.datagrams.outgoing.push_back(Datagram { data });
         Ok(())
+    }
+
+    /// Discard queued datagrams that no longer fit the active path, waking blocked senders.
+    pub(super) fn drop_oversized(&mut self) {
+        let Some(max_datagram_size) = self.max_size() else {
+            return;
+        };
+        if !self.conn.datagrams.drop_oversized(max_datagram_size)
+            || !self.conn.datagrams.send_blocked
+        {
+            return;
+        }
+
+        self.conn.datagrams.send_blocked = false;
+        self.conn.events.push_back(Event::DatagramsUnblocked);
     }
 
     /// Compute the maximum size of datagrams that may passed to `send_datagram`

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -174,7 +174,7 @@ impl DatagramState {
     pub(super) fn drop_oversized(&mut self, max_payload: usize) -> bool {
         let mut dropped_any = false;
         self.outgoing.queue.retain(|datagram| {
-            let result = datagram.data.len() < max_payload;
+            let result = datagram.data.len() <= max_payload;
             if !result {
                 trace!(
                     "dropping {} byte datagram violating {} byte limit",
@@ -302,6 +302,23 @@ mod tests {
                 break;
             }
         }
+    }
+
+    #[test]
+    fn drop_oversized_keeps_datagrams_at_limit() {
+        let mut state = DatagramState::default();
+        state.outgoing.push_back(Datagram {
+            data: Bytes::from_static(&[0; 10]),
+        });
+        state.outgoing.push_back(Datagram {
+            data: Bytes::from_static(&[0; 11]),
+        });
+
+        assert!(state.drop_oversized(10));
+
+        assert_eq!(state.outgoing.queue.len(), 1);
+        assert_eq!(state.outgoing.queue[0].data.len(), 10);
+        assert_eq!(state.outgoing.payload_bytes, 10);
     }
 }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1878,13 +1878,7 @@ impl Connection {
                 self.path
                     .congestion
                     .on_mtu_update(self.path.mtud.current_mtu());
-                if let Some(max_datagram_size) = self.datagrams().max_size()
-                    && self.datagrams.drop_oversized(max_datagram_size)
-                    && self.datagrams.send_blocked
-                {
-                    self.datagrams.send_blocked = false;
-                    self.events.push_back(Event::DatagramsUnblocked);
-                }
+                self.datagrams().drop_oversized();
             }
 
             // Don't apply congestion penalty for lost ack-only packets

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1454,6 +1454,7 @@ impl Connection {
     /// configuration in the [`TransportConfig`].
     pub fn path_changed(&mut self, now: Instant) {
         self.path.reset(now, &self.config);
+        self.datagrams().drop_oversized();
     }
 
     /// Modify the number of remotely initiated streams that may be concurrently open
@@ -3169,6 +3170,7 @@ impl Connection {
         let prev_pto = self.pto(SpaceId::Data);
 
         let mut prev = mem::replace(&mut self.path, new_path);
+        self.datagrams().drop_oversized();
         self.events.push_back(Event::PathUpdated);
 
         // Don't clobber the original path if the previous one hasn't been validated yet

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     convert::TryInto,
-    mem,
+    iter, mem,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::{Arc, Mutex},
 };
@@ -80,9 +80,7 @@ fn pending_incoming_survives_server_config_change() {
         pair.drive();
         for (endpoint, ch) in [(&mut pair.client, client_ch), (&mut pair.server, server_ch)] {
             let conn = endpoint.connections.get_mut(&ch).unwrap();
-            assert!(
-                std::iter::from_fn(|| conn.poll()).any(|event| matches!(event, Event::Connected))
-            );
+            assert!(iter::from_fn(|| conn.poll()).any(|event| matches!(event, Event::Connected)));
         }
     }
 }
@@ -108,7 +106,7 @@ fn pending_incoming_can_retry_after_disabling_server() {
     pair.drive();
     pair.server.assert_accept();
     assert!(
-        std::iter::from_fn(|| pair.client_conn_mut(client_ch).poll())
+        iter::from_fn(|| pair.client_conn_mut(client_ch).poll())
             .any(|event| matches!(event, Event::Connected))
     );
 }
@@ -4160,6 +4158,74 @@ fn ack_bundled_with_datagrams() {
         pair.server_conn_mut(server_ch).stats().frame_tx.acks,
         "server should not sent ACK frames"
     );
+}
+
+#[test]
+fn path_changes_unblock_oversized_datagrams() {
+    let _guard = subscribe();
+    for migrate in [false, true] {
+        let mut pair = Pair::default();
+        let (client_ch, server_ch) = pair.connect();
+        pair.drive();
+        let old_max = pair.server_datagrams(server_ch).max_size().unwrap();
+        assert!(old_max > 1200);
+        let empty_space = pair.server_datagrams(server_ch).send_buffer_space();
+        let data = Bytes::from(vec![42; old_max]);
+        loop {
+            match pair.server_datagrams(server_ch).send(data.clone(), false) {
+                Ok(()) => {}
+                Err(SendDatagramError::Blocked(_)) => break,
+                Err(error) => panic!("unexpected send error: {error}"),
+            }
+        }
+        while pair.server_conn_mut(server_ch).poll().is_some() {}
+
+        pair.mtu = 1200;
+        if migrate {
+            pair.client
+                .addr
+                .set_port(CLIENT_PORTS.lock().unwrap().next().unwrap());
+            pair.client_conn_mut(client_ch).ping();
+            pair.drive_client();
+            // Process migration without transmitting, so sends cannot free the buffer first.
+            let mut buf = Vec::new();
+            while let Some((received, ecn, packet)) = pair.server.inbound.pop_front() {
+                let Some(DatagramEvent::ConnectionEvent(ch, event)) =
+                    pair.server
+                        .handle(received, pair.client.addr, None, ecn, packet, &mut buf)
+                else {
+                    panic!("expected a connection event");
+                };
+                assert_eq!(ch, server_ch);
+                pair.server_conn_mut(ch).handle_event(event);
+            }
+            assert_eq!(
+                pair.server_conn_mut(server_ch).remote_address(),
+                pair.client.addr
+            );
+        } else {
+            let now = pair.time;
+            pair.server_conn_mut(server_ch).path_changed(now);
+        }
+
+        assert!(pair.server_datagrams(server_ch).max_size().unwrap() < old_max);
+        assert_eq!(
+            pair.server_datagrams(server_ch).send_buffer_space(),
+            empty_space
+        );
+        assert!(
+            iter::from_fn(|| pair.server_conn_mut(server_ch).poll())
+                .any(|event| matches!(event, Event::DatagramsUnblocked))
+        );
+
+        let small = Bytes::from_static(b"small");
+        pair.server_datagrams(server_ch)
+            .send(small.clone(), false)
+            .unwrap();
+        pair.drive();
+        assert_eq!(pair.client_datagrams(client_ch).recv(), Some(small));
+        assert_eq!(pair.client_datagrams(client_ch).recv(), None);
+    }
 }
 
 /// Verify that dropping oversized datagrams will trigger a DatagramsUnblocked event.


### PR DESCRIPTION
Queued DATAGRAMs can stop fitting after `path_changed` or migration resets the path MTU. Cleanup currently runs only after MTU black-hole detection, leaving those payloads at the front of the queue and senders waiting for buffer space.

This PR also runs cleanup after an explicit path reset or migration, wakes blocked senders when queued datagrams are dropped, and preserves payloads that exactly match the maximum allowed size.

The three commits separate the cleanup refactor, the payload-limit correction, and the path-change handling. Regression tests cover the exact limit, queue capacity, sender notification, and delivery of a smaller DATAGRAM after both a path reset and migration. The migration test delivers packets inline before polling server transmits, so its assertions observe the cleanup before sending can free buffer space.

Validation:

- `cargo test --locked -p quinn-proto`: 306 unit tests and 3 documentation tests passed.
- `cargo clippy --locked -p quinn-proto --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.

Prepared with AI assistance.
