### PR TITLE
proto: reset pacing state when resetting a path

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1444,7 +1444,7 @@ impl Connection {
     /// Resets path-specific settings.
     ///
     /// This will force-reset several subsystems related to a specific network path.
-    /// Currently this is the congestion controller, round-trip estimator, and the MTU
+    /// Currently this is the congestion controller, round-trip estimator, pacer, and MTU
     /// discovery.
     ///
     /// This is useful when it is known the underlying network path has changed and the old

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -143,7 +143,7 @@ impl PathData {
         }
     }
 
-    /// Resets RTT, congestion control and MTU states.
+    /// Resets RTT, congestion control, pacing and MTU states.
     ///
     /// This is useful when it is known the underlying path has changed.
     pub(super) fn reset(&mut self, now: Instant, config: &TransportConfig) {
@@ -153,6 +153,13 @@ impl PathData {
             .clone()
             .build(now, config.get_initial_mtu());
         self.mtud.reset(config.get_initial_mtu(), config.min_mtu);
+        self.pacing = Pacer::new(
+            self.rtt.get(),
+            self.congestion.initial_window(),
+            self.current_mtu(),
+            config.max_outgoing_bytes_per_second,
+            now,
+        );
     }
 
     /// Indicates whether we're a server that hasn't validated the peer's address and hasn't
@@ -465,5 +472,49 @@ impl InFlight {
     fn remove(&mut self, packet: &SentPacket) {
         self.bytes -= u64::from(packet.size);
         self.ack_eliciting -= u64::from(packet.ack_eliciting);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reset_refreshes_pacer_budget() {
+        let now = Instant::now();
+        let config = TransportConfig::default();
+        let remote = "203.0.113.1:4433".parse().unwrap();
+        let mut path = PathData::new(remote, true, None, 0, now, &config);
+        let mtu = path.current_mtu();
+        let window = path.congestion.window();
+
+        for _ in 0..1000 {
+            if path
+                .pacing
+                .delay(path.rtt.get(), mtu.into(), mtu, window, now)
+                .is_some()
+            {
+                break;
+            }
+            path.pacing.on_transmit(mtu);
+        }
+        assert!(
+            path.pacing
+                .delay(path.rtt.get(), mtu.into(), mtu, window, now)
+                .is_some()
+        );
+
+        path.reset(now, &config);
+
+        assert_eq!(
+            path.pacing.delay(
+                path.rtt.get(),
+                path.current_mtu().into(),
+                path.current_mtu(),
+                path.congestion.window(),
+                now
+            ),
+            None
+        );
     }
 }


### PR DESCRIPTION
`Connection::path_changed` resets RTT, congestion control and MTU state, but the pacer keeps its previous token budget and timestamp. An exhausted budget can therefore continue delaying traffic after an explicit path reset.

Recreate the pacer using the reset path's initial values and preserve the configured rate limit. The included regression case exhausts the old budget and checks that resetting the path permits an immediate send.

Validation: formatted with rustfmt and checked with `git diff --check`. Tests and builds have not been run locally.

Draft prepared with AI assistance from an existing fork change, pending the author's review.
