### PR TITLE
feat: add retain_datagrams for Connection

### DIFF
--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use thiserror::Error;
 use tracing::{debug, trace};
 
-use super::Connection;
+use super::{Connection, Event};
 use crate::{
     TransportError,
     frame::{Datagram, FrameStruct},
@@ -21,8 +21,8 @@ impl Datagrams<'_> {
     /// If `drop` is true, previously queued datagrams which are still unsent may be discarded to
     /// make space for this datagram, in order of oldest to newest. If `drop` is false, and there
     /// isn't enough space due to previously queued datagrams, this function will return
-    /// `SendDatagramError::Blocked`. `Event::DatagramsUnblocked` will be emitted once datagrams
-    /// have been sent.
+    /// `SendDatagramError::Blocked`. `Event::DatagramsUnblocked` will be emitted once buffer space
+    /// becomes available.
     ///
     /// Returns `Err` iff a `len`-byte datagram cannot currently be sent.
     pub fn send(&mut self, data: Bytes, drop: bool) -> Result<(), SendDatagramError> {
@@ -50,6 +50,22 @@ impl Datagrams<'_> {
         }
         self.conn.datagrams.outgoing.push_back(Datagram { data });
         Ok(())
+    }
+
+    /// Retain only outgoing datagrams for which `f` returns `true`
+    ///
+    /// The predicate is applied in queue order to every datagram that has not yet been written into
+    /// a packet. Retained datagrams remain in their original order.
+    ///
+    /// If datagrams are removed after [`send`](Self::send) returned
+    /// [`SendDatagramError::Blocked`], an [`Event::DatagramsUnblocked`] event is emitted.
+    pub fn retain(&mut self, f: impl Fn(&Datagram) -> bool) {
+        let datagram_removed = self.conn.datagrams.outgoing.retain(f);
+
+        if datagram_removed && self.conn.datagrams.send_blocked {
+            self.conn.datagrams.send_blocked = false;
+            self.conn.events.push_back(Event::DatagramsUnblocked);
+        }
     }
 
     /// Compute the maximum size of datagrams that may passed to `send_datagram`
@@ -222,6 +238,20 @@ impl DatagramBuffer {
     fn push_front(&mut self, datagram: Datagram) {
         self.payload_bytes += datagram.data.len();
         self.queue.push_front(datagram);
+    }
+
+    fn retain(&mut self, f: impl Fn(&Datagram) -> bool) -> bool {
+        let mut payload_removed = false;
+        self.queue.retain(|d| {
+            if f(d) {
+                true
+            } else {
+                self.payload_bytes -= d.data.len();
+                payload_removed = true;
+                false
+            }
+        });
+        payload_removed
     }
 
     fn memory_used(&self) -> usize {

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -3842,6 +3842,36 @@ fn oversized_datagrams_trigger_unblock() {
 }
 
 #[test]
+fn retain_datagrams_trigger_unblock() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let (client_ch, _) = pair.connect();
+
+    // Send datagrams until the send buffer is full.
+    let max_size = pair.client_datagrams(client_ch).max_size().unwrap();
+    let data = vec![0; max_size];
+    loop {
+        match pair
+            .client_datagrams(client_ch)
+            .send(data.clone().into(), false)
+        {
+            Ok(_) => {}
+            Err(SendDatagramError::Blocked(_)) => {
+                break;
+            }
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+    }
+
+    pair.client_datagrams(client_ch).retain(|_| false);
+
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::DatagramsUnblocked)
+    );
+}
+
+#[test]
 fn reject_short_idcid() {
     let _guard = subscribe();
     let client_addr = "[::2]:7890".parse().unwrap();

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -509,6 +509,18 @@ impl Connection {
         }
     }
 
+    /// Retains only outgoing datagrams for which `f` returns `true`.
+    ///
+    /// The predicate is applied to datagrams that have not yet been written into a packet.
+    /// If this frees send buffer space, a pending [`send_datagram_wait`](Self::send_datagram_wait)
+    /// operation may proceed.
+    pub fn retain_datagrams(&self, f: impl Fn(&Bytes) -> bool) {
+        let conn = &mut *self.0.state.lock("retain_datagrams");
+
+        conn.inner.datagrams().retain(|d| f(&d.data));
+        conn.wake();
+    }
+
     /// Transmit `data` as an unreliable, unordered application datagram
     ///
     /// Unlike [`send_datagram()`], this method will wait for buffer space during congestion

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -890,6 +890,55 @@ async fn two_datagram_readers() {
 }
 
 #[tokio::test]
+async fn retain_datagrams_unblocks_waiter() {
+    let _guard = subscribe();
+    let mut config = TransportConfig::default();
+    config.datagram_send_buffer_size(250);
+    let endpoint = endpoint_with_config(config);
+
+    let (client, server) = tokio::join!(
+        endpoint
+            .connect(endpoint.local_addr().unwrap(), "localhost")
+            .unwrap(),
+        async { endpoint.accept().await.unwrap().await }
+    );
+
+    let client = client.unwrap();
+    let server = server.unwrap();
+
+    let mut cx = Context::from_waker(Waker::noop());
+
+    for tag in [0, 1] {
+        let send = server.send_datagram_wait(Bytes::from(vec![tag; 100]));
+        let mut send = pin!(send);
+        assert_eq!(send.as_mut().poll(&mut cx), Poll::Ready(Ok(())));
+    }
+
+    let send = server.send_datagram_wait(Bytes::from(vec![2; 100]));
+    let mut send = pin!(send);
+    assert!(send.as_mut().poll(&mut cx).is_pending());
+
+    server.retain_datagrams(|data| data[0] != 0);
+
+    timeout(Duration::from_secs(1), &mut send)
+        .await
+        .expect("send should be unblocked after retaining datagrams")
+        .unwrap();
+
+    let mut received = Vec::new();
+    for _ in 0..2 {
+        received.push(
+            timeout(Duration::from_secs(1), client.read_datagram())
+                .await
+                .expect("retained datagrams should arrive")
+                .unwrap()[0],
+        );
+    }
+    received.sort_unstable();
+    assert_eq!(received, [1, 2]);
+}
+
+#[tokio::test]
 async fn multiple_conns_with_zero_length_cids() {
     let _guard = subscribe();
     let mut factory = EndpointFactory::new();


### PR DESCRIPTION
closes #2283 
use VecDeque.retain to retain outgoing datagrams, and add a high level api for Connection
