### PR TITLE
Fix: update stale waker

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -271,7 +271,10 @@ impl Future for ConnectionDriver {
                 // If the connection hasn't processed all tasks, schedule it again
                 cx.waker().wake_by_ref();
             } else {
-                conn.driver = Some(cx.waker().clone());
+                match conn.driver.as_mut() {
+                    Some(old_waker) => old_waker.clone_from(cx.waker()),
+                    None => conn.driver = Some(cx.waker().clone()),
+                };
             }
             return Poll::Pending;
         }

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -394,8 +394,9 @@ impl Future for EndpointDriver {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut endpoint = self.0.state.lock().unwrap();
-        if endpoint.driver.is_none() {
-            endpoint.driver = Some(cx.waker().clone());
+        match endpoint.driver.as_mut() {
+            Some(old_waker) => old_waker.clone_from(cx.waker()),
+            None => endpoint.driver = Some(cx.waker().clone()),
         }
 
         let now = endpoint.runtime.now();


### PR DESCRIPTION
### Problem description

Polling the endpoint is supposed to update the stored `Waker` so that the driver can let the endpoint know once it can make progress.

Right now, `poll` updates the `waker` only if it has not yet been set. Hence, if it has been set in a previous invocation, the logic keeps the old `Waker` in place which may cause the `EndpointDriver` to wake a stale `Waker`.

[code](https://github.com/quinn-rs/quinn/blob/253a5543b8fc3de783ad002559ccee3f06a5995b/quinn/src/endpoint.rs#L397-L399)
```rust
if endpoint.driver.is_none() {
    endpoint.driver = Some(cx.waker().clone());
}
```

The issue can be fixed by _always_ cloning the `Waker` or using the optimized `clone_from` [method](https://doc.rust-lang.org/std/task/struct.Waker.html#method.clone_from) which clones the `Waker` only if it wakes a different task.

### Overview of changes

This PR changes the `poll` function to replace stale `waker` instances and applies the `clone_from` method as well to `EndpointDriver` to increase efficiency.

```rust
match endpoint.driver.as_mut() {
    None => endpoint.driver = Some(cx.waker().clone()),
    Some(old_waker) => old_waker.clone_from(cx.waker()),
}
```
