### PR TITLE
[0.11.x] proto: release the send window when rejecting 0-RTT

### DIFF
--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -244,6 +244,7 @@ impl StreamsState {
         self.pending.clear();
         self.send_streams = 0;
         self.data_sent = 0;
+        self.unacked_data = 0;
         self.connection_blocked.clear();
     }
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -653,6 +653,8 @@ fn zero_rtt_rejection() {
     assert!(pair.client_conn_mut(client_ch).has_0rtt());
     let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
     const MSG: &[u8] = b"Hello, 0-RTT!";
+    pair.client_conn_mut(client_ch)
+        .set_send_window(MSG.len() as u64);
     pair.client_send(client_ch, s).write(MSG).unwrap();
     pair.drive();
     assert!(!pair.client_conn_mut(client_ch).accepted_0rtt());
@@ -674,6 +676,19 @@ fn zero_rtt_rejection() {
     assert_eq!(chunks.next(usize::MAX), Err(ReadError::Blocked));
     let _ = chunks.finalize();
     assert_eq!(pair.client_conn_mut(client_ch).stats().path.lost_packets, 0);
+
+    // Rejecting early data must release the entire send window for 1-RTT traffic.
+    assert_eq!(
+        pair.client_send(client_ch, s2).write(MSG).unwrap(),
+        MSG.len()
+    );
+    pair.client_send(client_ch, s2).finish().unwrap();
+    pair.drive();
+    let mut recv = pair.server_recv(server_ch, s2);
+    let mut chunks = recv.read(false).unwrap();
+    assert_eq!(chunks.next(usize::MAX).unwrap().unwrap().bytes, MSG);
+    assert_eq!(chunks.next(usize::MAX).unwrap(), None);
+    let _ = chunks.finalize();
 }
 
 fn test_zero_rtt_incoming_limit<F: FnOnce(&mut ServerConfig)>(configure_server: F) {


### PR DESCRIPTION
Backports #2835 to `0.11.x`, as requested by @djc. This is a clean cherry-pick of `b540b030f4aca8c416142c5d86793b9d01fb2871`, preserving the original commit reference.

Rejecting 0-RTT discards the outgoing streams and packets but leaves their bytes consuming the connection's send window. Reset `unacked_data` together with the rejected stream state so 1-RTT writes can use the full send window again. The existing rejection test fills a small send window with early data, then verifies that the same capacity can be written and received after rejection.

Validation on Windows x64:

- Confirmed the regression test fails with `Blocked` when the one-line fix is removed, and passes with the fix restored.
- `cargo test --locked`: 305 passed; 4 ignored by the standard test invocation.
- `cargo test --locked -- --ignored stress`: all 3 window stress tests passed.
- `cargo +1.85 check --locked --lib -p quinn-udp -p quinn-proto -p quinn --target-dir target\msrv`: passed.
- `cargo clippy --locked -p quinn-proto --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.

