### PR TITLE
[0.11.x] Reject DATAGRAMs larger than the send buffer

### DIFF
--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -33,7 +33,10 @@ impl Datagrams<'_> {
             .max_size()
             .ok_or(SendDatagramError::UnsupportedByPeer)?;
         let send_buffer_size = self.conn.config.datagram_send_buffer_size;
-        if data.len() > max {
+        let Some(max_buffer_payload) = send_buffer_size.checked_sub(size_of::<Datagram>()) else {
+            return Err(SendDatagramError::TooLarge);
+        };
+        if data.len() > Ord::min(max, max_buffer_payload) {
             return Err(SendDatagramError::TooLarge);
         }
         if drop {

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -37,15 +37,7 @@ impl Datagrams<'_> {
             return Err(SendDatagramError::TooLarge);
         }
         if drop {
-            while self.conn.datagrams.outgoing.memory_used() > send_buffer_size {
-                let prev = self
-                    .conn
-                    .datagrams
-                    .outgoing
-                    .pop_front()
-                    .expect("datagrams.outgoing.payload_bytes desynchronized");
-                trace!(len = prev.data.len(), "dropping outgoing datagram");
-            }
+            self.conn.datagrams.make_space_for(send_buffer_size);
         } else if self.conn.datagrams.outgoing.payload_bytes + data.len() + size_of::<Datagram>()
             > send_buffer_size
         {
@@ -135,6 +127,15 @@ impl DatagramState {
 
         self.incoming.push_back(datagram);
         Ok(was_empty)
+    }
+
+    fn make_space_for(&mut self, send_buffer_size: usize) {
+        while self.outgoing.memory_used() > send_buffer_size {
+            let Some(prev) = self.outgoing.pop_front() else {
+                break;
+            };
+            trace!(len = prev.data.len(), "dropping outgoing datagram");
+        }
     }
 
     /// Discard outgoing datagrams with a payload larger than `max_payload` bytes

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -37,7 +37,9 @@ impl Datagrams<'_> {
             return Err(SendDatagramError::TooLarge);
         }
         if drop {
-            self.conn.datagrams.make_space_for(send_buffer_size);
+            self.conn
+                .datagrams
+                .make_space_for(data.len(), send_buffer_size);
         } else if !self
             .conn
             .datagrams
@@ -88,7 +90,7 @@ impl Datagrams<'_> {
         self.conn
             .config
             .datagram_send_buffer_size
-            .saturating_sub(self.conn.datagrams.outgoing.payload_bytes)
+            .saturating_sub(self.conn.datagrams.outgoing.memory_used())
             .saturating_sub(size_of::<Datagram>())
     }
 }
@@ -131,8 +133,8 @@ impl DatagramState {
         Ok(was_empty)
     }
 
-    fn make_space_for(&mut self, send_buffer_size: usize) {
-        while self.outgoing.memory_used() > send_buffer_size {
+    fn make_space_for(&mut self, datagram_len: usize, send_buffer_size: usize) {
+        while !self.has_send_buffer_space(datagram_len, send_buffer_size) {
             let Some(prev) = self.outgoing.pop_front() else {
                 break;
             };
@@ -141,7 +143,16 @@ impl DatagramState {
     }
 
     fn has_send_buffer_space(&self, datagram_len: usize, send_buffer_size: usize) -> bool {
-        self.outgoing.payload_bytes + datagram_len + size_of::<Datagram>() <= send_buffer_size
+        let Some(total) = self
+            .outgoing
+            .memory_used()
+            .checked_add(datagram_len)
+            .and_then(|total| total.checked_add(size_of::<Datagram>()))
+        else {
+            return false;
+        };
+
+        total <= send_buffer_size
     }
 
     /// Discard outgoing datagrams with a payload larger than `max_payload` bytes
@@ -225,6 +236,62 @@ impl DatagramBuffer {
 
     pub(super) fn is_empty(&self) -> bool {
         self.queue.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn make_space_for_accounts_for_new_datagram() {
+        let mut state = DatagramState::default();
+        state.outgoing.push_back(Datagram {
+            data: Bytes::from_static(&[0; 7]),
+        });
+        state.outgoing.push_back(Datagram {
+            data: Bytes::from_static(&[0; 2]),
+        });
+        state.make_space_for(4, 10 + 2 * size_of::<Datagram>());
+
+        assert_eq!(state.outgoing.queue.len(), 1);
+        assert_eq!(state.outgoing.queue[0].data.len(), 2);
+        assert_eq!(state.outgoing.payload_bytes, 2);
+    }
+
+    #[test]
+    fn make_space_for_handles_overflowing_capacity_check() {
+        let mut state = DatagramState::default();
+        state.outgoing.queue.push_back(Datagram {
+            data: Bytes::from_static(&[0]),
+        });
+        state.outgoing.payload_bytes = usize::MAX - 1;
+
+        state.make_space_for(2, usize::MAX);
+
+        assert!(state.outgoing.is_empty());
+        assert_eq!(state.outgoing.payload_bytes, usize::MAX - 2);
+    }
+
+    #[test]
+    fn make_space_for_accounts_for_empty_datagram_metadata() {
+        let mut state = DatagramState::default();
+        for _ in 0..2 {
+            state.outgoing.push_back(Datagram { data: Bytes::new() });
+        }
+        let window = 2 * size_of::<Datagram>();
+
+        assert!(!state.has_send_buffer_space(0, window));
+        state.make_space_for(0, window);
+        assert_eq!(state.outgoing.queue.len(), 1);
+        assert!(state.has_send_buffer_space(0, window));
+        state.outgoing.push_back(Datagram { data: Bytes::new() });
+        assert_eq!(state.outgoing.memory_used(), window);
+    }
+
+    #[test]
+    fn send_buffer_space_handles_metadata_overflow() {
+        assert!(!DatagramState::default().has_send_buffer_space(usize::MAX, usize::MAX));
     }
 }
 

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -38,8 +38,10 @@ impl Datagrams<'_> {
         }
         if drop {
             self.conn.datagrams.make_space_for(send_buffer_size);
-        } else if self.conn.datagrams.outgoing.payload_bytes + data.len() + size_of::<Datagram>()
-            > send_buffer_size
+        } else if !self
+            .conn
+            .datagrams
+            .has_send_buffer_space(data.len(), send_buffer_size)
         {
             self.conn.datagrams.send_blocked = true;
             return Err(SendDatagramError::Blocked(data));
@@ -136,6 +138,10 @@ impl DatagramState {
             };
             trace!(len = prev.data.len(), "dropping outgoing datagram");
         }
+    }
+
+    fn has_send_buffer_space(&self, datagram_len: usize, send_buffer_size: usize) -> bool {
+        self.outgoing.payload_bytes + datagram_len + size_of::<Datagram>() <= send_buffer_size
     }
 
     /// Discard outgoing datagrams with a payload larger than `max_payload` bytes

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -32,13 +32,12 @@ impl Datagrams<'_> {
         let max = self
             .max_size()
             .ok_or(SendDatagramError::UnsupportedByPeer)?;
+        let send_buffer_size = self.conn.config.datagram_send_buffer_size;
         if data.len() > max {
             return Err(SendDatagramError::TooLarge);
         }
         if drop {
-            while self.conn.datagrams.outgoing.memory_used()
-                > self.conn.config.datagram_send_buffer_size
-            {
+            while self.conn.datagrams.outgoing.memory_used() > send_buffer_size {
                 let prev = self
                     .conn
                     .datagrams
@@ -48,7 +47,7 @@ impl Datagrams<'_> {
                 trace!(len = prev.data.len(), "dropping outgoing datagram");
             }
         } else if self.conn.datagrams.outgoing.payload_bytes + data.len() + size_of::<Datagram>()
-            > self.conn.config.datagram_send_buffer_size
+            > send_buffer_size
         {
             self.conn.datagrams.send_blocked = true;
             return Err(SendDatagramError::Blocked(data));

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -2021,6 +2021,108 @@ fn datagram_send_buffer_space_preserves_queued_datagrams() {
 }
 
 #[test]
+fn datagram_larger_than_send_buffer_is_too_large() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let mut client_config = client_config();
+    let mut transport_config = TransportConfig::default();
+    transport_config.datagram_send_buffer_size(1 + size_of::<Datagram>());
+    client_config.transport_config(transport_config.into());
+    let (client_ch, _) = pair.connect_with(client_config);
+
+    assert_matches!(
+        pair.client_datagrams(client_ch)
+            .send(Bytes::from_static(&[0; 2]), true),
+        Err(SendDatagramError::TooLarge)
+    );
+    assert_matches!(
+        pair.client_datagrams(client_ch)
+            .send(Bytes::from_static(&[0; 2]), false),
+        Err(SendDatagramError::TooLarge)
+    );
+}
+
+#[test]
+fn datagram_send_buffer_metadata_boundaries() {
+    let _guard = subscribe();
+    for window in [
+        0,
+        size_of::<Datagram>() - 1,
+        size_of::<Datagram>(),
+        size_of::<Datagram>() + 1,
+    ] {
+        for drop in [true, false] {
+            let mut pair = Pair::default();
+            let mut client_config = client_config();
+            let mut transport_config = TransportConfig::default();
+            transport_config.datagram_send_buffer_size(window);
+            client_config.transport_config(transport_config.into());
+            let (client_ch, server_ch) = pair.connect_with(client_config);
+
+            let Some(payload_capacity) = window.checked_sub(size_of::<Datagram>()) else {
+                assert_matches!(
+                    pair.client_datagrams(client_ch).send(Bytes::new(), drop),
+                    Err(SendDatagramError::TooLarge)
+                );
+                continue;
+            };
+
+            // An exact fit succeeds, and rejecting a larger datagram preserves the queued one.
+            let data = Bytes::from(vec![0xAB; payload_capacity]);
+            pair.client_datagrams(client_ch)
+                .send(data.clone(), drop)
+                .unwrap();
+            assert_matches!(
+                pair.client_datagrams(client_ch)
+                    .send(vec![0; payload_capacity + 1].into(), drop),
+                Err(SendDatagramError::TooLarge)
+            );
+            pair.drive();
+            assert_eq!(pair.server_datagrams(server_ch).recv(), Some(data));
+            assert_matches!(pair.server_datagrams(server_ch).recv(), None);
+        }
+    }
+}
+
+#[test]
+fn datagram_send_buffer_blocks_until_drained() {
+    let _guard = subscribe();
+    const LEN: usize = 4;
+    let mut pair = Pair::default();
+    let mut client_config = client_config();
+    let mut transport_config = TransportConfig::default();
+    transport_config.datagram_send_buffer_size(2 * (LEN + size_of::<Datagram>()));
+    client_config.transport_config(transport_config.into());
+    let (client_ch, server_ch) = pair.connect_with(client_config);
+
+    for i in 0..2u8 {
+        pair.client_datagrams(client_ch)
+            .send(vec![i; LEN].into(), false)
+            .unwrap();
+    }
+    let data = Bytes::from_static(&[2; LEN]);
+    assert_eq!(
+        pair.client_datagrams(client_ch).send(data.clone(), false),
+        Err(SendDatagramError::Blocked(data.clone()))
+    );
+    pair.drive();
+    for i in 0..2u8 {
+        assert_eq!(
+            pair.server_datagrams(server_ch).recv().unwrap(),
+            vec![i; LEN]
+        );
+    }
+    assert_matches!(pair.server_datagrams(server_ch).recv(), None);
+
+    pair.client_datagrams(client_ch)
+        .send(data.clone(), false)
+        .unwrap();
+    pair.drive();
+    assert_eq!(pair.server_datagrams(server_ch).recv(), Some(data));
+    assert_matches!(pair.server_datagrams(server_ch).recv(), None);
+}
+
+#[test]
 fn datagram_unsupported() {
     let _guard = subscribe();
     let server = ServerConfig {

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1979,11 +1979,43 @@ fn datagram_send_buffer_overflow() {
         pair.server_conn_mut(server_ch).poll(),
         Some(Event::DatagramReceived)
     );
-    for i in 7..10u8 {
+    // The window holds two datagrams, including their metadata.
+    for i in 8..10u8 {
         assert_eq!(
             pair.server_datagrams(server_ch).recv().unwrap(),
             vec![i; LEN]
         );
+    }
+    assert_matches!(pair.server_datagrams(server_ch).recv(), None);
+}
+
+#[test]
+fn datagram_send_buffer_space_preserves_queued_datagrams() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let mut client_config = client_config();
+    let mut transport_config = TransportConfig::default();
+    transport_config.datagram_send_buffer_size(100 + 3 * size_of::<Datagram>());
+    client_config.transport_config(transport_config.into());
+    let (client_ch, server_ch) = pair.connect_with(client_config);
+
+    let first = Bytes::from_static(&[1; 7]);
+    let second = Bytes::from_static(&[2; 2]);
+    for data in [&first, &second] {
+        pair.client_datagrams(client_ch)
+            .send(data.clone(), true)
+            .unwrap();
+    }
+    let available = pair.client_datagrams(client_ch).send_buffer_space();
+    assert!(available > 0);
+    let third = Bytes::from(vec![3; available]);
+    pair.client_datagrams(client_ch)
+        .send(third.clone(), true)
+        .unwrap();
+    pair.drive();
+
+    for data in [first, second, third] {
+        assert_eq!(pair.server_datagrams(server_ch).recv(), Some(data));
     }
     assert_matches!(pair.server_datagrams(server_ch).recv(), None);
 }


### PR DESCRIPTION
Backports #2626 to `0.11.x`, preserving the five reviewed commits and their original commit references.

Reject DATAGRAMs that cannot fit in the send buffer with `TooLarge` in both send modes, and account for the incoming DATAGRAM before evicting queued data. The release branch already uses `DatagramBuffer` and includes metadata in its memory limit, so this backport adapts the original changes to that accounting: capacity checks include existing and incoming metadata, oversized checks reserve metadata space, and `send_buffer_space()` reports capacity that can actually be used without evicting older datagrams. Queue removal continues to use `DatagramBuffer::pop_front()`, preserving the accounting fix from #2806.

The original regressions are adapted to the release branch, with additional coverage for metadata-only buffers, exact fits, empty DATAGRAMs, arithmetic overflow, blocked sends recovering after drainage, and the reported-buffer-space guarantee. The existing eviction regression now expects the last two datagrams, which are the ones that fit with their metadata.

Validation on Windows x64:

- The unchanged release implementation fails four DATAGRAM integration regressions; the completed backport passes all 17 DATAGRAM tests.
- Confirmed separately that leaving the old `send_buffer_space()` calculation in place causes queued DATAGRAMs to be evicted despite its guarantee; the adapted calculation passes the regression.
- `cargo test --locked`: 313 passed, 4 ignored by the standard test invocation.
- `cargo +1.85 check --locked --lib -p quinn-udp -p quinn-proto -p quinn`: passed.
- `cargo clippy --locked -p quinn-proto --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.

