### PR TITLE
proto: send DATA_BLOCKED and STREAM_DATA_BLOCKED when blocked by flow control

### DIFF
--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -329,6 +329,7 @@ pub struct Retransmits {
     pub(super) reset_stream: Vec<(StreamId, VarInt)>,
     pub(super) stop_sending: Vec<frame::StopSending>,
     pub(super) max_stream_data: FxHashSet<StreamId>,
+    pub(super) stream_data_blocked: FxHashSet<StreamId>,
     pub(super) crypto: VecDeque<frame::Crypto>,
     pub(super) new_cids: Vec<IssuedCid>,
     pub(super) retire_cids: Vec<u64>,
@@ -378,6 +379,10 @@ impl Retransmits {
                 .max_stream_data
                 .iter()
                 .all(|&id| !streams.can_send_flow_control(id))
+            && self
+                .stream_data_blocked
+                .iter()
+                .all(|&id| streams.stream_data_blocked_limit(id).is_none())
             && self.crypto.is_empty()
             && self.new_cids.is_empty()
             && self.retire_cids.is_empty()
@@ -405,6 +410,7 @@ impl ::std::ops::BitOrAssign for Retransmits {
         self.reset_stream.extend_from_slice(&rhs.reset_stream);
         self.stop_sending.extend_from_slice(&rhs.stop_sending);
         self.max_stream_data.extend(&rhs.max_stream_data);
+        self.stream_data_blocked.extend(&rhs.stream_data_blocked);
         for crypto in rhs.crypto.into_iter().rev() {
             self.crypto.push_front(crypto);
         }

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -323,6 +323,7 @@ pub(super) struct LostPacket {
 #[derive(Debug, Default, Clone)]
 pub struct Retransmits {
     pub(super) max_data: bool,
+    pub(super) data_blocked: bool,
     pub(super) max_stream_id: [bool; 2],
     pub(super) streams_blocked: [bool; 2],
     pub(super) reset_stream: Vec<(StreamId, VarInt)>,
@@ -368,6 +369,7 @@ impl Retransmits {
 
     pub(super) fn is_empty(&self, streams: &StreamsState) -> bool {
         !self.max_data
+            && !(self.data_blocked && streams.can_send_data_blocked())
             && !self.max_stream_id.into_iter().any(|x| x)
             && !self.streams_blocked.into_iter().any(|x| x)
             && self.reset_stream.is_empty()
@@ -395,6 +397,7 @@ impl ::std::ops::BitOrAssign for Retransmits {
         // We reduce in-stream head-of-line blocking by queueing retransmits before other data for
         // STREAM and CRYPTO frames.
         self.max_data |= rhs.max_data;
+        self.data_blocked |= rhs.data_blocked;
         for dir in Dir::iter() {
             self.max_stream_id[dir as usize] |= rhs.max_stream_id[dir as usize];
             self.streams_blocked[dir as usize] |= rhs.streams_blocked[dir as usize];

--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -267,7 +267,17 @@ impl<'a> SendStream<'a> {
         }
 
         let was_pending = stream.is_pending();
-        let written = stream.write(source, limit)?;
+        let written = match stream.write(source, limit) {
+            Ok(written) => written,
+            Err(WriteError::Blocked) => {
+                if stream.data_blocked_limit != Some(stream.max_data) {
+                    stream.data_blocked_limit = Some(stream.max_data);
+                    self.pending.stream_data_blocked.insert(self.id);
+                }
+                return Err(WriteError::Blocked);
+            }
+            Err(e) => return Err(e),
+        };
         self.state.data_sent += written.bytes as u64;
         self.state.unacked_data += written.bytes as u64;
         trace!(stream = %self.id, "wrote {} bytes", written.bytes);

--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -256,6 +256,13 @@ impl<'a> SendStream<'a> {
                 stream.connection_blocked = true;
                 self.state.connection_blocked.push(self.id);
             }
+            // Only report blocking on the peer's limit, not on our own send window
+            if self.state.data_sent == self.state.max_data
+                && self.state.data_blocked_limit != Some(self.state.max_data)
+            {
+                self.state.data_blocked_limit = Some(self.state.max_data);
+                self.pending.data_blocked = true;
+            }
             return Err(WriteError::Blocked);
         }
 

--- a/quinn-proto/src/connection/streams/send.rs
+++ b/quinn-proto/src/connection/streams/send.rs
@@ -13,6 +13,10 @@ pub(super) struct Send {
     pub(super) fin_pending: bool,
     /// Whether this stream is in the `connection_blocked` list of `Streams`
     pub(super) connection_blocked: bool,
+    /// Value of `max_data` for which a `STREAM_DATA_BLOCKED` frame was most recently queued
+    ///
+    /// A new frame is only queued once the peer has raised the limit.
+    pub(super) data_blocked_limit: Option<u64>,
     /// The reason the peer wants us to stop, if `STOP_SENDING` was received
     pub(super) stop_reason: Option<VarInt>,
 }
@@ -26,6 +30,7 @@ impl Send {
             priority: 0,
             fin_pending: false,
             connection_blocked: false,
+            data_blocked_limit: None,
             stop_reason: None,
         })
     }

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -414,6 +414,17 @@ impl StreamsState {
         self.data_blocked_limit == Some(self.max_data)
     }
 
+    /// Limit to send in a `STREAM_DATA_BLOCKED` frame for stream `id`, if one could be sent
+    ///
+    /// `None` if the stream is no longer writable, was stopped by the peer, or the peer has raised
+    /// the limit since the frame was queued.
+    pub(crate) fn stream_data_blocked_limit(&self, id: StreamId) -> Option<u64> {
+        let stream = self.send.get(&id)?.as_ref()?;
+        stream.data_blocked_limit.filter(|&limit| {
+            stream.is_writable() && stream.stop_reason.is_none() && limit == stream.max_data
+        })
+    }
+
     pub(in crate::connection) fn write_control_frames(
         &mut self,
         buf: &mut Vec<u8>,
@@ -575,6 +586,24 @@ impl StreamsState {
                 buf.write_var(self.max_data);
                 stats.data_blocked += 1;
             }
+        }
+
+        // STREAM_DATA_BLOCKED
+        while buf.len() + 17 < max_size {
+            let Some(&id) = pending.stream_data_blocked.iter().next() else {
+                break;
+            };
+            pending.stream_data_blocked.remove(&id);
+            let Some(limit) = self.stream_data_blocked_limit(id) else {
+                continue;
+            };
+            retransmits.get_or_create().stream_data_blocked.insert(id);
+
+            trace!(stream = %id, limit, "STREAM_DATA_BLOCKED");
+            buf.write(frame::FrameType::STREAM_DATA_BLOCKED);
+            buf.write(id);
+            buf.write_var(limit);
+            stats.stream_data_blocked += 1;
         }
     }
 

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -139,6 +139,10 @@ pub struct StreamsState {
     receive_window_shrink_debt: u64,
     /// Whether the locally-initiated stream limit has been hit, per direction
     pub(super) streams_blocked: [bool; 2],
+    /// Value of `max_data` for which a `DATA_BLOCKED` frame was most recently queued
+    ///
+    /// A new frame is only queued once the peer has raised the limit.
+    pub(super) data_blocked_limit: Option<u64>,
 }
 
 impl StreamsState {
@@ -184,6 +188,7 @@ impl StreamsState {
             initial_max_stream_data_bidi_remote: 0u32.into(),
             receive_window_shrink_debt: 0,
             streams_blocked: [false, false],
+            data_blocked_limit: None,
         };
 
         for dir in Dir::iter() {
@@ -249,6 +254,7 @@ impl StreamsState {
         self.data_sent = 0;
         self.unacked_data = 0;
         self.connection_blocked.clear();
+        self.data_blocked_limit = None;
     }
 
     /// Process incoming stream frame
@@ -403,6 +409,11 @@ impl StreamsState {
             .is_some_and(|s| s.can_send_flow_control())
     }
 
+    /// Whether a `DATA_BLOCKED` frame could be sent
+    pub(crate) fn can_send_data_blocked(&self) -> bool {
+        self.data_blocked_limit == Some(self.max_data)
+    }
+
     pub(in crate::connection) fn write_control_frames(
         &mut self,
         buf: &mut Vec<u8>,
@@ -550,6 +561,19 @@ impl StreamsState {
             match dir {
                 Dir::Uni => stats.streams_blocked_uni += 1,
                 Dir::Bi => stats.streams_blocked_bidi += 1,
+            }
+        }
+
+        // DATA_BLOCKED
+        if pending.data_blocked && buf.len() + 9 < max_size {
+            pending.data_blocked = false;
+            // The peer may have raised the limit since the frame was queued
+            if self.can_send_data_blocked() {
+                retransmits.get_or_create().data_blocked = true;
+                trace!(limit = self.max_data, "DATA_BLOCKED");
+                buf.write(frame::FrameType::DATA_BLOCKED);
+                buf.write_var(self.max_data);
+                stats.data_blocked += 1;
             }
         }
     }

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1329,6 +1329,84 @@ fn data_blocked() {
 }
 
 #[test]
+fn stream_data_blocked() {
+    let _guard = subscribe();
+    let server = ServerConfig {
+        transport: Arc::new(TransportConfig {
+            stream_receive_window: 10u32.into(),
+            ..TransportConfig::default()
+        }),
+        ..server_config()
+    };
+    let mut pair = Pair::new(Default::default(), server);
+    let (client_ch, server_ch) = pair.connect();
+
+    // Fill the stream-level window, then run into the limit
+    let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
+    assert_eq!(
+        pair.client_send(client_ch, s)
+            .write(b"0123456789ab")
+            .unwrap(),
+        10
+    );
+    assert_matches!(
+        pair.client_send(client_ch, s).write(b"c"),
+        Err(WriteError::Blocked)
+    );
+    pair.drive();
+    assert_eq!(
+        pair.client_conn_mut(client_ch)
+            .stats()
+            .frame_tx
+            .stream_data_blocked,
+        1
+    );
+    assert_eq!(
+        pair.server_conn_mut(server_ch)
+            .stats()
+            .frame_rx
+            .stream_data_blocked,
+        1
+    );
+
+    // Being refused again at the same limit does not repeat the frame
+    assert_matches!(
+        pair.client_send(client_ch, s).write(b"c"),
+        Err(WriteError::Blocked)
+    );
+    pair.drive();
+    assert_eq!(
+        pair.client_conn_mut(client_ch)
+            .stats()
+            .frame_tx
+            .stream_data_blocked,
+        1
+    );
+
+    // Running into the raised limit is reported again
+    assert_matches!(pair.server_streams(server_ch).accept(Dir::Uni), Some(stream) if stream == s);
+    let mut recv = pair.server_recv(server_ch, s);
+    let mut chunks = recv.read(true).unwrap();
+    assert_matches!(chunks.next(usize::MAX), Ok(Some(chunk)) if chunk.bytes.len() == 10);
+    let _ = chunks.finalize();
+    pair.drive();
+    assert_eq!(
+        pair.client_send(client_ch, s)
+            .write(b"0123456789ab")
+            .unwrap(),
+        10
+    );
+    assert_matches!(
+        pair.client_send(client_ch, s).write(b"c"),
+        Err(WriteError::Blocked)
+    );
+    pair.drive();
+    let stats = pair.client_conn_mut(client_ch).stats();
+    assert_eq!(stats.frame_tx.stream_data_blocked, 2);
+    assert_eq!(stats.frame_tx.data_blocked, 0);
+}
+
+#[test]
 fn data_blocked_not_sent_under_limit() {
     let _guard = subscribe();
     let mut pair = Pair::default();
@@ -1410,6 +1488,40 @@ fn data_blocked_dropped_when_limit_raised() {
             .data_blocked,
         0
     );
+}
+
+#[test]
+fn stream_data_blocked_not_sent_after_reset() {
+    let _guard = subscribe();
+    let server = ServerConfig {
+        transport: Arc::new(TransportConfig {
+            stream_receive_window: 10u32.into(),
+            ..TransportConfig::default()
+        }),
+        ..server_config()
+    };
+    let mut pair = Pair::new(Default::default(), server);
+    let (client_ch, _server_ch) = pair.connect();
+
+    let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
+    assert_eq!(
+        pair.client_send(client_ch, s)
+            .write(b"0123456789ab")
+            .unwrap(),
+        10
+    );
+    assert_matches!(
+        pair.client_send(client_ch, s).write(b"c"),
+        Err(WriteError::Blocked)
+    );
+
+    // Resetting the stream before the queued frame gets transmitted discards it
+    pair.client_send(client_ch, s).reset(0u32.into()).unwrap();
+    pair.drive();
+
+    let stats = pair.client_conn_mut(client_ch).stats();
+    assert_eq!(stats.frame_tx.stream_data_blocked, 0);
+    assert_eq!(stats.frame_tx.reset_stream, 1);
 }
 
 #[test]

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1251,6 +1251,214 @@ fn streams_blocked_not_sent_under_limit() {
 }
 
 #[test]
+fn data_blocked() {
+    let _guard = subscribe();
+    let server = ServerConfig {
+        transport: Arc::new(TransportConfig {
+            receive_window: 10u32.into(),
+            ..TransportConfig::default()
+        }),
+        ..server_config()
+    };
+    let mut pair = Pair::new(Default::default(), server);
+    let (client_ch, server_ch) = pair.connect();
+
+    // Fill the connection-level window, then run into the limit
+    let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
+    assert_eq!(
+        pair.client_send(client_ch, s)
+            .write(b"0123456789ab")
+            .unwrap(),
+        10
+    );
+    assert_matches!(
+        pair.client_send(client_ch, s).write(b"c"),
+        Err(WriteError::Blocked)
+    );
+    pair.drive();
+    assert_eq!(
+        pair.client_conn_mut(client_ch)
+            .stats()
+            .frame_tx
+            .data_blocked,
+        1
+    );
+    assert_eq!(
+        pair.server_conn_mut(server_ch)
+            .stats()
+            .frame_rx
+            .data_blocked,
+        1
+    );
+
+    // Being refused again at the same limit does not repeat the frame
+    assert_matches!(
+        pair.client_send(client_ch, s).write(b"c"),
+        Err(WriteError::Blocked)
+    );
+    pair.drive();
+    assert_eq!(
+        pair.client_conn_mut(client_ch)
+            .stats()
+            .frame_tx
+            .data_blocked,
+        1
+    );
+
+    // Running into the raised limit is reported again
+    assert_matches!(pair.server_streams(server_ch).accept(Dir::Uni), Some(stream) if stream == s);
+    let mut recv = pair.server_recv(server_ch, s);
+    let mut chunks = recv.read(true).unwrap();
+    assert_matches!(chunks.next(usize::MAX), Ok(Some(chunk)) if chunk.bytes.len() == 10);
+    let _ = chunks.finalize();
+    pair.drive();
+    assert_eq!(
+        pair.client_send(client_ch, s)
+            .write(b"0123456789ab")
+            .unwrap(),
+        10
+    );
+    assert_matches!(
+        pair.client_send(client_ch, s).write(b"c"),
+        Err(WriteError::Blocked)
+    );
+    pair.drive();
+    let stats = pair.client_conn_mut(client_ch).stats();
+    assert_eq!(stats.frame_tx.data_blocked, 2);
+    assert_eq!(stats.frame_tx.stream_data_blocked, 0);
+}
+
+#[test]
+fn data_blocked_not_sent_under_limit() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let (client_ch, _server_ch) = pair.connect();
+
+    // Default windows are far larger than this write, so nothing is blocked
+    let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
+    pair.client_send(client_ch, s).write(b"hi").unwrap();
+    pair.drive();
+
+    let stats = pair.client_conn_mut(client_ch).stats();
+    assert_eq!(stats.frame_tx.data_blocked, 0);
+    assert_eq!(stats.frame_tx.stream_data_blocked, 0);
+}
+
+#[test]
+fn data_blocked_not_sent_for_local_send_window() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let (client_ch, _server_ch) = pair.connect();
+
+    // Running out of our own send window is not the peer's flow control limit
+    pair.client_conn_mut(client_ch).set_send_window(5);
+    let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
+    assert_eq!(
+        pair.client_send(client_ch, s).write(b"0123456789").unwrap(),
+        5
+    );
+    assert_matches!(
+        pair.client_send(client_ch, s).write(b"x"),
+        Err(WriteError::Blocked)
+    );
+    pair.drive();
+
+    assert_eq!(
+        pair.client_conn_mut(client_ch)
+            .stats()
+            .frame_tx
+            .data_blocked,
+        0
+    );
+}
+
+#[test]
+fn data_blocked_dropped_when_limit_raised() {
+    let _guard = subscribe();
+    let server = ServerConfig {
+        transport: Arc::new(TransportConfig {
+            receive_window: 10u32.into(),
+            ..TransportConfig::default()
+        }),
+        ..server_config()
+    };
+    let mut pair = Pair::new(Default::default(), server);
+    let (client_ch, server_ch) = pair.connect();
+
+    let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
+    assert_eq!(
+        pair.client_send(client_ch, s)
+            .write(b"0123456789ab")
+            .unwrap(),
+        10
+    );
+    assert_matches!(
+        pair.client_send(client_ch, s).write(b"c"),
+        Err(WriteError::Blocked)
+    );
+
+    // The peer raises the limit before the queued frame gets transmitted
+    pair.server_conn_mut(server_ch)
+        .set_receive_window(100u32.into());
+    pair.drive_server();
+    pair.drive();
+
+    assert_eq!(
+        pair.client_conn_mut(client_ch)
+            .stats()
+            .frame_tx
+            .data_blocked,
+        0
+    );
+}
+
+#[test]
+fn data_blocked_retransmit() {
+    let _guard = subscribe();
+    let server = ServerConfig {
+        transport: Arc::new(TransportConfig {
+            receive_window: 10u32.into(),
+            ..TransportConfig::default()
+        }),
+        ..server_config()
+    };
+    let mut pair = Pair::new(Default::default(), server);
+    let (client_ch, server_ch) = pair.connect();
+
+    let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
+    assert_eq!(
+        pair.client_send(client_ch, s)
+            .write(b"0123456789ab")
+            .unwrap(),
+        10
+    );
+    assert_matches!(
+        pair.client_send(client_ch, s).write(b"c"),
+        Err(WriteError::Blocked)
+    );
+    pair.drive_client();
+    pair.server.inbound.clear(); // Lose the packet carrying the frame
+    pair.drive();
+
+    // Still blocked at the same limit, so the frame is sent again. A PTO may send several probes,
+    // each carrying the frame, so only check that it was repeated and got through.
+    assert!(
+        pair.client_conn_mut(client_ch)
+            .stats()
+            .frame_tx
+            .data_blocked
+            > 1
+    );
+    assert!(
+        pair.server_conn_mut(server_ch)
+            .stats()
+            .frame_rx
+            .data_blocked
+            > 0
+    );
+}
+
+#[test]
 fn key_update_simple() {
     let _guard = subscribe();
     let mut pair = Pair::default();


### PR DESCRIPTION
We parse DATA_BLOCKED and STREAM_DATA_BLOCKED but never send them. Now a write refused by the peer's connection or stream limit queues the matching frame ([RFC 9000 4.1](https://www.rfc-editor.org/rfc/rfc9000#section-4.1)). Our own send_window doesn't count. Same pattern as STREAMS_BLOCKED in #2579.

The periodic re-send from 4.1 is left for a follow-up.

Closes #658