### PR TITLE
[0.11.x] proto: prune queued DATAGRAMs after path MTU changes

### DIFF
--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -182,7 +182,7 @@ impl DatagramState {
     pub(super) fn drop_oversized(&mut self, max_payload: usize) -> bool {
         let mut dropped_any = false;
         self.outgoing.queue.retain(|datagram| {
-            let result = datagram.data.len() < max_payload;
+            let result = datagram.data.len() <= max_payload;
             if !result {
                 trace!(
                     "dropping {} byte datagram violating {} byte limit",
@@ -315,6 +315,23 @@ mod tests {
     #[test]
     fn send_buffer_space_handles_metadata_overflow() {
         assert!(!DatagramState::default().has_send_buffer_space(usize::MAX, usize::MAX));
+    }
+
+    #[test]
+    fn drop_oversized_keeps_datagrams_at_limit() {
+        let mut state = DatagramState::default();
+        state.outgoing.push_back(Datagram {
+            data: Bytes::from_static(&[0; 10]),
+        });
+        state.outgoing.push_back(Datagram {
+            data: Bytes::from_static(&[0; 11]),
+        });
+
+        assert!(state.drop_oversized(10));
+
+        assert_eq!(state.outgoing.queue.len(), 1);
+        assert_eq!(state.outgoing.queue[0].data.len(), 10);
+        assert_eq!(state.outgoing.payload_bytes, 10);
     }
 }
 

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use thiserror::Error;
 use tracing::{debug, trace};
 
-use super::Connection;
+use super::{Connection, Event};
 use crate::{
     TransportError,
     frame::{Datagram, FrameStruct},
@@ -53,6 +53,21 @@ impl Datagrams<'_> {
         }
         self.conn.datagrams.outgoing.push_back(Datagram { data });
         Ok(())
+    }
+
+    /// Discard queued datagrams that no longer fit the active path, waking blocked senders.
+    pub(super) fn drop_oversized(&mut self) {
+        let Some(max_datagram_size) = self.max_size() else {
+            return;
+        };
+        if !self.conn.datagrams.drop_oversized(max_datagram_size)
+            || !self.conn.datagrams.send_blocked
+        {
+            return;
+        }
+
+        self.conn.datagrams.send_blocked = false;
+        self.conn.events.push_back(Event::DatagramsUnblocked);
     }
 
     /// Compute the maximum size of datagrams that may passed to `send_datagram`

--- a/quinn-proto/src/connection/datagrams.rs
+++ b/quinn-proto/src/connection/datagrams.rs
@@ -160,9 +160,12 @@ impl DatagramState {
 
     /// Discard outgoing datagrams with a payload larger than `max_payload` bytes
     ///
+    /// Returns whether any datagrams were dropped.
+    ///
     /// Used to ensure that reductions in MTU don't get us stuck in a state where we have a datagram
     /// queued but can't send it.
-    pub(super) fn drop_oversized(&mut self, max_payload: usize) {
+    pub(super) fn drop_oversized(&mut self, max_payload: usize) -> bool {
+        let mut dropped_any = false;
         self.outgoing.queue.retain(|datagram| {
             let result = datagram.data.len() < max_payload;
             if !result {
@@ -172,9 +175,11 @@ impl DatagramState {
                     max_payload
                 );
                 self.outgoing.payload_bytes -= datagram.data.len();
+                dropped_any = true;
             }
             result
         });
+        dropped_any
     }
 
     /// Attempt to write a datagram frame into `buf`, consuming it from `self.outgoing`

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1798,14 +1798,7 @@ impl Connection {
                 self.path
                     .congestion
                     .on_mtu_update(self.path.mtud.current_mtu());
-                if let Some(max_datagram_size) = self.datagrams().max_size() {
-                    if self.datagrams.drop_oversized(max_datagram_size)
-                        && self.datagrams.send_blocked
-                    {
-                        self.datagrams.send_blocked = false;
-                        self.events.push_back(Event::DatagramsUnblocked);
-                    }
-                }
+                self.datagrams().drop_oversized();
             }
 
             // Don't apply congestion penalty for lost ack-only packets

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1429,6 +1429,7 @@ impl Connection {
     /// configuration in the [`TransportConfig`].
     pub fn path_changed(&mut self, now: Instant) {
         self.path.reset(now, &self.config);
+        self.datagrams().drop_oversized();
     }
 
     /// Modify the number of remotely initiated streams that may be concurrently open
@@ -3088,6 +3089,7 @@ impl Connection {
         let prev_pto = self.pto(SpaceId::Data);
 
         let mut prev = mem::replace(&mut self.path, new_path);
+        self.datagrams().drop_oversized();
         // Don't clobber the original path if the previous one hasn't been validated yet
         if prev.challenge.is_none() {
             prev.challenge = Some(self.rng.random());

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1799,7 +1799,12 @@ impl Connection {
                     .congestion
                     .on_mtu_update(self.path.mtud.current_mtu());
                 if let Some(max_datagram_size) = self.datagrams().max_size() {
-                    self.datagrams.drop_oversized(max_datagram_size);
+                    if self.datagrams.drop_oversized(max_datagram_size)
+                        && self.datagrams.send_blocked
+                    {
+                        self.datagrams.send_blocked = false;
+                        self.events.push_back(Event::DatagramsUnblocked);
+                    }
                 }
             }
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     convert::TryInto,
-    mem,
+    iter, mem,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::{Arc, Mutex},
 };
@@ -3565,6 +3565,74 @@ fn voluntary_ack_with_large_datagrams() {
         COUNT as u64,
         "client should have sent some ACK-only packets"
     );
+}
+
+#[test]
+fn path_changes_unblock_oversized_datagrams() {
+    let _guard = subscribe();
+    for migrate in [false, true] {
+        let mut pair = Pair::default();
+        let (client_ch, server_ch) = pair.connect();
+        pair.drive();
+        let old_max = pair.server_datagrams(server_ch).max_size().unwrap();
+        assert!(old_max > 1200);
+        let empty_space = pair.server_datagrams(server_ch).send_buffer_space();
+        let data = Bytes::from(vec![42; old_max]);
+        loop {
+            match pair.server_datagrams(server_ch).send(data.clone(), false) {
+                Ok(()) => {}
+                Err(SendDatagramError::Blocked(_)) => break,
+                Err(error) => panic!("unexpected send error: {error}"),
+            }
+        }
+        while pair.server_conn_mut(server_ch).poll().is_some() {}
+
+        pair.mtu = 1200;
+        if migrate {
+            pair.client
+                .addr
+                .set_port(CLIENT_PORTS.lock().unwrap().next().unwrap());
+            pair.client_conn_mut(client_ch).ping();
+            pair.drive_client();
+            // Process migration without transmitting, so sends cannot free the buffer first.
+            let mut buf = Vec::new();
+            while let Some((received, ecn, packet)) = pair.server.inbound.pop_front() {
+                let Some(DatagramEvent::ConnectionEvent(ch, event)) =
+                    pair.server
+                        .handle(received, pair.client.addr, None, ecn, packet, &mut buf)
+                else {
+                    panic!("expected a connection event");
+                };
+                assert_eq!(ch, server_ch);
+                pair.server_conn_mut(ch).handle_event(event);
+            }
+            assert_eq!(
+                pair.server_conn_mut(server_ch).remote_address(),
+                pair.client.addr
+            );
+        } else {
+            let now = pair.time;
+            pair.server_conn_mut(server_ch).path_changed(now);
+        }
+
+        assert!(pair.server_datagrams(server_ch).max_size().unwrap() < old_max);
+        assert_eq!(
+            pair.server_datagrams(server_ch).send_buffer_space(),
+            empty_space
+        );
+        assert!(
+            iter::from_fn(|| pair.server_conn_mut(server_ch).poll())
+                .any(|event| matches!(event, Event::DatagramsUnblocked))
+        );
+
+        let small = Bytes::from_static(b"small");
+        pair.server_datagrams(server_ch)
+            .send(small.clone(), false)
+            .unwrap();
+        pair.drive();
+        assert_eq!(pair.client_datagrams(client_ch).recv(), Some(small));
+        assert_eq!(pair.client_datagrams(client_ch).recv(), None);
+    }
 }
 
 /// Verify that dropping oversized datagrams will trigger a DatagramsUnblocked event.

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -3567,6 +3567,87 @@ fn voluntary_ack_with_large_datagrams() {
     );
 }
 
+/// Verify that dropping oversized datagrams will trigger a DatagramsUnblocked event.
+#[test]
+fn oversized_datagrams_trigger_unblock() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    // Start the connection with a large MTU.
+    const INITIAL_MTU: usize = 1300;
+    pair.mtu = INITIAL_MTU;
+
+    let mut client_config = client_config();
+    let mut transport_config = TransportConfig::default();
+    let send_buffer_size = transport_config.datagram_send_buffer_size;
+    transport_config.initial_mtu(INITIAL_MTU as u16);
+    client_config.transport_config(transport_config.into());
+
+    let (client_ch, _) = pair.connect_with(client_config);
+
+    // Send datagrams until the send buffer is full.
+    let max_size = pair.client_datagrams(client_ch).max_size().unwrap();
+    let data = vec![0; max_size];
+    loop {
+        match pair
+            .client_datagrams(client_ch)
+            .send(data.clone().into(), false)
+        {
+            Ok(_) => {}
+            Err(SendDatagramError::Blocked(_)) => {
+                break;
+            }
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+    }
+    // Set the MTU to a smaller value so the queued datagrams cannot be sent.
+    pair.mtu = 1200;
+
+    // Drive the pair until black hole detection kicks in and the path MTU is adjusted.
+    while pair.step() {
+        let err = loop {
+            if let Err(e) = pair
+                .client_datagrams(client_ch)
+                .send(data.clone().into(), false)
+            {
+                break e;
+            }
+        };
+        match err {
+            SendDatagramError::Blocked(_) => {
+                // continue with the next step but drain the DatagramsUnblocked events
+                // emitted datagrams were sent out.
+                while let Some(event) = pair.client_conn_mut(client_ch).poll() {
+                    tracing::info!("ignoring connection event: {event:?}");
+                }
+            }
+            SendDatagramError::TooLarge => {
+                // mtu adjusted, break the loop
+                break;
+            }
+            _ => panic!("unexpected error: {err}"),
+        }
+    }
+
+    assert_eq!(
+        pair.client_conn_mut(client_ch)
+            .stats()
+            .path
+            .black_holes_detected,
+        1,
+        "expected a black hole to have been detected",
+    );
+
+    assert_eq!(
+        pair.client_datagrams(client_ch).send_buffer_space(),
+        send_buffer_size - size_of::<Datagram>(),
+        "expected the send buffer to be empty after too large datagrams were dropped",
+    );
+    match pair.client_conn_mut(client_ch).poll() {
+        Some(Event::DatagramsUnblocked) => {}
+        _ => panic!("expected DatagramsUnblocked event"),
+    }
+}
+
 #[test]
 fn ack_bundled_with_datagrams() {
     let _guard = subscribe();


### PR DESCRIPTION
Queued DATAGRAMs can stop fitting after `path_changed()` or peer migration lowers the path MTU, leaving the send buffer occupied and `send_datagram_wait()` callers blocked. Prune oversized payloads after these path changes, notify blocked senders when space is freed, and retain payloads exactly at the current size limit.

Backports #2839 at 0888165de743a589a53a5945f562ef84aa2a8a14 together with prerequisite commit c09ff210125b0ebecbe9d74bba2ae401322e32ef, which adds the missing sender notification after MTU black-hole cleanup. The prerequisite is adapted to the `0.11.x` queue and memory accounting.

The four commits separate the prerequisite, cleanup refactor, payload-limit correction, and path-change handling. Cleanup is a private method on `Datagrams`. The migration test delivers packets inline before polling server transmits, so it checks queue cleanup before sending can free buffer space.

Regression coverage includes explicit path reset, peer migration, exact-limit retention, and sender notification after MTU black-hole detection.

Validation on the updated backport branch:

- `cargo test --locked -p quinn-proto`: 285 unit tests and 3 documentation tests passed.
- `cargo clippy --locked -p quinn-proto --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- Rust 1.85.0: `cargo check --locked --lib -p quinn-udp -p quinn-proto -p quinn` passed.

Local validation limits: the Rust 1.85.0 check with `--all-features` could not complete because the AWS-LC FIPS build requires Go, which is not installed. Running tests with Rust 1.85.0 is blocked by the existing lockfile's `time` and `time-core` test dependencies, which require Rust 1.88; the tests above passed with Rust 1.98.0. The PR CI includes the full MSRV library check with all features.

Prepared with AI assistance.
