### PR TITLE
[0.11.x] proto: reset pacing state when resetting a path

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1420,7 +1420,7 @@ impl Connection {
     /// Resets path-specific settings.
     ///
     /// This will force-reset several subsystems related to a specific network path.
-    /// Currently this is the congestion controller, round-trip estimator, and the MTU
+    /// Currently this is the congestion controller, round-trip estimator, pacer, and MTU
     /// discovery.
     ///
     /// This is useful when it is known the underlying network path has changed and the old

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -136,7 +136,7 @@ impl PathData {
         }
     }
 
-    /// Resets RTT, congestion control and MTU states.
+    /// Resets RTT, congestion control, pacing and MTU states.
     ///
     /// This is useful when it is known the underlying path has changed.
     pub(super) fn reset(&mut self, now: Instant, config: &TransportConfig) {
@@ -146,6 +146,12 @@ impl PathData {
             .clone()
             .build(now, config.get_initial_mtu());
         self.mtud.reset(config.get_initial_mtu(), config.min_mtu);
+        self.pacing = Pacer::new(
+            self.rtt.get(),
+            self.congestion.initial_window(),
+            self.current_mtu(),
+            now,
+        );
     }
 
     /// Indicates whether we're a server that hasn't validated the peer's address and hasn't
@@ -448,5 +454,49 @@ impl InFlight {
     fn remove(&mut self, packet: &SentPacket) {
         self.bytes -= u64::from(packet.size);
         self.ack_eliciting -= u64::from(packet.ack_eliciting);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reset_refreshes_pacer_budget() {
+        let now = Instant::now();
+        let config = TransportConfig::default();
+        let remote = "203.0.113.1:4433".parse().unwrap();
+        let mut path = PathData::new(remote, true, None, 0, now, &config);
+        let mtu = path.current_mtu();
+        let window = path.congestion.window();
+
+        for _ in 0..1000 {
+            if path
+                .pacing
+                .delay(path.rtt.get(), mtu.into(), mtu, window, now)
+                .is_some()
+            {
+                break;
+            }
+            path.pacing.on_transmit(mtu);
+        }
+        assert!(
+            path.pacing
+                .delay(path.rtt.get(), mtu.into(), mtu, window, now)
+                .is_some()
+        );
+
+        path.reset(now, &config);
+
+        assert_eq!(
+            path.pacing.delay(
+                path.rtt.get(),
+                path.current_mtu().into(),
+                path.current_mtu(),
+                path.congestion.window(),
+                now
+            ),
+            None
+        );
     }
 }


### PR DESCRIPTION
`Connection::path_changed()` resets RTT, congestion control and MTU discovery, but retains the pacer's previous token budget and timestamp. If that budget is exhausted, sending remains delayed after the reset. Recreate the pacer from the reset path's RTT, initial congestion window, MTU and current time.

Backports #2840 after rebasing it onto current `main`. The constructor call is adapted to `0.11.x`, whose pacer has no rate-limit argument. No public API changes.

The regression test fails on the unmodified `0.11.x` implementation because pacing still returns a send deadline after the reset. It passes with this backport.

Validation:
- `cargo test --locked -p quinn-proto`: 283 tests and 3 doc-tests passed.
- `cargo build --locked --all-targets`: passed.
- `cargo fmt --all -- --check`: passed using the available standalone cargo-fmt/rustfmt binaries.
- `git diff --check`: passed.
