### PR TITLE
fix: stale waker in `blocked_readers`

### DIFF
--- a/quinn/src/recv_stream.rs
+++ b/quinn/src/recv_stream.rs
@@ -364,6 +364,8 @@ impl RecvStream {
         T: FnMut(&mut Chunks<'_>) -> ReadStatus<U>,
     {
         use proto::ReadError::*;
+        use std::collections::hash_map::Entry;
+
         if self.all_data_read {
             return Poll::Ready(Ok(None));
         }
@@ -392,6 +394,8 @@ impl RecvStream {
             ReadStatus::Readable(read) => Poll::Ready(Ok(Some(read))),
             ReadStatus::Finished(read) => {
                 self.all_data_read = true;
+                // Stream is dead, cleanup stale waker
+                conn.blocked_readers.remove(&self.stream);
                 Poll::Ready(Ok(read))
             }
             ReadStatus::Failed(read, Blocked) => match read {
@@ -400,7 +404,14 @@ impl RecvStream {
                     if let Some(x) = &conn.error {
                         return Poll::Ready(Err(ReadError::ConnectionLost(x.clone())));
                     }
-                    conn.blocked_readers.insert(self.stream, cx.waker().clone());
+                    match conn.blocked_readers.entry(self.stream) {
+                        Entry::Occupied(mut entry) => {
+                            entry.get_mut().clone_from(cx.waker());
+                        }
+                        Entry::Vacant(entry) => {
+                            entry.insert(cx.waker().clone());
+                        }
+                    }
                     Poll::Pending
                 }
             },
@@ -408,6 +419,8 @@ impl RecvStream {
                 None => {
                     self.all_data_read = true;
                     self.reset = Some(error_code);
+                    // Stream is dead, cleanup stale waker
+                    conn.blocked_readers.remove(&self.stream);
                     Poll::Ready(Err(ReadError::Reset(error_code)))
                 }
                 done => {


### PR DESCRIPTION
# Problem description

`Connection`s maintain a list of blocked readers in which they store `Waker` instances so they can get notified once the streams get unblocked or closed and the `Future` can make progress.

If a stream is considered done, i.e. the property `all_data_read` is set, the stream may be dropped. The `Drop` implementation distinguishes streams with `all_data_read` property being set and returns early.

```rust
if self.all_data_read {
    debug_assert!(
        !self
            .conn
            .state
            .lock("RecvStream:drop")
            .blocked_readers
            .contains_key(&self.stream),
        "Stream {} should not have a blocked reader when all data read is true",
        self.stream
    );
    return;
}
```

However, `poll_read_generic` sets `all_data_read` when streams have `ReadStatus::Finished` and `ReadStatus::Failed(None, Reset(_))`. This leaves stale entries in `blocked_readers` and drains memory unnecessarily.

Even if the `Waker` received a `wake` call, the `poll` function will return early.

```rust
if self.all_data_read {
    return Poll::Ready(Ok(None));
}
```

# Code changes

- Remove stale waker from `blocked_readers` after the `all_data_read` property got set.
- Use in-memory manipulation with [`HashMap::entry(_)`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.entry) and [`Waker::clone_from(_)`](https://doc.rust-lang.org/std/task/struct.Waker.html#method.clone_from) when updating wakers in `blocked_readers`