### PR TITLE
streams: bound retained send storage by the send window

### DIFF
--- a/quinn-proto/src/config/transport.rs
+++ b/quinn-proto/src/config/transport.rs
@@ -128,12 +128,18 @@ impl TransportConfig {
         self
     }
 
-    /// Maximum number of bytes to transmit to a peer without acknowledgment
+    /// Maximum number of bytes retained from application writes across all streams of a connection
     ///
-    /// Provides an upper bound on memory when communicating with peers that issue large amounts of
-    /// flow control credit. Endpoints that wish to handle large numbers of connections robustly
-    /// should take care to set this low enough to guarantee memory exhaustion does not occur if
-    /// every connection uses the entire window.
+    /// Acknowledged data continues to count against this limit until its storage is released. This
+    /// can keep writes blocked while earlier data is awaiting acknowledgment or only part of a buffer
+    /// has been acknowledged.
+    ///
+    /// Limits memory use when communicating with peers that issue large amounts of flow control
+    /// credit. Endpoints that wish to handle large numbers of connections robustly should take care
+    /// to set this low enough to avoid memory exhaustion if every connection uses the entire window.
+    ///
+    /// The limit counts bytes accepted from application buffers. Slices of larger allocations can
+    /// retain more memory than this limit accounts for.
     pub fn send_window(&mut self, value: u64) -> &mut Self {
         self.send_window = value;
         self

--- a/quinn-proto/src/connection/send_buffer.rs
+++ b/quinn-proto/src/connection/send_buffer.rs
@@ -155,6 +155,15 @@ impl SendBuffer {
         &[]
     }
 
+    /// Release abandoned data while preserving the final offset for RESET_STREAM
+    pub(super) fn discard(&mut self) {
+        *self = Self {
+            offset: self.offset,
+            unsent: self.offset,
+            ..Self::default()
+        };
+    }
+
     /// Queue a range of sent but unacknowledged data to be retransmitted
     pub(super) fn retransmit(&mut self, range: Range<u64>) {
         debug_assert!(range.end <= self.unsent, "unsent data can't be lost");

--- a/quinn-proto/src/connection/send_buffer.rs
+++ b/quinn-proto/src/connection/send_buffer.rs
@@ -11,6 +11,8 @@ pub(super) struct SendBuffer {
     unacked_segments: VecDeque<Bytes>,
     /// Total size of `unacked_segments`
     unacked_len: usize,
+    /// Acknowledged bytes removed from the first segment's view but still held by its allocation
+    front_trimmed: usize,
     /// The first offset that hasn't been written by the application, i.e. the offset past the end of `unacked`
     offset: u64,
     /// The first offset that hasn't been sent
@@ -61,12 +63,14 @@ impl SendBuffer {
                 if front.len() <= to_advance {
                     to_advance -= front.len();
                     self.unacked_segments.pop_front();
+                    self.front_trimmed = 0;
 
                     if self.unacked_segments.len() * 4 < self.unacked_segments.capacity() {
                         self.unacked_segments.shrink_to_fit();
                     }
                 } else {
                     front.advance(to_advance);
+                    self.front_trimmed += to_advance;
                     to_advance = 0;
                 }
             }
@@ -193,9 +197,9 @@ impl SendBuffer {
         self.unsent != self.offset || !self.retransmits.is_empty()
     }
 
-    /// Compute the amount of data that hasn't been acknowledged
-    pub(super) fn unacked(&self) -> u64 {
-        self.unacked_len as u64 - self.acks.iter().map(|x| x.end - x.start).sum::<u64>()
+    /// Bytes still retained from application writes, including acknowledged data
+    pub(super) fn buffered(&self) -> u64 {
+        (self.unacked_len + self.front_trimmed) as u64
     }
 }
 

--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -279,7 +279,7 @@ impl<'a> SendStream<'a> {
             Err(e) => return Err(e),
         };
         self.state.data_sent += written.bytes as u64;
-        self.state.unacked_data += written.bytes as u64;
+        self.state.buffered_data += written.bytes as u64;
         trace!(stream = %self.id, "wrote {} bytes", written.bytes);
         if !was_pending {
             self.state.pending.push_pending(self.id, stream.priority);
@@ -340,7 +340,7 @@ impl<'a> SendStream<'a> {
         // Restore the portion of the send window consumed by the data that we aren't about to
         // send. We leave flow control alone because the peer's responsible for issuing additional
         // credit based on the final offset communicated in the RESET_STREAM frame we send.
-        self.state.unacked_data -= stream.pending.unacked();
+        self.state.buffered_data -= stream.pending.buffered();
         stream.reset();
         self.pending.reset_stream.push((self.id, error_code));
 

--- a/quinn-proto/src/connection/streams/send.rs
+++ b/quinn-proto/src/connection/streams/send.rs
@@ -93,6 +93,8 @@ impl Send {
         use SendState::*;
         if let DataSent { .. } | Ready = self.state {
             self.state = ResetSent;
+            self.pending.discard();
+            self.fin_pending = false;
         }
     }
 

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -738,6 +738,9 @@ impl StreamsState {
             // Loss of data on a closed stream is a noop
             return;
         };
+        if stream.is_reset() {
+            return;
+        }
         if !stream.is_pending() {
             self.pending.push_pending(frame.id, stream.priority);
         }
@@ -1049,6 +1052,73 @@ mod tests {
             (1024 * 1024u32).into(),
             (1024 * 1024u32).into(),
         )
+    }
+
+    #[test]
+    fn reset_releases_retained_send_storage() {
+        let mut server = make(Side::Server);
+        server.send_window = 24;
+        server.set_params(&TransportParameters {
+            initial_max_streams_uni: 1u32.into(),
+            initial_max_data: 1000u32.into(),
+            initial_max_stream_data_uni: 1000u32.into(),
+            ..TransportParameters::default()
+        });
+        let (mut pending, state) = (Retransmits::default(), ConnState::Established);
+        let id = Streams {
+            state: &mut server,
+            conn_state: &state,
+        }
+        .open(Dir::Uni)
+        .unwrap();
+        SendStream {
+            id,
+            state: &mut server,
+            pending: &mut pending,
+            conn_state: &state,
+        }
+        .write(&[42; 24])
+        .unwrap();
+        let send = server.send.get_mut(&id).unwrap().as_mut().unwrap();
+        send.pending.poll_transmit(16);
+        send.pending.poll_transmit(16);
+        server.received_ack_of(frame::StreamMeta {
+            id,
+            offsets: 16..23,
+            fin: false,
+        });
+        SendStream {
+            id,
+            state: &mut server,
+            pending: &mut pending,
+            conn_state: &state,
+        }
+        .reset(0u32.into())
+        .unwrap();
+
+        let send = server.send.get_mut(&id).unwrap().as_mut().unwrap();
+        assert!(
+            send.pending.is_fully_acked(),
+            "reset must release the abandoned allocation"
+        );
+        assert_eq!(
+            send.offset(),
+            24,
+            "RESET_STREAM must retain its final offset"
+        );
+        assert_eq!(server.write_limit(), 24);
+        server.retransmit(frame::StreamMeta {
+            id,
+            offsets: 0..16,
+            fin: false,
+        });
+        server.received_ack_of(frame::StreamMeta {
+            id,
+            offsets: 0..16,
+            fin: false,
+        });
+        assert!(!server.send[&id].as_ref().unwrap().is_pending());
+        assert_eq!(server.write_limit(), 24);
     }
 
     #[test]

--- a/quinn-proto/src/connection/streams/state.rs
+++ b/quinn-proto/src/connection/streams/state.rs
@@ -121,11 +121,11 @@ pub struct StreamsState {
     pub(super) data_sent: u64,
     /// Sum of end offsets of all receive streams. Includes gaps, so it's an upper bound.
     data_recvd: u64,
-    /// Total quantity of unacknowledged outgoing data
-    pub(super) unacked_data: u64,
-    /// Configured upper bound for `unacked_data`.
+    /// Total quantity of outgoing data retained in send buffers, including acknowledged data
+    pub(super) buffered_data: u64,
+    /// Configured upper bound for `buffered_data`.
     ///
-    /// Note this may be less than `unacked_data` if the user has set a new value.
+    /// Note this may be less than `buffered_data` if the user has set a new value.
     pub(super) send_window: u64,
     /// Configured upper bound for how much unacked data the peer can send us per stream
     pub(super) stream_receive_window: u64,
@@ -180,7 +180,7 @@ impl StreamsState {
             sent_max_data: receive_window,
             data_sent: 0,
             data_recvd: 0,
-            unacked_data: 0,
+            buffered_data: 0,
             send_window,
             stream_receive_window: stream_receive_window.into(),
             initial_max_stream_data_uni: 0u32.into(),
@@ -252,7 +252,7 @@ impl StreamsState {
         self.pending.clear();
         self.send_streams = 0;
         self.data_sent = 0;
-        self.unacked_data = 0;
+        self.buffered_data = 0;
         self.connection_blocked.clear();
         self.data_blocked_limit = None;
     }
@@ -722,8 +722,10 @@ impl StreamsState {
             return;
         }
         let id = frame.id;
-        self.unacked_data -= frame.offsets.end - frame.offsets.start;
-        if !stream.ack(frame) {
+        let buffered = stream.pending.buffered();
+        let finished = stream.ack(frame);
+        self.buffered_data -= buffered - stream.pending.buffered();
+        if !finished {
             // The stream is unfinished or may still need retransmits
             return;
         }
@@ -835,8 +837,8 @@ impl StreamsState {
     /// Returns the maximum amount of data this is allowed to be written on the connection
     pub(crate) fn write_limit(&self) -> u64 {
         (self.max_data - self.data_sent)
-            // `send_window` can be set after construction to something *less* than `unacked_data`
-            .min(self.send_window.saturating_sub(self.unacked_data))
+            // `send_window` can be set after construction to something *less* than `buffered_data`
+            .min(self.send_window.saturating_sub(self.buffered_data))
     }
 
     /// Yield stream events
@@ -1052,6 +1054,73 @@ mod tests {
             (1024 * 1024u32).into(),
             (1024 * 1024u32).into(),
         )
+    }
+
+    #[test]
+    fn send_window_retains_selectively_acked_data() {
+        let mut server = make(Side::Server);
+        server.send_window = 24;
+        server.set_params(&TransportParameters {
+            initial_max_streams_uni: 1u32.into(),
+            initial_max_data: 1000u32.into(),
+            initial_max_stream_data_uni: 1000u32.into(),
+            ..TransportParameters::default()
+        });
+        let (mut pending, state) = (Retransmits::default(), ConnState::Established);
+        let id = Streams {
+            state: &mut server,
+            conn_state: &state,
+        }
+        .open(Dir::Uni)
+        .unwrap();
+        SendStream {
+            id,
+            state: &mut server,
+            pending: &mut pending,
+            conn_state: &state,
+        }
+        .write(&[42; 24])
+        .unwrap();
+        let send = server.send.get_mut(&id).unwrap().as_mut().unwrap();
+        assert_eq!(send.pending.poll_transmit(16).0, 0..16);
+        assert_eq!(send.pending.poll_transmit(16).0, 16..23);
+        assert_eq!(send.pending.poll_transmit(16).0, 23..24);
+
+        server.received_ack_of(frame::StreamMeta {
+            id,
+            offsets: 16..23,
+            fin: false,
+        });
+        assert_eq!(
+            server.write_limit(),
+            0,
+            "acknowledged suffix still occupies storage"
+        );
+        server.received_ack_of(frame::StreamMeta {
+            id,
+            offsets: 0..16,
+            fin: false,
+        });
+        assert_eq!(
+            server.write_limit(),
+            0,
+            "partial prefix keeps the original Bytes allocation"
+        );
+        server.received_ack_of(frame::StreamMeta {
+            id,
+            offsets: 23..24,
+            fin: false,
+        });
+        assert_eq!(server.write_limit(), 24);
+        SendStream {
+            id,
+            state: &mut server,
+            pending: &mut pending,
+            conn_state: &state,
+        }
+        .write(&[7; 24])
+        .unwrap();
+        assert_eq!(server.write_limit(), 0);
     }
 
     #[test]


### PR DESCRIPTION
Selective acknowledgments can restore `send_window` credit while the acknowledged suffix remains allocated behind an earlier gap. A continuing writer can therefore retain more data than the configured send window permits.

The commits separate two related changes:

1. Release abandoned buffers on reset, preserving the final offset and ignoring later loss notifications for reset streams.
2. Charge the send window for retained storage and refund it only when storage is released. This includes acknowledged suffixes and a trimmed prefix that still shares the first segment's allocation.

This deliberately applies backpressure while acknowledged data is still retained. It preserves stream offsets, retransmission, flow control, and existing zero-copy application buffers. The accounting covers the bytes supplied in each application slice; it cannot infer a larger allocation an application chose to slice before writing.

Regression tests fail before the changes and pass afterward. They cover suffix acknowledgments, a partially released prefix, restored write credit after full acknowledgment, reset storage release, final-offset preservation, and late ACK/loss notifications.

Validation:

- `cargo test --locked -p quinn-proto`: 314 unit tests and 3 documentation tests passed on Windows.
- `cargo fmt --all -- --check` and package-scoped `cargo clippy --locked --all-targets -- -D warnings` passed on Linux (Rust 1.98.1); `git diff --check` passed.

Assisted by GPT-6 Astra.
