### PR TITLE
[0.11.x] proto: preserve the server config for pending incoming connections

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -94,6 +94,8 @@ impl Endpoint {
     }
 
     /// Replace the server configuration, affecting new incoming connections only
+    ///
+    /// Pending incoming connections retain the configuration active when they first arrived.
     pub fn set_server_config(&mut self, server_config: Option<Arc<ServerConfig>>) {
         self.server_config = server_config;
     }
@@ -221,7 +223,7 @@ impl Endpoint {
             match route_to {
                 RouteDatagramTo::Incoming(incoming_idx) => {
                     let incoming_buffer = &mut self.incoming_buffers[incoming_idx];
-                    let config = &self.server_config.as_ref().unwrap();
+                    let config = &incoming_buffer.server_config;
 
                     if incoming_buffer
                         .total_bytes
@@ -516,7 +518,11 @@ impl Endpoint {
             }
         };
 
-        let incoming_idx = self.incoming_buffers.insert(IncomingBuffer::default());
+        let incoming_idx = self.incoming_buffers.insert(IncomingBuffer {
+            server_config,
+            datagrams: Vec::new(),
+            total_bytes: 0,
+        });
         self.index
             .insert_initial_incoming(header.dst_cid, incoming_idx);
 
@@ -559,8 +565,7 @@ impl Endpoint {
             version,
             ..
         } = incoming.packet.header;
-        let server_config =
-            server_config.unwrap_or_else(|| self.server_config.as_ref().unwrap().clone());
+        let server_config = server_config.unwrap_or_else(|| incoming_buffer.server_config.clone());
 
         if server_config
             .transport
@@ -741,10 +746,11 @@ impl Endpoint {
             return Err(RetryError(Box::new(incoming)));
         }
 
+        let server_config = self.incoming_buffers[incoming.incoming_idx]
+            .server_config
+            .clone();
         self.clean_up_incoming(&incoming);
         incoming.improper_drop_warner.dismiss();
-
-        let server_config = self.server_config.as_ref().unwrap();
 
         // First Initial
         // The peer will use this as the DCID of its following Initials. Initial DCIDs are
@@ -964,8 +970,8 @@ impl fmt::Debug for Endpoint {
 }
 
 /// Buffered Initial and 0-RTT messages for a pending incoming connection
-#[derive(Default)]
 struct IncomingBuffer {
+    server_config: Arc<ServerConfig>,
     datagrams: Vec<DatagramConnectionEvent>,
     total_bytes: u64,
 }

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -46,6 +46,73 @@ use wasm_bindgen_test::wasm_bindgen_test as test;
 // wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]
+fn pending_incoming_survives_server_config_change() {
+    let _guard = subscribe();
+    let replacement = ServerConfig::with_crypto(Arc::new(server_crypto_with_alpn(vec![
+        "replacement-only".into(),
+    ])));
+    for replacement in [None, Some(Arc::new(replacement))] {
+        let mut pair = Pair::default();
+        let client_ch = pair.begin_connect(client_config());
+        pair.drive_client();
+        let (received, ecn, data) = pair.server.inbound.pop_front().unwrap();
+        let mut response = Vec::new();
+        let Some(DatagramEvent::NewConnection(incoming)) = pair.server.handle(
+            received,
+            pair.client.addr,
+            None,
+            ecn,
+            data.clone(),
+            &mut response,
+        ) else {
+            panic!("expected an incoming connection");
+        };
+
+        pair.server.set_server_config(replacement);
+        // Retransmitted Initials must still be buffered after the configuration changes.
+        assert!(
+            pair.server
+                .handle(received, pair.client.addr, None, ecn, data, &mut response)
+                .is_none()
+        );
+        let server_ch = pair.server.try_accept(incoming, pair.time).unwrap();
+        pair.drive();
+        for (endpoint, ch) in [(&mut pair.client, client_ch), (&mut pair.server, server_ch)] {
+            let conn = endpoint.connections.get_mut(&ch).unwrap();
+            assert!(
+                std::iter::from_fn(|| conn.poll()).any(|event| matches!(event, Event::Connected))
+            );
+        }
+    }
+}
+
+#[test]
+fn pending_incoming_can_retry_after_disabling_server() {
+    let _guard = subscribe();
+    let config = server_config();
+    let mut pair = Pair::new(Default::default(), config.clone());
+    pair.server.handle_incoming = Box::new(|_| IncomingConnectionBehavior::Wait);
+    let client_ch = pair.begin_connect(client_config());
+    pair.drive_client();
+    pair.server.drive_incoming(pair.time, pair.client.addr);
+    let incoming = pair.server.waiting_incoming.pop().unwrap();
+
+    pair.server.set_server_config(None);
+    pair.server.retry(incoming);
+    pair.server.set_server_config(Some(Arc::new(config)));
+    pair.server.handle_incoming = Box::new(|incoming| {
+        assert!(incoming.remote_address_validated());
+        IncomingConnectionBehavior::Accept
+    });
+    pair.drive();
+    pair.server.assert_accept();
+    assert!(
+        std::iter::from_fn(|| pair.client_conn_mut(client_ch).poll())
+            .any(|event| matches!(event, Event::Connected))
+    );
+}
+
+#[test]
 fn version_negotiate_server() {
     let _guard = subscribe();
     let client_addr = "[::2]:7890".parse().unwrap();


### PR DESCRIPTION
Backports #2838 to `0.11.x`.

Disabling or replacing an endpoint's server configuration can panic or change the configuration used by an incoming connection that is still pending. Retain the configuration active when the attempt arrived and use it for buffering, default acceptance and Retry. An explicit configuration passed to `accept` still takes precedence.

The backport adapts two differences in the release branch: `accept` reads the saved configuration from the incoming buffer it has already removed, and `retry` saves the configuration before calling the existing `clean_up_incoming` helper. The original regression tests are included.

Validation on Linux with Rust 1.98.1:

- Both pending-incoming regression tests panic on the unmodified release implementation and pass with the backport. They cover configuration removal/replacement and Retry after disabling the server.
- `cargo test --locked`: 324 tests and 4 doc-tests passed; 4 tests remain ignored.
- `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings` and `git diff --check` passed.

Assisted by GPT-6 Astra.
